### PR TITLE
Make all traps attackable and give them configurable HP

### DIFF
--- a/config/traps.cfg
+++ b/config/traps.cfg
@@ -5,6 +5,10 @@
 #
 # Supported elements:
 # BoulderCostPerTile                (int)    Cost per tile for boulder trap
+# BoulderHP                         (double) Hit points of each boulder trap tile when attacked
+# CannonHP                          (double) Hit points of each cannon trap tile when attacked
+# SpikeHP                           (double) Hit points of each spike trap tile when attacked
+# WoodenDoorHP                      (double) Hit points of each wooden door tile when attacked
 # BoulderWorkshopPointsPerTile      (int)    How many Workshop points required to craft a Boulder
 # BoulderReloadTurns                (uint)   How many turns to wait for a boulder to reload
 # BoulderSpeed                      (double) Boulder speed (tiles per turn)
@@ -30,6 +34,7 @@
 
 [Traps]
     BoulderCostPerTile	500
+    BoulderHP	15
     BoulderWorkshopPointsPerTile	70
     BoulderReloadTurns	50
     BoulderSpeed	1
@@ -37,6 +42,7 @@
     BoulderDamagePerHitMax	120
     BoulderNbShootsBeforeDeactivation	1
     CannonCostPerTile	500
+    CannonHP	20
     CannonPhyDef	8.0
     CannonMagDef	8.0
     CannonEleDef	8.0
@@ -48,11 +54,13 @@
     CannonDamagePerHitMax	15
     CannonNbShootsBeforeDeactivation	20
     SpikeCostPerTile	400
+    SpikeHP	10
     SpikeWorkshopPointsPerTile	60
     SpikeReloadTurns	5
     SpikeDamagePerHitMin	10
     SpikeDamagePerHitMax	15
     SpikeNbShootsBeforeDeactivation	5
     WoodenDoorCostPerTile	250
