### PR TITLE
Add updated links (& request updating destinations & GitHub settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ a very relevant way of contributing to the development of this game,
 so please get in touch!
 
 You will find us on the following channels:
-
-- Forum: http://forum.freegamedev.net/viewforum.php?f=15
-- GitHub: https://github.com/tomluchowski/OpenDungeonsPlus
-- IRC: #opendungeons channel on Freenode
+- Snapcraft: https://snapcraft.io/opendungeons-plus
+- Discord (Scroll down and click "Links"): https://flathub.org/apps/io.github.tomluchowski.OpenDungeonsPlus 
+- OpenDungeons (upstream code):
+  - Forum: http://forum.freegamedev.net/viewforum.php?f=15
+  - GitHub: https://github.com/tomluchowski/OpenDungeonsPlus
+  - IRC: #opendungeons channel on Freenode
 
 ### Build instructions
 


### PR DESCRIPTION
Hello,

I want to help with your fork. I have no way to reach you due to the issues below, please see what you can do about fixing all of these links. I am very interested in using this program as a design tool and adding an option to export an image it from a top view. I would be interested in contributing code to fix other issues along the way.

However, there are a few things that need to be fixed to help me and other people get in touch:
- [x] On the ~~appimage site~~ [flathub page](https://flathub.org/apps/io.github.tomluchowski.OpenDungeonsPlus) it says to contact you on Discord, but if I click on the Discord under "Links", it says there are no text channels (the Discord server is totally blank). ~~Maybe start a new server or something? I'd be happy to host a channel for this on my Discord server, Hierosoft: <https://discord.gg/gMHNvrNH>. I am poikilos_ on Discord.~~ The problem seems to be it is a server link not an invite link.
- [ ] The GitHub project's website is still set to the old OpenDungeons' SourceForge page.
  - [ ] I would happy to register a domain and host a page. Otherwise, I could register a domain and point it to the appimage page since that has the most project and contact info.
- [x] Please enable "Issues" in the GitHub repo. Issues are off by default for forks, but I'd love to discuss issues regarding fixes or features where I could help.
  - :edit: See comment-- https://github.com/flathub/io.github.tomluchowski.OpenDungeonsPlus/issues is probably fine for flatpak issues but if you enable https://github.com/tomluchowski/OpenDungeonsPlus issues in settings that would help with organizing issues for the game itself not involving flatpak.


![image](https://github.com/user-attachments/assets/4452cbc6-4896-4d1e-a224-c57598acac10)
