### PR TITLE
Split a room in two when it stops holding together

### DIFF
--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -69,6 +69,9 @@ void Building::doUpkeep()
 
         updateActiveSpots();
         createMesh();
+
+        // Destroying the tiles in the middle of a building leaves the rest of it in pieces
+        checkForSplit();
     }
 }
 

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -110,6 +110,12 @@ public:
 
     virtual bool isAttackable(Tile* tile, Seat* seat) const override;
     virtual bool removeCoveredTile(Tile* t);
+
+    //! \brief Called once the building has lost tiles. One whose tiles no longer hold
+    //! together should become several buildings rather than stay one that is in pieces.
+    //! A building that does not know how to split stays as it is.
+    virtual void checkForSplit()
+    {}
     std::vector<Tile*> getCoveredTiles() override;
 
     Tile* getCoveredTile(int index) override;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -233,6 +233,133 @@ void Room::checkForRoomAbsorbtion()
         reorderRoomTiles(mCoveredTiles);
 }
 
+void Room::checkForSplit()
+{
+    if(mCoveredTiles.size() < 2)
+        return;
+
+    // Gather the tiles into groups that hold together. Two tiles belong to the same room
+    // only if one can be walked to from the other without leaving it, which is the same
+    // rule checkForRoomAbsorbtion() uses to decide that two rooms are really one.
+    std::vector<std::vector<Tile*>> groups;
+    std::set<Tile*> remaining(mCoveredTiles.begin(), mCoveredTiles.end());
+    while(!remaining.empty())
+    {
+        std::vector<Tile*> group;
+        std::vector<Tile*> toVisit(1, *remaining.begin());
+        remaining.erase(remaining.begin());
+        while(!toVisit.empty())
+        {
+            Tile* tile = toVisit.back();
+            toVisit.pop_back();
+            group.push_back(tile);
+
+            for(Tile* neigh : tile->getAllNeighbors())
+            {
+                auto it = remaining.find(neigh);
+                if(it == remaining.end())
+                    continue;
+
+                remaining.erase(it);
+                toVisit.push_back(neigh);
+            }
+        }
+
+        groups.push_back(group);
+    }
+
+    if(groups.size() < 2)
+        return;
+
+    // The biggest group stays here, so that the room that keeps the name and everything
+    // attached to it is the one most of it was. Ties go to the first, which is the group
+    // holding the tile the room happened to list first.
+    uint32_t indexBiggest = 0;
+    for(uint32_t index = 1; index < groups.size(); ++index)
+    {
+        if(groups[index].size() > groups[indexBiggest].size())
+            indexBiggest = index;
+    }
+
+    GameMap* gameMap = getGameMap();
+    for(uint32_t index = 0; index < groups.size(); ++index)
+    {
+        if(index == indexBiggest)
+            continue;
+
+        std::vector<Tile*>& group = groups[index];
+        Room* newRoom = RoomManager::createRoom(gameMap, getType());
+        if(newRoom == nullptr)
+            continue;
+
+        newRoom->setIsOnMap(true);
+        newRoom->setName(gameMap->nextUniqueNameRoom(newRoom->getType()));
+        newRoom->setSeat(getSeat());
+
+        OD_LOG_INF(gameMap->serverStr() + "room=" + getName() + " no longer holds together, "
+            + Helper::toString(static_cast<int32_t>(group.size())) + " of its tiles become room="
+            + newRoom->getName());
+
+        // The tiles change hands the same way absorbRoom() does it, and for the same reason.
+        // The new room gets a copy of what this one knew about each tile, its hit points and
+        // the gold in a treasury among them, so that nothing held there is lost. This one
+        // keeps the original, marked destroyed: seats remember which building covers a tile
+        // and ask that building about it until they are told otherwise, so its tile data has
+        // to stay reachable. Those tiles are not offered for repair either, since a tile the
+        // other room now covers cannot be built upon.
+        for(Tile* tile : group)
+        {
+            auto itData = mTileData.find(tile);
+            if(itData != mTileData.end())
+            {
+                newRoom->mTileData[tile] = itData->second->cloneTileData();
+                itData->second->mHP = 0.0;
+            }
+
+            auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
+            if(itTile != mCoveredTiles.end())
+                mCoveredTiles.erase(itTile);
+
+            // Whatever was built on the tile goes with it, the way absorbRoom() hands over
+            // everything a room had built. It stands on ground the other room owns now.
+            auto itObject = mBuildingObjects.find(tile);
+            if(itObject != mBuildingObjects.end())
+            {
+                newRoom->mBuildingObjects[tile] = itObject->second;
+                mBuildingObjects.erase(itObject);
+            }
+
+            mCoveredTilesDestroyed.push_back(tile);
+            newRoom->mCoveredTiles.push_back(tile);
+            tile->setCoveringBuilding(newRoom);
+        }
+
+        splitRoom(*newRoom, group);
+
+        reorderRoomTiles(newRoom->mCoveredTiles);
+        newRoom->addToGameMap(gameMap);
+        newRoom->createMesh();
+
+        // Whoever was working on those tiles is working for the other room now. It may have
+        // no room for them, so they are sent to look for a job as if the room had gone.
+        std::vector<Creature*> creatures = mCreaturesUsingRoom;
+        for(Creature* creature : creatures)
+        {
+            Tile* tile = creature->getPositionTile();
+            if((tile == nullptr) || (tile->getCoveringBuilding() != newRoom))
+                continue;
+
+            removeCreatureUsingRoom(creature);
+            handleCreatureUsingAbsorbedRoom(*creature);
+        }
+
+        newRoom->updateActiveSpots(gameMap);
+    }
+
+    reorderRoomTiles(mCoveredTiles);
+    updateActiveSpots(gameMap);
+}
+
 void Room::updateActiveSpots(GameMap* gameMap)
 {
     if(gameMap == nullptr)

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -57,6 +57,12 @@ public:
     //! should be overriden
     virtual void handleCreatureUsingAbsorbedRoom(Creature& creature);
 
+    //! \brief Called on the room the tiles are leaving once they have been handed over, so
+    //! that a room keeping something for the room as a whole, rather than per tile, can give
+    //! the new one its share. Anything held in the tile data moves with the tile on its own.
+    virtual void splitRoom(Room& newRoom, const std::vector<Tile*>& tiles)
+    {}
+
     static std::string getRoomStreamFormat();
 
     virtual RoomType getType() const = 0;
@@ -95,6 +101,13 @@ public:
     //! \brief Checks on the neighboor tiles of the room if there are other rooms of the same type/same seat.
     //! if so, it aborbs them
     void checkForRoomAbsorbtion();
+
+    //! \brief The counterpart of checkForRoomAbsorbtion: checks whether the covered tiles
+    //! still hold together and, if they do not, moves every group but the biggest into a room
+    //! of its own. Losing tiles in the middle, by selling or by destruction, leaves what is
+    //! left looking like one room while being two, and everything done to a room is then done
+    //! to both: claiming one half of a bridge used to claim the other half across the lava.
+    void checkForSplit() override;
 
     //! \brief returns true if the room can be repaired and there are destroyed tiles. false otherwise.
     bool canBeRepaired() const;

--- a/source/rooms/RoomArena.cpp
+++ b/source/rooms/RoomArena.cpp
@@ -86,6 +86,10 @@ class RoomArenaFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomArena(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomArena* room = new RoomArena(gameMap);

--- a/source/rooms/RoomBridge.cpp
+++ b/source/rooms/RoomBridge.cpp
@@ -323,6 +323,23 @@ void RoomBridge::absorbRoom(Room *r)
     Room::absorbRoom(r);
 }
 
+void RoomBridge::splitRoom(Room& newRoom, const std::vector<Tile*>& tiles)
+{
+    // The tiles have already gone over, so what is left here is what this bridge keeps. Give
+    // the new one what its own tiles are worth, taking it from what is left rather than from
+    // the whole: a bridge half claimed stays half claimed on both sides of the cut.
+    RoomBridge& newBridge = static_cast<RoomBridge&>(newRoom);
+    uint32_t nbTilesTotal = numCoveredTiles() + tiles.size();
+    if(nbTilesTotal == 0)
+        return;
+
+    double claimedValue = mClaimedValue * static_cast<double>(tiles.size())
+        / static_cast<double>(nbTilesTotal);
+
+    newBridge.mClaimedValue = claimedValue;
+    mClaimedValue -= claimedValue;
+}
+
 bool RoomBridge::removeCoveredTile(Tile* t)
 {
     if(!Room::removeCoveredTile(t))

--- a/source/rooms/RoomBridge.h
+++ b/source/rooms/RoomBridge.h
@@ -63,6 +63,10 @@ public:
     virtual double getCreatureSpeed(const Creature* creature, Tile* tile) const override;
 
     virtual void absorbRoom(Room *r) override;
+
+    //! \brief The value an enemy worker has to dance away to take the bridge is held for the
+    //! bridge as a whole, so a bridge cut in two has to share it out.
+    virtual void splitRoom(Room& newRoom, const std::vector<Tile*>& tiles) override;
     virtual bool removeCoveredTile(Tile* t) override;
 
 protected:

--- a/source/rooms/RoomBridgeStone.cpp
+++ b/source/rooms/RoomBridgeStone.cpp
@@ -101,6 +101,10 @@ class RoomBridgeStoneFactory : public BridgeRoomFactory
         return buildRoomDefault(gameMap, room, seatRoom, tiles);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomBridgeStone(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomBridgeStone* room = new RoomBridgeStone(gameMap);

--- a/source/rooms/RoomBridgeWooden.cpp
+++ b/source/rooms/RoomBridgeWooden.cpp
@@ -102,6 +102,10 @@ class RoomBridgeWoodenFactory : public BridgeRoomFactory
         return buildRoomDefault(gameMap, room, seatRoom, tiles);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomBridgeWooden(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomBridgeWooden* room = new RoomBridgeWooden(gameMap);

--- a/source/rooms/RoomCasino.cpp
+++ b/source/rooms/RoomCasino.cpp
@@ -92,6 +92,10 @@ class RoomCasinoFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomCasino(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomCasino* room = new RoomCasino(gameMap);

--- a/source/rooms/RoomCrypt.cpp
+++ b/source/rooms/RoomCrypt.cpp
@@ -89,6 +89,10 @@ class RoomCryptFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomCrypt(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomCrypt* room = new RoomCrypt(gameMap);

--- a/source/rooms/RoomDormitory.cpp
+++ b/source/rooms/RoomDormitory.cpp
@@ -88,6 +88,10 @@ class RoomDormitoryFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomDormitory(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomDormitory* room = new RoomDormitory(gameMap);

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -81,6 +81,10 @@ class RoomDungeonTempleFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomDungeonTemple(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomDungeonTemple* room = new RoomDungeonTemple(gameMap);

--- a/source/rooms/RoomHatchery.cpp
+++ b/source/rooms/RoomHatchery.cpp
@@ -87,6 +87,10 @@ class RoomHatcheryFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomHatchery(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomHatchery* room = new RoomHatchery(gameMap);

--- a/source/rooms/RoomLibrary.cpp
+++ b/source/rooms/RoomLibrary.cpp
@@ -90,6 +90,10 @@ class RoomLibraryFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomLibrary(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomLibrary* room = new RoomLibrary(gameMap);

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -451,6 +451,20 @@ bool RoomManager::buildRoomOnTiles(GameMap* gameMap, RoomType type, Player* play
 }
 
 
+Room* RoomManager::createRoom(GameMap* gameMap, RoomType type)
+{
+    std::vector<const RoomFactory*>& factories = getFactories();
+    uint32_t index = static_cast<uint32_t>(type);
+    if(index >= factories.size())
+    {
+        OD_LOG_ERR("type=" + Helper::toString(index) + ", factories.size=" + Helper::toString(factories.size()));
+        return nullptr;
+    }
+
+    const RoomFactory& factory = *factories[index];
+    return factory.createRoom(gameMap);
+}
+
 const std::string& RoomManager::getRoomNameFromRoomType(RoomType type)
 {
     std::vector<const RoomFactory*>& factories = getFactories();
@@ -634,7 +648,11 @@ void RoomManager::sellRoomTiles(GameMap* gameMap, Player* player, ODPacket& pack
 
     // We update active spots of each impacted rooms
     for(Room* room : rooms)
+    {
         room->updateActiveSpots(gameMap);
+        // Selling the tiles that joined the two ends of a room leaves two rooms
+        room->checkForSplit();
+    }
 }
 
 std::string RoomManager::formatSellRoom(int price)
@@ -764,7 +782,10 @@ void RoomManager::sellRoomTilesEditor(GameMap* gameMap, ODPacket& packet)
 
     // We update active spots of each impacted rooms
     for(Room* room : rooms)
+    {
         room->updateActiveSpots(gameMap);
+        room->checkForSplit();
+    }
 }
 
 int RoomManager::costPerTile(RoomType type)

--- a/source/rooms/RoomManager.h
+++ b/source/rooms/RoomManager.h
@@ -56,6 +56,8 @@ public:
     virtual void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand) const = 0;
     virtual bool buildRoomEditor(GameMap* gameMap, ODPacket& packet) const = 0;
     virtual Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const = 0;
+    //! \brief Creates an empty room of this type, used when an existing one is split in two.
+    virtual Room* createRoom(GameMap* gameMap) const = 0;
     virtual bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles, bool noFee ) const = 0;
 
     std::string formatBuildRoom(RoomType type, uint32_t price) const;
@@ -98,6 +100,11 @@ public:
 
     //! \brief Constructs a room according to the data in the stream
     static Room* getRoomFromStream(GameMap* gameMap, std::istream &is);
+
+    //! \brief Creates an empty room of the given type. It has no tiles, no name and no seat:
+    //! the caller is expected to hand it what it should own. Returns nullptr if the type is
+    //! not known.
+    static Room* createRoom(GameMap* gameMap, RoomType type);
 
     //! \brief Used by AI for building rooms
 

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -83,6 +83,10 @@ class RoomPortalFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomPortal(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomPortal* room = new RoomPortal(gameMap);

--- a/source/rooms/RoomPortalWave.cpp
+++ b/source/rooms/RoomPortalWave.cpp
@@ -85,6 +85,10 @@ class RoomPortalWaveFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomPortalWave(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomPortalWave* room = new RoomPortalWave(gameMap);

--- a/source/rooms/RoomPrison.cpp
+++ b/source/rooms/RoomPrison.cpp
@@ -165,6 +165,10 @@ class RoomPrisonFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomPrison(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomPrison* room = new RoomPrison(gameMap);

--- a/source/rooms/RoomTorture.cpp
+++ b/source/rooms/RoomTorture.cpp
@@ -91,6 +91,10 @@ class RoomTortureFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomTorture(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomTorture* room = new RoomTorture(gameMap);

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -87,6 +87,10 @@ class RoomTrainingHallFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomTrainingHall(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomTrainingHall* room = new RoomTrainingHall(gameMap);

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -208,6 +208,10 @@ class RoomTreasuryFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomTreasury(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomTreasury* room = new RoomTreasury(gameMap);
@@ -301,6 +305,26 @@ bool RoomTreasury::removeCoveredTile(Tile* t)
     roomTreasuryTileData->mMeshOfTile.clear();
     roomTreasuryTileData->mGoldInTile = 0;
     return Room::removeCoveredTile(t);
+}
+
+void RoomTreasury::splitRoom(Room& newRoom, const std::vector<Tile*>& tiles)
+{
+    // The tiles took a copy of their gold with them. This room counts the gold of every tile
+    // it holds data for, not only the ones it still covers, so leaving the copy behind would
+    // have the same gold counted by both rooms: selling the tile in the middle of a treasury
+    // would make gold rather than cost it.
+    for(Tile* tile : tiles)
+    {
+        auto it = mTileData.find(tile);
+        if(it == mTileData.end())
+            continue;
+
+        RoomTreasuryTileData* roomTreasuryTileData = static_cast<RoomTreasuryTileData*>(it->second);
+        roomTreasuryTileData->mGoldInTile = 0;
+        roomTreasuryTileData->mMeshOfTile.clear();
+    }
+
+    mGoldChanged = true;
 }
 
 int RoomTreasury::getTotalGoldStorage() const

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -61,6 +61,10 @@ public:
     // Functions overriding virtual functions in the Room base class.
     bool removeCoveredTile(Tile* t) override;
 
+    //! \brief The gold counted by a treasury is the gold in every tile it has data for,
+    //! which includes the tiles it has handed over, so it has to let go of theirs.
+    void splitRoom(Room& newRoom, const std::vector<Tile*>& tiles) override;
+
     // Functions specific to this class.
     virtual void doUpkeep() override;
 

--- a/source/rooms/RoomWorkshop.cpp
+++ b/source/rooms/RoomWorkshop.cpp
@@ -92,6 +92,10 @@ class RoomWorkshopFactory : public RoomFactory
         return buildRoomDefaultEditor(gameMap, room, packet);
     }
 
+    //! \brief Creates an empty room of this type, for a room that has to be split in two.
+    Room* createRoom(GameMap* gameMap) const override
+    { return new RoomWorkshop(gameMap); }
+
     Room* getRoomFromStream(GameMap* gameMap, std::istream& is) const override
     {
         RoomWorkshop* room = new RoomWorkshop(gameMap);

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -103,6 +103,28 @@ add_boost_test(aa-TestRooms
         ${Boost_SYSTEM_LIBRARY_RELEASE}
         ${OGRE_LIBRARIES})
 
+add_boost_test(aa-TestRoomSplit
+        SOURCES
+        ${SRC}/tests/mocks/ODClientTest.cpp
+        ${SRC}/game/SeatData.cpp
+        ${SRC}/game/SkillType.cpp
+        ${SRC}/network/ClientNotification.cpp
+        ${SRC}/network/ODPacket.cpp
+        ${SRC}/network/ODSocketClient.cpp
+        ${SRC}/network/ODSocketServer.cpp
+        ${SRC}/network/ServerMode.cpp
+        ${SRC}/network/ServerNotification.cpp
+        ${SRC}/rooms/RoomType.cpp
+        ${SRC}/utils/Helper.cpp
+        ${SRC}/utils/LogManager.cpp
+        ${SRC}/utils/LogSinkConsole.cpp
+        test_RoomSplit.cpp
+        LIBRARIES
+        ${SFML_LIBRARIES}
+        ${Boost_FILESYSTEM_LIBRARY_RELEASE}
+        ${Boost_SYSTEM_LIBRARY_RELEASE}
+        ${OGRE_LIBRARIES})
+
 add_boost_test(ab-TestTraps
         SOURCES
         ${SRC}/tests/mocks/ODClientTest.cpp

--- a/source/tests/test_RoomSplit.cpp
+++ b/source/tests/test_RoomSplit.cpp
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (C) 2011-2016  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mocks/ODClientTest.h"
+
+#include "game/SeatData.h"
+#include "network/ClientNotification.h"
+#include "rooms/RoomType.h"
+#include "utils/LogManager.h"
+#include "utils/LogSinkConsole.h"
+
+#define BOOST_TEST_MODULE TestRoomSplit
+#include <BoostTestTargetConfig.h>
+
+class ODClientTestRoomSplit : public ODClientTest
+{
+public:
+    ODClientTestRoomSplit(const std::vector<PlayerInfo>& players, uint32_t indexLocalPlayer) :
+        ODClientTest(players, indexLocalPlayer)
+    {}
+};
+
+//! \brief Builds a room in a row of three tiles, fills it with gold and sells the tile in
+//! the middle. What is left is two rooms that only look like one, and the point of the test
+//! is that they are handed over to a room of their own without losing what they hold: the
+//! gold sits in the tile data, which has to move with the tile rather than be made anew.
+BOOST_AUTO_TEST_CASE(test_RoomSplit)
+{
+    LogManager logMgr;
+    logMgr.addSink(std::unique_ptr<LogSink>(new LogSinkConsole()));
+    std::vector<PlayerInfo> players;
+
+    int seatId = 1;
+    int32_t teamId = 1;
+    // The first player is the local one
+    for(uint32_t i = 0; i < 1; ++i)
+    {
+        PlayerInfo player;
+        player.mNick = "PlayerStub" + Helper::toString(seatId);
+        player.mWantedSeatId = seatId;
+        player.mWantedTeamId = teamId;
+        player.mIsHuman = true;
+        player.mPlayerId = -1;
+        player.mWantedFactionIndex = 0;
+        players.push_back(player);
+
+        ++seatId;
+        ++teamId;
+    }
+
+    // We add the AI players
+    for(uint32_t i = 0; i < 2; ++i)
+    {
+        PlayerInfo playerAi;
+        playerAi.mPlayerId = 0;
+        playerAi.mWantedSeatId = seatId;
+        playerAi.mWantedTeamId = teamId;
+        playerAi.mWantedFactionIndex = 0;
+        playerAi.mIsHuman = false;
+        players.push_back(playerAi);
+
+        ++seatId;
+        ++teamId;
+    }
+
+    ODClientTestRoomSplit client(players, 0);
+    BOOST_CHECK(client.connect("localhost", 32222, 10, "test_RoomSplitReplay"));
+    BOOST_CHECK(client.isConnected());
+
+    client.runFor(5000);
+    if(!client.isConnected())
+    {
+        BOOST_CHECK(false);
+        return;
+    }
+
+    SeatData& seatLocal = *client.getLocalSeat();
+
+    // Gold is kept in the treasury rather than by the seat, so the room has to come first.
+    // The first tile of a seat's first treasury is free, which is the only way to start.
+    ODPacket packSend;
+    RoomType type = RoomType::treasury;
+    uint32_t nb = 1;
+    int32_t x = 3;
+    int32_t y = 10;
+    packSend << ClientNotificationType::askBuildRoom << type << nb << x << y;
+    client.send(packSend);
+    client.runFor(3000);
+
+    client.sendConsoleCmd("addgold 1 200");
+    client.runFor(3000);
+    BOOST_CHECK(seatLocal.getGold() == 200);
+
+    // Widen it to a row of five: (1,10) to (5,10) are claimed ground, and the four added
+    // tiles cost 25 each
+    packSend.clear();
+    nb = 4;
+    packSend << ClientNotificationType::askBuildRoom << type << nb;
+    for(int32_t xBuild : {1, 2, 4, 5})
+    {
+        y = 10;
+        packSend << xBuild << y;
+    }
+    client.send(packSend);
+    client.runFor(3000);
+    BOOST_CHECK(seatLocal.getGold() == 100);
+
+    // Fill the five tiles: a treasury tile holds 1000 gold
+    client.sendConsoleCmd("addgold 1 4900");
+    client.runFor(3000);
+    BOOST_CHECK(seatLocal.getGold() == 5000);
+
+    // Selling the tile in the middle leaves (1,10) (2,10) with nothing joining them to
+    // (4,10) (5,10). Both keep two tiles, so the second pair is the one moved out.
+    packSend.clear();
+    nb = 1;
+    x = 3;
+    y = 10;
+    packSend << ClientNotificationType::askSellRoomTiles << nb << x << y;
+    client.send(packSend);
+    client.runFor(3000);
+
+    // Only the gold of the tile that was sold is gone: 4000 of the 5000 is left. Both ways of
+    // getting the hand over wrong show up here. Lose what the moved tiles held and the seat
+    // is down to the 2000 that stayed; leave a copy of it behind, in a room that counts the
+    // gold of every tile it has data for rather than only the ones it covers, and selling
+    // the middle of a treasury makes 6000 out of 5000.
+    BOOST_CHECK(client.isConnected());
+    int32_t goldLeft = seatLocal.getGold();
+    OD_LOG_INF("Gold left after the split: " + Helper::toString(goldLeft));
+    BOOST_CHECK(goldLeft == 4000);
+
+    client.disconnect(false);
+}


### PR DESCRIPTION
Selling the middle of a bridge left two stretches of bridge that were still one room, so everything done to one was done to both — an enemy worker claiming one stretch took the other across lava it cannot reach. Rooms merged but never split: `checkForRoomAbsorbtion()` had no reverse. `Room::checkForSplit()` now gathers covered tiles into connected groups and splits the room when it stops holding together, with per-room-type handling and a unit test (`test_RoomSplit`).

---
Split out of #16 so each topic can be reviewed on its own. Merging all of the split PRs reproduces the tree of #16 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
