### PR TITLE
Fix window event pumping, mouse cursor sync and window sizing

### DIFF
--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -147,7 +147,11 @@ void ODApplication::startClient()
     OD_LOG_INF("Creating window...");
 
     const unsigned int MIN_WIDTH = 800;
-    const unsigned int MIN_HEIGHT = 600;
+    // MenuMain.layout stacks its seven buttons around the vertical centre, from
+    // {0.5,-240} down to {0.5,320}, inside a root window inset by 10px top and bottom.
+    // The last one ("Quit") therefore only fits when 0.5*(h-20)+320 <= h-20, i.e. from
+    // 660px up. Anything shorter silently clips the bottom of the menu.
+    const unsigned int MIN_HEIGHT = 660;
 
     // Get width/height values from config
     unsigned int w = MIN_WIDTH;
@@ -301,7 +305,24 @@ void ODApplication::startClient()
         sfmlWindow.display();
     }
 #else /* OD_USE_SFML_WINDOW */
-    ogreRoot.startRendering();
+    // NOTE: Ogre::Root::startRendering() does not pump window events (Ogre::Bites does
+    // that for applications built on its context, which we are not). Without a message
+    // pump, ConfigureNotify never arrives, so windowResized() would only ever run once
+    // at startup and CEGUI's display size and OIS' clipping rectangle would go stale as
+    // soon as the window is resized. Drive the loop ourselves and pump every frame.
+    while (true)
+    {
+        Ogre::WindowEventUtilities::messagePump();
+
+        // Closing the window destroys the mode manager from within the pump above, so
+        // bail out here rather than rendering a frame that would still use it.
+        if (frameListener.isExitRequested())
+            break;
+
+        // renderOneFrame() returns false once an exit has been requested.
+        if (!ogreRoot.renderOneFrame())
+            break;
+    }
 #endif /* OD_USE_SFML_WINDOW */
 
     OD_LOG_INF("Disconnecting client...");

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -89,7 +89,10 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     paramList.insert(std::make_pair(std::string("w32_keyboard"), std::string(keyboardGrab ? "DISCL_EXCLUSIVE" : "DISCL_NONEXCLUSIVE")));
 #elif defined OIS_LINUX_PLATFORM
     paramList.insert(std::make_pair(std::string("x11_mouse_grab"), std::string(mouseGrab ? "true" : "false")));
-    paramList.insert(std::make_pair(std::string("x11_mouse_hide"), std::string("false")));
+    // When grabbing, OIS tracks the pointer by accumulating relative motion and warps
+    // the real pointer back to the window centre near the edges. Leaving the system
+    // cursor visible then shows it drifting away from the one CEGUI draws, so hide it.
+    paramList.insert(std::make_pair(std::string("x11_mouse_hide"), std::string(mouseGrab ? "true" : "false")));
     paramList.insert(std::make_pair(std::string("x11_keyboard_grab"), std::string(keyboardGrab ? "true" : "false")));
     paramList.insert(std::make_pair(std::string("XAutoRepeatOn"), std::string("true")));
 #endif

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -127,6 +127,10 @@ void ODFrameListener::windowResized(Ogre::RenderWindow* rw)
 
 void ODFrameListener::windowClosed(Ogre::RenderWindow*)
 {
+    // Stop the render loop: we are about to destroy the mode manager, which
+    // frameStarted() dereferences unconditionally.
+    requestExit();
+
     // We remove the mode manager to make sure it is destroyed before the window is. That
     // allows to release all taken resources in the mode
     mModeManager = nullptr;

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -87,6 +87,12 @@ public:
 
     void requestExit();
 
+    //! \brief Whether shutting down has been asked for, either by the game itself or by
+    //! the window being closed. Once set, no further frame may be rendered: closing the
+    //! window destroys the mode manager that frameStarted() relies on.
+    inline bool isExitRequested() const
+    { return mExitRequested; }
+
     inline float getEventMaxTimeDisplay() const
     { return mEventMaxTimeDisplay; }
 

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1882,7 +1882,12 @@ bool ConfigManager::initVideoConfig(Ogre::Root& ogreRoot)
             }
             if (!valueIsPossible)
             {
-                optionsToRemove.push_back(setting.first);
+                // The video mode also sizes the window when running windowed, where it
+                // need not be one of the render system's fullscreen modes. Dropping it
+                // would silently fall back to the minimum window size, so keep the
+                // user's value and simply don't push it to the render system.
+                if (setting.first != Config::VIDEO_MODE)
+                    optionsToRemove.push_back(setting.first);
                 continue;
             }
 


### PR DESCRIPTION
Five related defects that surfaced while getting the game running against OGRE 13.6.5 on X11: `Ogre::Root::startRendering()` no longer pumps window events for applications not built on Ogre::Bites, so resize events never arrived and CEGUI's display size and OIS' clipping rectangle went stale. The render loop is now driven directly with `messagePump()` every frame, and the mouse cursor, window sizing and related event handling are fixed along the way.

One commit: `Fix window event pumping, mouse cursor sync and window sizing`.

---
Split out of #16 so each topic can be reviewed on its own. Merging all of the split PRs reproduces the tree of #16 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
