### PR TITLE
Send creatures another way when the bridge they were using is sold

### DIFF
--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -968,6 +968,14 @@ void Creature::doUpkeep()
         return;
     }
 
+    // The ground the creature is standing on, or the ground it is walking towards, may have
+    // stopped being walkable since it last decided anything. Selling or destroying a bridge
+    // is what does that: the tiles it covered go back to being lava or water, and nothing
+    // told the creatures using them. Both checks have to happen before the creature acts, so
+    // that it acts on where it can actually go.
+    checkStandsOnWalkableTile();
+    checkWalkPathIsStillValid();
+
     // Check to see if we have earned enough experience to level up.
     checkLevelUp();
 
@@ -2478,6 +2486,162 @@ bool Creature::setDestination(Tile* tile)
     setWalkPath(EntityAnimation::walk_anim, EntityAnimation::idle_anim, true, true, path,true);
     pushAction(Utils::make_unique<CreatureActionWalkToTile>(*this));
     return true;
+}
+
+void Creature::checkWalkPathIsStillValid()
+{
+    if(mWalkQueue.empty())
+        return;
+
+    bool isPathBlocked = false;
+    for(const Ogre::Vector2& step : mWalkQueue)
+    {
+        Tile* tile = getGameMap()->getTile(Helper::round(step.x), Helper::round(step.y));
+        if(canGoThroughTile(tile))
+            continue;
+
+        // A building that will not let the creature through, a closed door or a prison, is
+        // another matter: those are meant to stop it where it is, and it was already
+        // walking towards one knowing what it would find. Only the ground going away from
+        // under the path is unexpected.
+        if((tile != nullptr) && (tile->getCoveringBuilding() != nullptr))
+            continue;
+
+        isPathBlocked = true;
+        break;
+    }
+
+    if(!isPathBlocked)
+        return;
+
+    const Ogre::Vector2& lastStep = mWalkQueue.back();
+    Tile* destination = getGameMap()->getTile(Helper::round(lastStep.x), Helper::round(lastStep.y));
+
+    OD_LOG_INF("creature=" + getName() + " cannot walk its path anymore, destination="
+        + Tile::displayAsString(destination));
+
+    // Stop where we are rather than walk into what is now lava or water. If there is no
+    // other way to the destination, the action that started the walk gets to decide what
+    // to do instead, exactly as it would have done had the creature arrived.
+    clearDestinations(EntityAnimation::idle_anim, true, true);
+
+    if(!canGoThroughTile(destination))
+        return;
+
+    std::list<Tile*> result = getGameMap()->path(this, destination);
+    if(result.size() <= 1)
+        return;
+
+    std::vector<Ogre::Vector2> path;
+    tileToVector2(result, path, true, 0.0);
+    setWalkPath(EntityAnimation::walk_anim, EntityAnimation::idle_anim, true, true, path, true);
+}
+
+void Creature::checkStandsOnWalkableTile()
+{
+    Tile* myTile = getPositionTile();
+    if(canGoThroughTile(myTile))
+        return;
+
+    // Prisons, fenced rooms and locked doors give a null speed on purpose, to hold the
+    // creature where it is. What we are after here is the ground going away from under
+    // it, which leaves the tile covered by nothing at all.
+    if(myTile->getCoveringBuilding() != nullptr)
+        return;
+
+    // And a bridge is the only thing that can be taken away from under a creature, so
+    // water and lava are the only ground it can be left standing on. Anything else that
+    // gives a null speed is left alone rather than guessed at.
+    if((myTile->getTileVisual() != TileVisual::waterGround) &&
+       (myTile->getTileVisual() != TileVisual::lavaGround))
+    {
+        return;
+    }
+
+    // A null move speed is used for everything, including the creature's own movement, so
+    // a creature standing where it cannot walk is stuck there for good. That happens when
+    // the bridge it was standing on is sold or destroyed under its feet.
+    Tile* tileDest = findClosestWalkableTile();
+    if(tileDest == nullptr)
+    {
+        OD_LOG_INF("creature=" + getName() + " is stuck on tile=" + Tile::displayAsString(myTile)
+            + " with nowhere to stand nearby");
+        return;
+    }
+
+    OD_LOG_INF("creature=" + getName() + " cannot stand on tile=" + Tile::displayAsString(myTile)
+        + " anymore, moving it to tile=" + Tile::displayAsString(tileDest));
+
+    clearDestinations(EntityAnimation::idle_anim, true, true);
+    teleportToTile(tileDest);
+}
+
+Tile* Creature::findClosestWalkableTile() const
+{
+    Tile* myTile = getPositionTile();
+    if(myTile == nullptr)
+        return nullptr;
+
+    // Search ring by ring around the creature and keep the closest tile of the first ring
+    // that has any. A bridge is at most a few tiles from a shore, so there is no point in
+    // looking very far: if nothing is found, the creature is in the middle of a lake and
+    // dropping it on the far bank would be worse than leaving it where it is.
+    const int32_t maxRadius = 5;
+    for(int32_t radius = 1; radius <= maxRadius; ++radius)
+    {
+        Tile* tileClosest = nullptr;
+        int32_t distClosest = 0;
+        for(int32_t xx = myTile->getX() - radius; xx <= myTile->getX() + radius; ++xx)
+        {
+            for(int32_t yy = myTile->getY() - radius; yy <= myTile->getY() + radius; ++yy)
+            {
+                // Only the tiles on the ring itself, the ones within it were checked by a
+                // previous round
+                if((std::abs(xx - myTile->getX()) != radius) &&
+                   (std::abs(yy - myTile->getY()) != radius))
+                {
+                    continue;
+                }
+
+                Tile* tile = getGameMap()->getTile(xx, yy);
+                if(!canGoThroughTile(tile))
+                    continue;
+
+                int32_t dist = Pathfinding::squaredDistanceTile(*myTile, *tile);
+                if((tileClosest != nullptr) && (dist >= distClosest))
+                    continue;
+
+                tileClosest = tile;
+                distClosest = dist;
+            }
+        }
+
+        if(tileClosest != nullptr)
+            return tileClosest;
+    }
+
+    return nullptr;
+}
+
+void Creature::teleportToTile(Tile* tile)
+{
+    // Keep the height we are at: flying creatures do not walk at ground level
+    Ogre::Vector3 dest(static_cast<Ogre::Real>(tile->getX()),
+        static_cast<Ogre::Real>(tile->getY()), getPosition().z);
+    setPosition(dest);
+
+    for(Seat* seat : mSeatsWithVisionNotified)
+    {
+        if(seat->getPlayer() == nullptr)
+            continue;
+        if(!seat->getPlayer()->getIsHuman())
+            continue;
+
+        ServerNotification* serverNotification = new ServerNotification(
+            ServerNotificationType::entityTeleported, seat->getPlayer());
+        serverNotification->mPacket << getName() << dest;
+        ODServer::getSingleton().queueServerNotification(serverNotification);
+    }
 }
 
 bool Creature::wanderRandomly(const std::string& animationState)

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -2558,90 +2558,14 @@ void Creature::checkStandsOnWalkableTile()
         return;
     }
 
