### PR TITLE
Keep the labels over the creatures they belong to

### DIFF
--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -46,6 +46,7 @@
 #include "network/ODServer.h"
 #include "network/ServerMode.h"
 #include "network/ServerNotification.h"
+#include "render/CreatureOverlayStatus.h"
 #include "render/ODFrameListener.h"
 #include "rooms/Room.h"
 #include "rooms/RoomManager.h"
@@ -1330,15 +1331,37 @@ unsigned long int GameMap::doMiscUpkeep(double timeSinceLastTurn)
 
 void GameMap::updateAnimations(Ogre::Real timeSinceLastFrame)
 {
-    if(mIsPaused)
+    if(mIsPaused || (getTurnNumber() <= 0))
+    {
+        // The labels over the creatures are placed on the screen rather than in the world,
+        // so they only stay over their creature for as long as something keeps putting them
+        // where the camera now sees it. The camera goes on moving while the game is paused,
+        // which left every label of them behind, sitting over whatever the creature had
+        // been standing on. They are moved without being given any time, so nothing they
+        // say changes and no mood of theirs takes its turn while the game is not running.
+        updateCreatureOverlays(0.0);
         return;
-
-    if(getTurnNumber() <= 0)
-        return;
+    }
 
     // Update the animations on all AnimatedObjects
     for(MovableGameEntity* mge : mAnimatedObjects)
         mge->update(timeSinceLastFrame);
+}
+
+void GameMap::updateCreatureOverlays(Ogre::Real timeSinceLastFrame)
+{
+    // Only the client has them
+    if(isServerGameMap())
+        return;
+
+    for(Creature* creature : mCreatures)
+    {
+        CreatureOverlayStatus* overlayStatus = creature->getOverlayStatus();
+        if(overlayStatus == nullptr)
+            continue;
+
+        overlayStatus->update(timeSinceLastFrame);
+    }
 }
 
 void GameMap::playerIsFighting(Player* player, Tile* tile)

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -415,6 +415,11 @@ public:
     //! \brief Updates the different entities animations.
     void updateAnimations(Ogre::Real timeSinceLastFrame);
 
+    //! \brief Client side. Puts the labels back over the creatures they belong to. They
+    //! are placed on the screen, so they have to follow the camera even when the game is
+    //! not running.
+    void updateCreatureOverlays(Ogre::Real timeSinceLastFrame);
+
     inline int64_t getTurnNumber() const
     { return mTurnNumber; }
 

--- a/source/render/CreatureOverlayStatus.cpp
+++ b/source/render/CreatureOverlayStatus.cpp
@@ -178,11 +178,19 @@ void CreatureOverlayStatus::updateStatus(Ogre::Real timeSincelastFrame)
 
 void CreatureOverlayStatus::update(Ogre::Real timeSincelastFrame)
 {
-    // If the creature is not on map, we do not display the overlays
-    mMovableTextOverlay->setVisible(mCreature->getIsOnMap());
+    // If the creature is not on map, we do not display the overlays. Neither do we over a
+    // dead one: it lies there for a few turns before it is taken away, and its level and its
+    // mood are of no interest by then.
+    mMovableTextOverlay->setVisible(mCreature->getIsOnMap() && mCreature->isAlive());
 
     updateHealth();
-    updateStatus(timeSincelastFrame);
+
+    // A creature with several moods to show takes them in turns, one second each. No time
+    // passing means no turn taken: the labels are put back where the camera sees them while
+    // the game is paused, and cycling then would run through the moods as fast as the game
+    // draws.
+    if(timeSincelastFrame > 0.0)
+        updateStatus(timeSincelastFrame);
 
     mMovableTextOverlay->update(timeSincelastFrame);
 }

--- a/source/render/MovableTextOverlay.cpp
+++ b/source/render/MovableTextOverlay.cpp
@@ -273,8 +273,11 @@ void MovableTextOverlay::setMaterialName(uint32_t childOverlayId, const Ogre::St
 
 bool MovableTextOverlay::computeOverlayPositionHead(Ogre::Vector2& position)
 {
-    // the AABB of the target
-    const Ogre::AxisAlignedBox& AABB = mFollowedMov->getWorldBoundingBox();
+    // The AABB of the target. It has to be derived rather than taken as it stands: the
+    // entities are moved during the frame, after the scene was last updated, so the box
+    // Ogre holds is where the creature was on the previous frame. Placing the label from
+    // that leaves it trailing behind whatever is moving.
+    const Ogre::AxisAlignedBox& AABB = mFollowedMov->getWorldBoundingBox(true);
     if (!mCamera->isVisible(AABB))
         return false;
 


### PR DESCRIPTION
The label over a creature is placed on screen from where the camera sees the creature, so it is only over it while something keeps putting it back. Three things stopped that from happening (pausing then moving the camera among them), leaving labels floating over ground their creatures had left. One commit.

---
Split out of #16 so each topic can be reviewed on its own. Merging all of the split PRs reproduces the tree of #16 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