+    WoodenDoorHP	25
     WoodenDoorPointsPerTile	50
 [/Traps]

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -302,7 +302,7 @@ void Trap::setupTrap(const std::string& name, Seat* seat, const std::vector<Tile
         mCoveredTiles.push_back(tile);
         TrapTileData* trapTileData = createTileData(tile);
         mTileData[tile] = trapTileData;
-        trapTileData->mHP = DEFAULT_TILE_HP;
+        trapTileData->mHP = getTileHP();
         trapTileData->setReloadTime(mReloadTime);
         // Allied seats with the creator do see the trap from the start
         trapTileData->seatsSawTriggering(alliedSeats);
@@ -504,7 +504,7 @@ bool Trap::importTileDataFromStream(std::istream& is, Tile* tile, TileData* tile
     if(is.eof())
     {
         // Default initialization
-        trapTileData->mHP = DEFAULT_TILE_HP;
+        trapTileData->mHP = getTileHP();
         mCoveredTiles.push_back(tile);
         tile->setCoveringBuilding(this);
         if(isTrapActiv != 0)

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -205,6 +205,11 @@ public:
 
     virtual bool isAttackable(Tile* tile, Seat* seat) const override;
 
+    //! \brief Hit points each tile of the trap starts with. Trap types
+    //! override this to read their value from the trap configuration file.
+    virtual double getTileHP() const
+    { return DEFAULT_TILE_HP; }
+
     virtual bool shouldSetCoveringTileDirty(Seat* seat, Tile* tile) override;
 
     virtual void restoreInitialEntityState() override;

--- a/source/traps/TrapBoulder.cpp
+++ b/source/traps/TrapBoulder.cpp
@@ -127,6 +127,11 @@ TrapBoulder::TrapBoulder(GameMap* gameMap) :
     setMeshName("");
 }
 
+double TrapBoulder::getTileHP() const
+{
+    return ConfigManager::getSingleton().getTrapConfigDoubleOrDefault("BoulderHP", DEFAULT_TILE_HP);
+}
+
 bool TrapBoulder::shoot(Tile* tile)
 {
     std::vector<Tile*> tiles = tile->getAllNeighbors();

--- a/source/traps/TrapBoulder.h
+++ b/source/traps/TrapBoulder.h
@@ -30,10 +30,8 @@ public:
     { return TrapType::boulder; }
 
     virtual bool shoot(Tile* tile) override;
-    virtual bool isAttackable(Tile* tile, Seat* seat) const override
-    {
-        return false;
-    }
+
+    virtual double getTileHP() const override;
 
     virtual bool displayTileMesh() const override
     { return true; }

--- a/source/traps/TrapCannon.cpp
+++ b/source/traps/TrapCannon.cpp
@@ -207,3 +207,8 @@ double TrapCannon::getElementDefense() const
 {
     return ConfigManager::getSingleton().getTrapConfigUInt32("CannonEleDef");
 }
+
+double TrapCannon::getTileHP() const
+{
+    return ConfigManager::getSingleton().getTrapConfigDoubleOrDefault("CannonHP", DEFAULT_TILE_HP);
+}

--- a/source/traps/TrapCannon.h
+++ b/source/traps/TrapCannon.h
@@ -45,6 +45,8 @@ public:
     virtual double getMagicalDefense() const override;
     virtual double getElementDefense() const override;
 
+    virtual double getTileHP() const override;
+
     virtual TrapEntity* getTrapEntity(Tile* tile) override;
 
     static const TrapType mTrapType;

--- a/source/traps/TrapDoor.cpp
+++ b/source/traps/TrapDoor.cpp
@@ -432,6 +432,11 @@ bool TrapDoor::permitsVision(Tile* tile)
     return !mIsLockedState;
 }
 
+double TrapDoor::getTileHP() const
+{
+    return ConfigManager::getSingleton().getTrapConfigDoubleOrDefault("WoodenDoorHP", DEFAULT_TILE_HP);
+}
+
 double TrapDoor::getCreatureSpeed(const Creature* creature, Tile* tile) const
 {
     const TrapTileData* trapTileData = static_cast<const TrapTileData*>(mTileData.at(tile));

--- a/source/traps/TrapDoor.h
+++ b/source/traps/TrapDoor.h
@@ -57,6 +57,8 @@ public:
 
     double getCreatureSpeed(const Creature* creature, Tile* tile) const override;
 
+    double getTileHP() const override;
+
     bool permitsVision(Tile* tile) override;
 
     //! Returns true if tiles North and South (or east and west) are suitable to have a door on the

--- a/source/traps/TrapSpike.cpp
+++ b/source/traps/TrapSpike.cpp
@@ -126,6 +126,11 @@ TrapSpike::TrapSpike(GameMap* gameMap) :
     setMeshName("");
 }
 
+double TrapSpike::getTileHP() const
+{
+    return ConfigManager::getSingleton().getTrapConfigDoubleOrDefault("SpikeHP", DEFAULT_TILE_HP);
+}
+
 bool TrapSpike::shoot(Tile* tile)
 {
     std::vector<Tile*> visibleTiles;

--- a/source/traps/TrapSpike.h
+++ b/source/traps/TrapSpike.h
@@ -30,10 +30,8 @@ public:
     { return TrapType::spike; }
 
     virtual bool shoot(Tile* tile) override;
-    virtual bool isAttackable(Tile* tile, Seat* seat) const override
-    {
-        return false;
-    }
+
+    virtual double getTileHP() const override;
 
     virtual bool displayTileMesh() const override
     { return true; }

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1654,7 +1654,7 @@ double ConfigManager::getTrapConfigDouble(const std::string& param) const
 
 double ConfigManager::getTrapConfigDoubleOrDefault(const std::string& param, double defaultValue) const
 {
-    auto it = mTrapsConfig.find(param);
+    std::map<const std::string, std::string>::const_iterator it = mTrapsConfig.find(param);
     if(it == mTrapsConfig.end())
         return defaultValue;
 

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1652,6 +1652,15 @@ double ConfigManager::getTrapConfigDouble(const std::string& param) const
     return Helper::toDouble(it->second);
 }
 
+double ConfigManager::getTrapConfigDoubleOrDefault(const std::string& param, double defaultValue) const
+{
+    auto it = mTrapsConfig.find(param);
+    if(it == mTrapsConfig.end())
+        return defaultValue;
+
+    return Helper::toDouble(it->second);
+}
+
 const std::string& ConfigManager::getSpellConfigString(const std::string& param) const
 {
     auto it = mSpellConfig.find(param);

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -193,6 +193,10 @@ public:
     uint32_t getTrapConfigUInt32(const std::string& param) const;
     int32_t getTrapConfigInt32(const std::string& param) const;
     double getTrapConfigDouble(const std::string& param) const;
+    //! \brief Same as getTrapConfigDouble but returns defaultValue instead of
+    //! logging an error when the parameter is not in the configuration file.
+    //! Useful for newly introduced parameters older config files do not have.
+    double getTrapConfigDoubleOrDefault(const std::string& param, double defaultValue) const;
 
     //! Spells configuration
     const std::string& getSpellConfigString(const std::string& param) const;


### PR DESCRIPTION
Proposal 1 of a set of PRs following the mechanics discussion in #23 (https://github.com/tomluchowski/OpenDungeonsPlus/pull/23#issuecomment-5192770974) — this one covers the part Tom was certain about: *"anyway Traps should be destructible"*.

It turns out the attack machinery for traps already exists end to end (per-tile HP, `Building::takeDamage`, target discovery in `GameMap::getVisibleForce`, fight actions) — but `TrapSpike` and `TrapBoulder` override `isAttackable()` to `false`, so only cannons and wooden doors could actually be fought. This PR:

- **Removes those two overrides**, so spike and boulder traps can be attacked and destroyed like cannons already could. The *vision gate* in `Trap::isAttackable` is deliberately kept: a trap that a player has never seen trigger stays invisible and unattackable for them, so hidden traps remain a real threat.
- **Makes trap HP configurable per trap type.** Tile HP was a flat `Building::DEFAULT_TILE_HP = 10.0` for every building in the game. Traps now read `BoulderHP`, `CannonHP`, `SpikeHP`, `WoodenDoorHP` from `traps.cfg` via a new `getTrapConfigDoubleOrDefault()`, which falls back to the old value of 10 when the entry is missing — older/custom config files keep working unchanged.

The shipped values (Spike 10, Boulder 15, Cannon 20, WoodenDoor 25) are conservative first guesses to make sturdiness roughly track cost — obviously up for balance discussion, that's why they're config entries.

Not touched here: traps were already *claimable* tile-by-tile by enemy workers (`Trap::claimForSeat` destroys the danced tile), and that stays as it is.

Validated: builds and the full test suite passes (including `ab-TestTraps`) via `ctest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