-    // A null move speed is used for everything, including the creature's own movement, so
-    // a creature standing where it cannot walk is stuck there for good. That happens when
-    // the bridge it was standing on is sold or destroyed under its feet.
-    Tile* tileDest = findClosestWalkableTile();
-    if(tileDest == nullptr)
-    {
-        OD_LOG_INF("creature=" + getName() + " is stuck on tile=" + Tile::displayAsString(myTile)
-            + " with nowhere to stand nearby");
-        return;
-    }
-
-    OD_LOG_INF("creature=" + getName() + " cannot stand on tile=" + Tile::displayAsString(myTile)
-        + " anymore, moving it to tile=" + Tile::displayAsString(tileDest));
+    // The creature cannot go through this tile, or canGoThroughTile above would have
+    // accepted it, so it cannot live in what it is now standing in. It does not get
+    // fished out or teleported ashore: it drowns, or burns.
+    OD_LOG_INF("creature=" + getName() + " lost the ground under its feet on tile="
+        + Tile::displayAsString(myTile) + " and dies");
 
     clearDestinations(EntityAnimation::idle_anim, true, true);
-    teleportToTile(tileDest);
-}
-
-Tile* Creature::findClosestWalkableTile() const
-{
-    Tile* myTile = getPositionTile();
-    if(myTile == nullptr)
-        return nullptr;
-
-    // Search ring by ring around the creature and keep the closest tile of the first ring
-    // that has any. A bridge is at most a few tiles from a shore, so there is no point in
-    // looking very far: if nothing is found, the creature is in the middle of a lake and
-    // dropping it on the far bank would be worse than leaving it where it is.
-    const int32_t maxRadius = 5;
-    for(int32_t radius = 1; radius <= maxRadius; ++radius)
-    {
-        Tile* tileClosest = nullptr;
-        int32_t distClosest = 0;
-        for(int32_t xx = myTile->getX() - radius; xx <= myTile->getX() + radius; ++xx)
-        {
-            for(int32_t yy = myTile->getY() - radius; yy <= myTile->getY() + radius; ++yy)
-            {
-                // Only the tiles on the ring itself, the ones within it were checked by a
-                // previous round
-                if((std::abs(xx - myTile->getX()) != radius) &&
-                   (std::abs(yy - myTile->getY()) != radius))
-                {
-                    continue;
-                }
-
-                Tile* tile = getGameMap()->getTile(xx, yy);
-                if(!canGoThroughTile(tile))
-                    continue;
-
-                int32_t dist = Pathfinding::squaredDistanceTile(*myTile, *tile);
-                if((tileClosest != nullptr) && (dist >= distClosest))
-                    continue;
-
-                tileClosest = tile;
-                distClosest = dist;
-            }
-        }
-
-        if(tileClosest != nullptr)
-            return tileClosest;
-    }
-
-    return nullptr;
-}
-
-void Creature::teleportToTile(Tile* tile)
-{
-    // Keep the height we are at: flying creatures do not walk at ground level
-    Ogre::Vector3 dest(static_cast<Ogre::Real>(tile->getX()),
-        static_cast<Ogre::Real>(tile->getY()), getPosition().z);
-    setPosition(dest);
-
-    for(Seat* seat : mSeatsWithVisionNotified)
-    {
-        if(seat->getPlayer() == nullptr)
-            continue;
-        if(!seat->getPlayer()->getIsHuman())
-            continue;
-
-        ServerNotification* serverNotification = new ServerNotification(
-            ServerNotificationType::entityTeleported, seat->getPlayer());
-        serverNotification->mPacket << getName() << dest;
-        ODServer::getSingleton().queueServerNotification(serverNotification);
-    }
+    takeDamage(nullptr, getHP(), 0.0, 0.0, 0.0, myTile, false);
 }
 
 bool Creature::wanderRandomly(const std::string& animationState)

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -218,6 +218,17 @@ public:
     
     bool setDestination(Tile* tile);
 
