### PR TITLE
Fix client crashes: dangling creature pointer and missile null tile

### DIFF
--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -280,7 +280,17 @@ Creature::Creature(GameMap* gameMap) :
 
 Creature::~Creature()
 {
+    // The client remembers the creature the mouse is hovering in a bare pointer, so that
+    // it can restore its ambient once the mouse leaves it. Nothing used to clear that
+    // pointer when the creature itself went away, so a creature dying while highlighted
+    // left it dangling and the next mouse move dereferenced freed memory.
+    if(getIsOnServerMap())
+        return;
 
+    // May already be gone when the game map is torn down at shutdown.
+    InputManager* inputManager = InputManager::getSingletonPtr();
+    if(inputManager != nullptr && inputManager->mHighlightedCreature == this)
+        inputManager->mHighlightedCreature = nullptr;
 }
 
 void Creature::createMeshLocal(NodeType nt)
@@ -660,10 +670,16 @@ void Creature::setPosition(const Ogre::Vector3& v, GameMap *gameMap )
     
         InputManager& inputManager = InputManager::getSingleton();
 
-        if((getPositionTile()->getX() == inputManager.mXPos && getPositionTile()->getY() == inputManager.mYPos))
+        // getPositionTile() returns null whenever the creature sits outside the map,
+        // which happens while it is held in the keeper hand or carried around.
+        Tile* positionTile = getPositionTile();
+
+        if(positionTile != nullptr &&
+           positionTile->getX() == inputManager.mXPos &&
+           positionTile->getY() == inputManager.mYPos)
         {
-    
-            Creature* closestCreature = getPositionTile()->getClosestCreature(inputManager.mCreatureTypeForOutliner );
+
+            Creature* closestCreature = positionTile->getClosestCreature(inputManager.mCreatureTypeForOutliner );
             if(closestCreature != nullptr)
             {
                 if(closestCreature != inputManager.mHighlightedCreature)

--- a/source/entities/MissileObject.cpp
+++ b/source/entities/MissileObject.cpp
@@ -118,6 +118,20 @@ void MissileObject::doUpkeep()
             Ogre::Vector3 nextDirection;
             OD_LOG_INF("missile name=" + getName() + ", hit wall on tile=" + Tile::displayAsString(tmpTile));
             mIsMissileAlive = wallHitNextDirection(mDirection, lastTile, nextDirection);
+
+            // lastTile is the tile the missile is coming from, and there is none when
+            // the very first tile of the path is already a wall: a missile launched
+            // straight at one, or one whose own tile got filled in under it. Both
+            // branches below would read through the null, so stop where we are. The
+            // loop below already checks lastTile for the same reason.
+            if(lastTile == nullptr)
+            {
+                mIsMissileAlive = false;
+                destination.x = position.x;
+                destination.y = position.y;
+                break;
+            }
+
             if(!mIsMissileAlive)
             {
                 destination.x = static_cast<Ogre::Real>(lastTile->getX());

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -256,7 +256,7 @@ public:
         return mEverVisible;
     }
 
-    inline bool setEverVisible(bool s)
+    inline void setEverVisible(bool s)
     {
         mEverVisible = s;
     }

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -261,21 +261,30 @@ bool ODFrameListener::frameStarted(const Ogre::FrameEvent& evt)
     if(mRenderManager  && mRenderManager->mRenderTarget != nullptr)
     {
         // preRenderTargetUpdate:
-        for (int i = 0; i < mGameMap->getCreatures().size(); i++)
+        // getOverlayStatus() is null for every creature whose mesh is not currently
+        // created, so it has to be checked here the same way Creature::update() does.
+        // Remember the overlays we actually hid rather than walking the creature list a
+        // second time: that kept the two loops in lockstep only as long as no creature
+        // gained or lost its overlay in between.
+        for (Creature* creature : mGameMap->getCreatures())
         {
-            CreatureOverlayStatus* tmp = mGameMap->getCreatures()[i]->getOverlayStatus();
-            mTemporaryWasVisible.push_back(tmp->getMovableTextOverlay()->isVisible());
-            tmp->getMovableTextOverlay()->setVisible(false);
+            CreatureOverlayStatus* tmp = creature->getOverlayStatus();
+            if(tmp == nullptr)
+                continue;
+
+            MovableTextOverlay* overlay = tmp->getMovableTextOverlay();
+            if(overlay == nullptr || !overlay->isVisible())
+                continue;
+
+            overlay->setVisible(false);
+            mTemporaryHiddenOverlays.push_back(overlay);
         }
         mRenderManager->mRenderTarget->update();
         // postRenderTargetUpdate:
-        int tmpItr = 0;
-        for (int i = 0; i < mGameMap->getCreatures().size() ; i++)
-        {
-            CreatureOverlayStatus* tmp = mGameMap->getCreatures()[i]->getOverlayStatus();
-            tmp->getMovableTextOverlay()->setVisible(mTemporaryWasVisible[tmpItr++]);
-        }        
-        mTemporaryWasVisible.clear();
+        for (MovableTextOverlay* overlay : mTemporaryHiddenOverlays)
+            overlay->setVisible(true);
+
+        mTemporaryHiddenOverlays.clear();
     }
    
     return true;

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -42,6 +42,7 @@
 class ChatMessage;
 class GameMap;
 class Gui;
+class MovableTextOverlay;
 class ModeManager;
 class RenderManager;
 class RenderSceneMenu;
@@ -200,9 +201,10 @@ private:
     bool mInitialized;
 
     /*! \brief For the upgrade renderer hook : due to alleged bug in ogre
-    *    we hide and save the CreatureOverlay state in that vector bool flags
+    *    we hide the CreatureOverlays while the render target updates, and keep the ones
+    *    we hid here so they can be shown again right after
     */
-    std::vector<bool> mTemporaryWasVisible;
+    std::vector<MovableTextOverlay*> mTemporaryHiddenOverlays;
     
     //! \brief The Ogre render window reference. Don't delete it.
     Ogre::RenderWindow* mWindow;


### PR DESCRIPTION
Two reliably reproducible segfaults, one commit each:

- **Dangling and null creature pointers on the client.** `InputManager::mHighlightedCreature` was left dangling when the hovered creature died, so the next mouse move read freed memory. Also fixes three null dereferences in the same area, and `Tile::setEverVisible()` being declared `bool` while returning nothing — which is what currently breaks the base branch's build when `OD_ENABLE_WARNINGS` is on (`-Werror=return-type`).
- **Null tile dereference when a missile starts against a wall.** `MissileObject::doUpkeep()` read through a null `lastTile` when the first tile of the missile's path is already a wall.

---
Split out of #16 so each topic can be reviewed on its own. Merging all of the split PRs reproduces the tree of #16 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
