### PR TITLE
Keep the spell cooldown next to the pointer counting down

### DIFF
--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -73,6 +73,7 @@ const std::string TEXT_SEAT_TEAM_ID_PREFIX = "TextSeatTeam";
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
+    mIsSpellCooldownDisplayed(false),
     mIndexEvent(0),
     mSettings(SettingsWindow(mRootWindow)),
     mIsSkillWindowOpen(false),
@@ -1146,6 +1147,9 @@ void GameMode::onFrameStarted(const Ogre::FrameEvent& evt)
     }
     player->frameStarted(evt.timeSinceLastFrame);
 
+    // After frameStarted, so that the countdown shown is the one just computed.
+    refreshSpellCooldownText();
+
     if((mSkillCurrentCompletion.mProgressBar != nullptr) &&
        (mSkillCurrentCompletion.mCompletenessDisplayed < mSkillCurrentCompletion.mCompleteness))
     {
@@ -1670,6 +1674,41 @@ void GameMode::refreshSpellButtonCoolDowns()
             progressBar->hide();
         }
     });
+}
+
+void GameMode::refreshSpellCooldownText()
+{
+    // checkInputCommand() is what writes the text next to the pointer, and it only runs
+    // when the mouse moves or is clicked. Everything it displays is a function of where
+    // the pointer is, except the spell cooldown, which counts down on its own: holding
+    // the mouse still, over an enemy waiting to cast at it for instance, left the
+    // countdown frozen at whatever it read when the mouse last moved.
+    if(mPlayerSelection.getCurrentAction() != SelectedAction::castSpell)
+    {
+        mIsSpellCooldownDisplayed = false;
+        return;
+    }
+
+    if(SpellManager::checkSpellCooldown(mGameMap, mPlayerSelection.getNewSpellType(), *this))
+    {
+        mIsSpellCooldownDisplayed = true;
+        return;
+    }
+
+    if(!mIsSpellCooldownDisplayed)
+        return;
+
+    // The cooldown has just run out. What belongs next to the pointer now is whatever
+    // the spell itself wants to display there, and only the spell knows that, so ask it
+    // once. Not while the mouse button is being released though: checkSpellCast() casts
+    // the spell in that state rather than describing it.
+    mIsSpellCooldownDisplayed = false;
+
+    const InputManager& inputManager = mModeManager->getInputManager();
+    if(inputManager.mCommandState == InputCommandState::validated)
+        return;
+
+    SpellManager::checkSpellCast(mGameMap, mPlayerSelection.getNewSpellType(), inputManager, *this);
 }
 
 void GameMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2)

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -193,6 +193,10 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     //! \brief Called at each frame. Updates spell cooldowns.
     void refreshSpellButtonCoolDowns();
 
+    //! \brief Called at each frame. Keeps the countdown next to the mouse pointer ticking
+    //! while a spell that is still cooling down is selected.
+    void refreshSpellCooldownText();
+
     Creature* getClosestCreature(Tile*);
     
 protected:
@@ -218,6 +222,10 @@ private:
     //! \brief Sets whether a tile must marked or unmarked for digging.
     //! this value is based on the first marked flag tile selected.
     bool mDigSetBool;
+
+    //! \brief Whether the text next to the mouse pointer is currently a spell cooldown
+    //! countdown, and thus whether it will need replacing once the cooldown runs out.
+    bool mIsSpellCooldownDisplayed;
 
     //! \brief Index of the event in the game event queue (for zooming automatically)
     uint32_t mIndexEvent;

--- a/source/spells/SpellManager.cpp
+++ b/source/spells/SpellManager.cpp
@@ -116,18 +116,24 @@ void SpellManager::write(const Spell& spell, std::ostream& os)
     spell.exportToStream(os);
 }
 
-void SpellManager::checkSpellCast(GameMap* gameMap, SpellType type, const InputManager& inputManager, InputCommand& inputCommand)
+bool SpellManager::checkSpellCooldown(GameMap* gameMap, SpellType type, InputCommand& inputCommand)
 {
     Player* player = gameMap->getLocalPlayer();
     float cooldown = player->getSpellCooldownSmoothTime(type);
-    if(cooldown > 0)
-    {
-        std::string errorStr = getSpellNameFromSpellType(type)
-            + " (" + Helper::toString(cooldown, 2)+ " s)";
+    if(cooldown <= 0)
+        return false;
 
-        inputCommand.displayText(Ogre::ColourValue::Red, errorStr);
+    std::string errorStr = getSpellNameFromSpellType(type)
+        + " (" + Helper::toString(cooldown, 2)+ " s)";
+
+    inputCommand.displayText(Ogre::ColourValue::Red, errorStr);
+    return true;
+}
+
+void SpellManager::checkSpellCast(GameMap* gameMap, SpellType type, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    if(checkSpellCooldown(gameMap, type, inputCommand))
         return;
-    }
 
     std::vector<const SpellFactory*>& factories = getFactories();
     uint32_t index = static_cast<uint32_t>(type);

--- a/source/spells/SpellManager.h
+++ b/source/spells/SpellManager.h
@@ -68,6 +68,13 @@ public:
     //! will be called with the data from the client and it should cast the spell if it is validated.
     static void checkSpellCast(GameMap* gameMap, SpellType type, const InputManager& inputManager, InputCommand& inputCommand);
 
+    //! \brief Called on client side. If the local player cannot cast the given spell yet, displays
+    //! how long is left before he can and returns true. Displays nothing and returns false otherwise.
+    //! This is the part of checkSpellCast that changes on its own while the player does nothing, so
+    //! it can be called on every frame to keep the countdown ticking. Unlike checkSpellCast, it never
+    //! casts anything, whatever the state of the input.
+    static bool checkSpellCooldown(GameMap* gameMap, SpellType type, InputCommand& inputCommand);
+
     //! \brief Called on server side. Casts the spell according to the information in the packet
     //! returns true if the spell was correctly cast and false otherwise
     //! Note that this function does not set the cooldown


### PR DESCRIPTION
Selecting a spell still cooling down shows a countdown next to the pointer, but it was only rewritten on mouse move, so it froze whenever the mouse did — still showing a stale value once the spell was castable again. The countdown now keeps counting next to a resting pointer. One commit.

---
Split out of #16 so each topic can be reviewed on its own. Merging all of the split PRs reproduces the tree of #16 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