+    //! \brief Server side. Checks that the creature can still walk the path it is following and,
+    //! if it cannot, looks for another way to the same destination. Tiles the creature could walk
+    //! on when the path was computed can stop being walkable while it is on its way, which is what
+    //! happens to a bridge over lava or water that is sold or destroyed.
+    void checkWalkPathIsStillValid();
+
+    //! \brief Server side. Checks that the creature is standing somewhere it can stand and, if it
+    //! is not, puts it back on the closest tile where it can. A creature on a tile it cannot walk
+    //! on has a null move speed, so it can never leave by itself.
+    void checkStandsOnWalkableTile();
+
     //! \brief Picks a destination far away in the visible tiles and goes there
     //! Returns true if a valid Tile was found. The creature will go there
     //! Returns false if no reachable Tile was found
@@ -637,6 +648,14 @@ private:
 
     void createMeshWeapons();
     void destroyMeshWeapons();
+
+    //! \brief Returns the closest tile the creature could stand on, searching outwards from the
+    //! tile it is on, or nullptr if there is none anywhere near.
+    Tile* findClosestWalkableTile() const;
+
+    //! \brief Server side. Moves the creature to the given tile without walking there, and tells
+    //! the clients that can see it.
+    void teleportToTile(Tile* tile);
 
     //! \brief Constructor for sending creatures through network. It should not be used in game.
     Creature(GameMap* gameMap);

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -224,9 +224,9 @@ public:
     //! happens to a bridge over lava or water that is sold or destroyed.
     void checkWalkPathIsStillValid();
 
-    //! \brief Server side. Checks that the creature is standing somewhere it can stand and, if it
-    //! is not, puts it back on the closest tile where it can. A creature on a tile it cannot walk
-    //! on has a null move speed, so it can never leave by itself.
+    //! \brief Server side. Checks that the creature is standing somewhere it can stand and, if
+    //! the ground has turned into water or lava it cannot live in, kills it. A creature on a
+    //! tile it cannot walk on has a null move speed, so it could never leave by itself anyway.
     void checkStandsOnWalkableTile();
 
     //! \brief Picks a destination far away in the visible tiles and goes there
@@ -648,14 +648,6 @@ private:
 
     void createMeshWeapons();
     void destroyMeshWeapons();
-
-    //! \brief Returns the closest tile the creature could stand on, searching outwards from the
-    //! tile it is on, or nullptr if there is none anywhere near.
-    Tile* findClosestWalkableTile() const;
-
-    //! \brief Server side. Moves the creature to the given tile without walking there, and tells
-    //! the clients that can see it.
-    void teleportToTile(Tile* tile);
 
     //! \brief Constructor for sending creatures through network. It should not be used in game.
     Creature(GameMap* gameMap);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -608,8 +608,13 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             
             OD_ASSERT_TRUE(packetReceived >> objName >> dest);
             MovableGameEntity *obj = gameMap->getAnimatedObject(objName);
+            if (obj == nullptr)
+            {
+                OD_LOG_ERR("Server told us to teleport unknown entity name=" + objName);
+                break;
+            }
             obj->setPosition(dest);
-            
+
             break;
         }
         case ServerNotificationType::entitySlapped:


### PR DESCRIPTION
A creature walking towards (or standing on) a bridge when it is sold kept its computed path, stepped onto the uncovered lava/water tile, and stopped there permanently, because its move speed there is zero. Now a creature walking towards the missing bridge is stopped and re-routed, and a creature left standing in lava or water it cannot live in dies — as discussed in the review, it does not get teleported ashore. Two commits.

---
Split out of #16 so each topic can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
