### PR TITLE
Let enemy workers claim room tiles (DK2-style), behind a config switch

### DIFF
--- a/config/rooms.cfg
+++ b/config/rooms.cfg
@@ -57,9 +57,14 @@
 # TortureDamagePerTurn              (double) Damages per turn done by the torture room (ignores physical and magical defense)
 
 [Rooms]
-    # When set to 1, enemy workers can claim room tiles by dancing on them, one
-    # tile at a time, the way they already claim bridges and traps. The dungeon
-    # temple can never be claimed. When 0, rooms can only be destroyed.
+    # What enemies can do to a room:
+    #   0  rooms cannot be claimed, only destroyed (the historical behaviour)
+    #   1  enemy workers can claim room tiles by dancing on them, one tile at a
+    #      time, the way they already claim bridges and traps, and fighters
+    #      can still destroy them
+    #   2  only workers can take a room, tile by tile; fighters leave rooms alone
+    # The dungeon temple can never be claimed, so it stays destructible in every
+    # mode: destroying it is how a player is defeated.
     RoomsClaimableByEnemies	0
     HatcheryCostPerTile	100
     HatcheryHungerPerChicken	10

--- a/config/rooms.cfg
+++ b/config/rooms.cfg
@@ -57,6 +57,10 @@
 # TortureDamagePerTurn              (double) Damages per turn done by the torture room (ignores physical and magical defense)
 
 [Rooms]
+    # When set to 1, enemy workers can claim room tiles by dancing on them, one
+    # tile at a time, the way they already claim bridges and traps. The dungeon
+    # temple can never be claimed. When 0, rooms can only be destroyed.
+    RoomsClaimableByEnemies	0
     HatcheryCostPerTile	100
     HatcheryHungerPerChicken	10
     HatcheryHpRecoveredPerChicken	5

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -39,11 +39,13 @@ class TileData
 
 public:
     TileData() :
-        mHP(0)
+        mHP(0),
+        mClaimedValue(1.0)
     {}
 
     TileData(const TileData* tileData) :
-        mHP(tileData->mHP)
+        mHP(tileData->mHP),
+        mClaimedValue(tileData->mClaimedValue)
     {}
 
     virtual ~TileData()
@@ -53,6 +55,12 @@ public:
     { return new TileData(this); }
 
     double mHP;
+
+    //! How much dancing an enemy worker still has to do on this tile before it
+    //! changes hands, for buildings claimable tile by tile (bridges, rooms).
+    //! Note that TrapTileData keeps its own field of the same name that hides
+    //! this one; unifying the two is left for when trap serialization can move.
+    double mClaimedValue;
 
     //! Seats with vision on the corresponding tile. Note that seats with vision are not copied when cloning a TileData
     std::vector<Seat*> mSeatsVision;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -51,6 +51,122 @@ GameEntityType Room::getObjectType() const
     return GameEntityType::room;
 }
 
+const double CLAIMED_VALUE_PER_TILE = 1.0;
+
+bool Room::isClaimable(Seat* seat) const
+{
+    ConfigManager& config = ConfigManager::getSingleton();
+    if(config.getRoomConfigDoubleOrDefault("RoomsClaimableByEnemies", 0.0) == 0.0)
+        return false;
+
+    if(getSeat()->isAlliedSeat(seat))
+        return false;
+
+    if(getType() == RoomType::dungeonTemple)
+        return false;
+
+    return true;
+}
+
+void Room::claimForSeat(Seat* seat, Tile* tile, double danceRate)
+{
+    auto it = mTileData.find(tile);
+    if(it == mTileData.end())
+    {
+        OD_LOG_ERR("room=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        return;
+    }
+
+    TileData* tileData = it->second;
+    if(tileData->mClaimedValue > danceRate)
+    {
+        tileData->mClaimedValue -= danceRate;
+        return;
+    }
+
+    handTileOverToSeat(seat, tile);
+}
+
+Room* Room::handTileOverToSeat(Seat* seat, Tile* tile)
+{
+    GameMap* gameMap = getGameMap();
+
+    OD_LOG_INF("Room=" + getName() + " tile=" + Tile::displayAsString(tile)
+        + " claimed by seat id=" + Helper::toString(seat->getId()));
+
+    Room* newRoom = RoomManager::createRoom(gameMap, getType());
+    if(newRoom == nullptr)
+        return nullptr;
+
+    newRoom->setIsOnMap(true);
+    newRoom->setName(gameMap->nextUniqueNameRoom(newRoom->getType()));
+    newRoom->setSeat(seat);
+
+    // The tile changes hands the way checkForSplit() hands tiles over: the new
+    // room gets a copy of the tile data, this one keeps the original marked
+    // destroyed so seats that still think this room covers the tile can keep
+    // asking it.
+    auto itData = mTileData.find(tile);
+    if(itData != mTileData.end())
+    {
+        TileData* newData = itData->second->cloneTileData();
+        // The new owner starts with the tile fully claimed, so it can be danced
+        // back just as it was danced away.
+        newData->mClaimedValue = CLAIMED_VALUE_PER_TILE;
+        newRoom->mTileData[tile] = newData;
+        itData->second->mHP = 0.0;
+    }
+
+    auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
+    if(itTile != mCoveredTiles.end())
+        mCoveredTiles.erase(itTile);
+
+    auto itObject = mBuildingObjects.find(tile);
+    if(itObject != mBuildingObjects.end())
+    {
+        newRoom->mBuildingObjects[tile] = itObject->second;
+        mBuildingObjects.erase(itObject);
+    }
+
+    mCoveredTilesDestroyed.push_back(tile);
+    newRoom->mCoveredTiles.push_back(tile);
+    tile->setCoveringBuilding(newRoom);
+    tile->claimTile(seat);
+
+    // Anything this room keeps for the room as a whole rather than per tile,
+    // the gold in a treasury among it, goes over with the tile's share.
+    std::vector<Tile*> group(1, tile);
+    splitRoom(*newRoom, group);
+
+    newRoom->addToGameMap(gameMap);
+    newRoom->createMesh();
+
+    // Whoever was working on that tile is working for the other room now. It
+    // may have no room for them, so they are sent to look for a job as if the
+    // room had gone.
+    std::vector<Creature*> creatures = mCreaturesUsingRoom;
+    for(Creature* creature : creatures)
+    {
+        Tile* creatureTile = creature->getPositionTile();
+        if((creatureTile == nullptr) || (creatureTile->getCoveringBuilding() != newRoom))
+            continue;
+
+        removeCreatureUsingRoom(creature);
+        handleCreatureUsingAbsorbedRoom(*creature);
+    }
+
+    // The tile taken may sit next to another room of the claimer of the same
+    // type (the previous tiles they danced down, or a room of their own): merge.
+    newRoom->checkForRoomAbsorbtion();
+    newRoom->updateActiveSpots(gameMap);
+
+    // And losing the tile may have cut this room in two.
+    checkForSplit();
+    updateActiveSpots(gameMap);
+
+    return newRoom;
+}
+
 bool Room::compareTile(Tile* tile1, Tile* tile2)
 {
     if(tile1->getX() < tile2->getX())

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -70,7 +70,7 @@ bool Room::isClaimable(Seat* seat) const
 
 void Room::claimForSeat(Seat* seat, Tile* tile, double danceRate)
 {
-    auto it = mTileData.find(tile);
+    std::map<Tile*, TileData*>::iterator it = mTileData.find(tile);
     if(it == mTileData.end())
     {
         OD_LOG_ERR("room=" + getName() + ", tile=" + Tile::displayAsString(tile));
@@ -106,7 +106,7 @@ Room* Room::handTileOverToSeat(Seat* seat, Tile* tile)
     // room gets a copy of the tile data, this one keeps the original marked
     // destroyed so seats that still think this room covers the tile can keep
     // asking it.
-    auto itData = mTileData.find(tile);
+    std::map<Tile*, TileData*>::iterator itData = mTileData.find(tile);
     if(itData != mTileData.end())
     {
         TileData* newData = itData->second->cloneTileData();
@@ -117,11 +117,11 @@ Room* Room::handTileOverToSeat(Seat* seat, Tile* tile)
         itData->second->mHP = 0.0;
     }
 
-    auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
+    std::vector<Tile*>::iterator itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
     if(itTile != mCoveredTiles.end())
         mCoveredTiles.erase(itTile);
 
-    auto itObject = mBuildingObjects.find(tile);
+    std::map<Tile*, BuildingObject*>::iterator itObject = mBuildingObjects.find(tile);
     if(itObject != mBuildingObjects.end())
     {
         newRoom->mBuildingObjects[tile] = itObject->second;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -53,10 +53,21 @@ GameEntityType Room::getObjectType() const
 
 const double CLAIMED_VALUE_PER_TILE = 1.0;
 
-bool Room::isClaimable(Seat* seat) const
+Room::ClaimMode Room::getClaimMode()
 {
     ConfigManager& config = ConfigManager::getSingleton();
-    if(config.getRoomConfigDoubleOrDefault("RoomsClaimableByEnemies", 0.0) == 0.0)
+    double mode = config.getRoomConfigDoubleOrDefault("RoomsClaimableByEnemies", 0.0);
+    if(mode == 1.0)
+        return ClaimMode::claimableAndDestructible;
+    if(mode == 2.0)
+        return ClaimMode::claimableOnly;
+
+    return ClaimMode::destructibleOnly;
+}
+
+bool Room::isClaimable(Seat* seat) const
+{
+    if(getClaimMode() == ClaimMode::destructibleOnly)
         return false;
 
     if(getSeat()->isAlliedSeat(seat))
@@ -85,6 +96,36 @@ void Room::claimForSeat(Seat* seat, Tile* tile, double danceRate)
     }
 
     handTileOverToSeat(seat, tile);
+}
+
+bool Room::isDestructible() const
+{
+    if(getClaimMode() != ClaimMode::claimableOnly)
+        return true;
+
+    // The one room nobody can claim has to stay destructible, or the game
+    // could never be won.
+    return getType() == RoomType::dungeonTemple;
+}
+
+bool Room::isAttackable(Tile* tile, Seat* seat) const
+{
+    if(!isDestructible())
+        return false;
+
+    return Building::isAttackable(tile, seat);
+}
+
+double Room::takeDamage(GameEntity* attacker, double absoluteDamage, double physicalDamage, double magicalDamage, double elementDamage,
+        Tile* tileTakingDamage, bool ko)
+{
+    // Fighters never pick a room they cannot attack as a target, but damage
+    // that does not go through target selection (a boulder rolling through,
+    // an area spell) lands here all the same.
+    if(!isDestructible())
+        return 0.0;
+
+    return Building::takeDamage(attacker, absoluteDamage, physicalDamage, magicalDamage, elementDamage, tileTakingDamage, ko);
 }
 
 Room* Room::handTileOverToSeat(Seat* seat, Tile* tile)

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -67,6 +67,22 @@ public:
 
     virtual RoomType getType() const = 0;
 
+    //! \brief What enemies can do to a room, read from RoomsClaimableByEnemies
+    //! in the room configuration file.
+    enum class ClaimMode
+    {
+        //! Rooms cannot be claimed, only destroyed (the historical behaviour).
+        destructibleOnly = 0,
+        //! Workers can dance room tiles away and fighters can still destroy them.
+        claimableAndDestructible = 1,
+        //! Only workers can take a room, tile by tile; fighters leave rooms alone.
+        claimableOnly = 2
+    };
+
+    //! \brief The RoomsClaimableByEnemies value of the room configuration file.
+    //! Anything unknown counts as destructibleOnly.
+    static ClaimMode getClaimMode();
+
     //! \brief Rooms can be danced away tile by tile by enemy workers, the way
     //! bridges and traps already can, when the RoomsClaimableByEnemies switch is
     //! set in the room configuration file. The dungeon temple is never claimable:
@@ -74,6 +90,16 @@ public:
     //! portals override this pair with their own claiming rules.
     virtual bool isClaimable(Seat* seat) const override;
     virtual void claimForSeat(Seat* seat, Tile* tile, double danceRate) override;
+
+    //! \brief False in the claimableOnly mode, where a room changes hands by being
+    //! danced away and fighters have nothing to do with it. The dungeon temple
+    //! cannot be claimed, so it stays destructible in every mode: destroying it is
+    //! how a player gets defeated.
+    bool isDestructible() const;
+
+    virtual bool isAttackable(Tile* tile, Seat* seat) const override;
+    virtual double takeDamage(GameEntity* attacker, double absoluteDamage, double physicalDamage, double magicalDamage, double elementDamage,
+        Tile* tileTakingDamage, bool ko) override;
 
     static bool compareTile(Tile* tile1, Tile* tile2);
 

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -67,6 +67,14 @@ public:
 
     virtual RoomType getType() const = 0;
 
+    //! \brief Rooms can be danced away tile by tile by enemy workers, the way
+    //! bridges and traps already can, when the RoomsClaimableByEnemies switch is
+    //! set in the room configuration file. The dungeon temple is never claimable:
+    //! losing it means defeat and that path expects destruction. Bridges and
+    //! portals override this pair with their own claiming rules.
+    virtual bool isClaimable(Seat* seat) const override;
+    virtual void claimForSeat(Seat* seat, Tile* tile, double danceRate) override;
+
     static bool compareTile(Tile* tile1, Tile* tile2);
 
     //! \brief Adds a creature using the room. If the creature is allowed, true is returned
@@ -148,6 +156,14 @@ public:
 
 protected:
     static void fireRoomSound(Tile& tile, const std::string& soundFamily);
+
+    //! \brief Hands the given tile of this room over to a room of the same type
+    //! owned by the claiming seat, merging it with an adjacent room of theirs
+    //! when there is one and splitting this room when the loss cuts it in two.
+    //! Room-level state gets shared out through splitRoom(), so e.g. a treasury
+    //! tile takes its share of the stored gold with it. Returns the room the
+    //! tile ended up in, or nullptr if no room could be created.
+    Room* handTileOverToSeat(Seat* seat, Tile* tile);
 
     /*! \brief Exports the headers needed to recreate the Room. It allows to extend Room as much as wanted.
      * The content of the Room will be exported by exportToPacket.

--- a/source/rooms/RoomBridge.cpp
+++ b/source/rooms/RoomBridge.cpp
@@ -29,8 +29,6 @@
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
 
-const double CLAIMED_VALUE_PER_TILE = 1.0;
-
 void BridgeRoomFactory::checkBuildBridge(RoomType type, GameMap* gameMap, Seat* seat, const InputManager& inputManager,
     InputCommand& inputCommand, const std::vector<TileVisual>& allowedTilesVisual, bool isEditor) const
 {
@@ -282,13 +280,6 @@ void RoomBridge::setupRoom(const std::string& name, Seat* seat, const std::vecto
         updateFloodFillPathCreated(s, tiles);
 }
 
-BridgeTileData* RoomBridge::createTileData(Tile* tile)
-{
-    BridgeTileData* tileData = new BridgeTileData;
-    tileData->mClaimedValue = CLAIMED_VALUE_PER_TILE;
-    return tileData;
-}
-
 void RoomBridge::restoreInitialEntityState()
 {
     Room::restoreInitialEntityState();
@@ -306,7 +297,7 @@ void RoomBridge::restoreInitialEntityState()
             if(it == mTileData.end())
                 continue;
 
-            static_cast<BridgeTileData*>(it->second)->mClaimedValue = claimedValuePerTile;
+            it->second->mClaimedValue = claimedValuePerTile;
         }
     }
 
@@ -325,7 +316,7 @@ void RoomBridge::exportToStream(std::ostream& os) const
         if(it == mTileData.end())
             continue;
 
-        claimedValue += static_cast<BridgeTileData*>(it->second)->mClaimedValue;
+        claimedValue += it->second->mClaimedValue;
     }
     os << claimedValue << "\n";
 }
@@ -368,75 +359,14 @@ void RoomBridge::claimForSeat(Seat* seat, Tile* tile, double danceRate)
         return;
     }
 
-    BridgeTileData* tileData = static_cast<BridgeTileData*>(it->second);
+    TileData* tileData = it->second;
     if(tileData->mClaimedValue > danceRate)
     {
         tileData->mClaimedValue -= danceRate;
         return;
     }
 
-    claimTileForSeat(seat, tile);
-}
-
-void RoomBridge::claimTileForSeat(Seat* seat, Tile* tile)
-{
-    GameMap* gameMap = getGameMap();
-
-    OD_LOG_INF("Bridge=" + getName() + " tile=" + Tile::displayAsString(tile)
-        + " claimed by seat id=" + Helper::toString(seat->getId()));
-
-    Room* newRoom = RoomManager::createRoom(gameMap, getType());
-    if(newRoom == nullptr)
-        return;
-
-    RoomBridge* newBridge = static_cast<RoomBridge*>(newRoom);
-    newBridge->setIsOnMap(true);
-    newBridge->setName(gameMap->nextUniqueNameRoom(newBridge->getType()));
-    newBridge->setSeat(seat);
-
-    // The tile changes hands the way checkForSplit() hands tiles over: the new
-    // bridge gets a copy of the tile data, this one keeps the original marked
-    // destroyed so seats that still think this bridge covers the tile can keep
-    // asking it. The tile stays a bridge tile throughout, so pathing across it
-    // is never interrupted for anybody and no flood fill has to change.
-    auto itData = mTileData.find(tile);
-    if(itData != mTileData.end())
-    {
-        BridgeTileData* newData = static_cast<BridgeTileData*>(itData->second->cloneTileData());
-        // The new owner starts with the tile fully claimed, just as the whole
-        // bridge used to start fully claimed for whoever took it.
-        newData->mClaimedValue = CLAIMED_VALUE_PER_TILE;
-        newBridge->mTileData[tile] = newData;
-        itData->second->mHP = 0.0;
-    }
-
-    auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
-    if(itTile != mCoveredTiles.end())
-        mCoveredTiles.erase(itTile);
-
-    auto itObject = mBuildingObjects.find(tile);
-    if(itObject != mBuildingObjects.end())
-    {
-        newBridge->mBuildingObjects[tile] = itObject->second;
-        mBuildingObjects.erase(itObject);
-    }
-
-    mCoveredTilesDestroyed.push_back(tile);
-    newBridge->mCoveredTiles.push_back(tile);
-    tile->setCoveringBuilding(newBridge);
-    tile->claimTile(seat);
-
-    newBridge->addToGameMap(gameMap);
-    newBridge->createMesh();
-
-    // The square taken may sit next to another bridge of the claimer (their own
-    // side of the crossing, or the previous squares they danced down): merge.
-    newBridge->checkForRoomAbsorbtion();
-    newBridge->updateActiveSpots(gameMap);
-
-    // And losing the square may have cut this bridge in two.
-    checkForSplit();
-    updateActiveSpots(gameMap);
+    handTileOverToSeat(seat, tile);
 }
 
 double RoomBridge::getCreatureSpeed(const Creature* creature, Tile* tile) const

--- a/source/rooms/RoomBridge.h
+++ b/source/rooms/RoomBridge.h
@@ -34,30 +34,6 @@ protected:
         const std::vector<TileVisual>& allowedTilesVisual, ODPacket& packet, bool isEditor) const;
 };
 
-//! \brief Per tile state of a bridge: how much dancing an enemy worker still has
-//! to do on this tile before it changes hands.
-class BridgeTileData : public TileData
-{
-public:
-    BridgeTileData() :
-        TileData(),
-        mClaimedValue(0.0)
-    {}
-
-    BridgeTileData(const BridgeTileData* tileData) :
-        TileData(tileData),
-        mClaimedValue(tileData->mClaimedValue)
-    {}
-
-    virtual ~BridgeTileData()
-    {}
-
-    virtual BridgeTileData* cloneTileData() const override
-    { return new BridgeTileData(this); }
-
-    double mClaimedValue;
-};
-
 //! \brief this class is a convenience class that handle shared bridges behaviour. It
 //! is designed to be extended
 class RoomBridge: public Room
@@ -92,17 +68,10 @@ protected:
     virtual void exportToStream(std::ostream& os) const override;
     virtual bool importFromStream(std::istream& is) override;
 
-    virtual BridgeTileData* createTileData(Tile* tile) override;
-
     virtual void updateFloodFillPathCreated(Seat* seat, const std::vector<Tile*>& tiles);
     virtual void updateFloodFillTileRemoved(Seat* seat, Tile* tile) = 0;
 
 private:
-    //! \brief Hands the given tile of this bridge over to a bridge owned by the
-    //! claiming seat, merging it with an adjacent bridge of theirs when there is
-    //! one and splitting this bridge when the loss cuts it in two.
-    void claimTileForSeat(Seat* seat, Tile* tile);
-
     //! \brief The stream format keeps one claim value for the whole bridge, so old
     //! saves and level files load unchanged. It is read into this field and shared
     //! out over the tiles in restoreInitialEntityState(); the live value is per

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1606,7 +1606,7 @@ double ConfigManager::getRoomConfigDouble(const std::string& param) const
 
 double ConfigManager::getRoomConfigDoubleOrDefault(const std::string& param, double defaultValue) const
 {
-    auto it = mRoomsConfig.find(param);
+    std::map<const std::string, std::string>::const_iterator it = mRoomsConfig.find(param);
     if(it == mRoomsConfig.end())
         return defaultValue;
 

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1604,6 +1604,15 @@ double ConfigManager::getRoomConfigDouble(const std::string& param) const
     return Helper::toDouble(it->second);
 }
 
+double ConfigManager::getRoomConfigDoubleOrDefault(const std::string& param, double defaultValue) const
+{
+    auto it = mRoomsConfig.find(param);
+    if(it == mRoomsConfig.end())
+        return defaultValue;
+
+    return Helper::toDouble(it->second);
+}
+
 const std::string& ConfigManager::getTrapConfigString(const std::string& param) const
 {
     auto it = mTrapsConfig.find(param);

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -187,6 +187,10 @@ public:
     uint32_t getRoomConfigUInt32(const std::string& param) const;
     int32_t getRoomConfigInt32(const std::string& param) const;
     double getRoomConfigDouble(const std::string& param) const;
+    //! \brief Same as getRoomConfigDouble but returns defaultValue instead of
+    //! logging an error when the parameter is not in the configuration file.
+    //! Useful for newly introduced parameters older config files do not have.
+    double getRoomConfigDoubleOrDefault(const std::string& param, double defaultValue) const;
 
     //! Traps configuration
     const std::string& getTrapConfigString(const std::string& param) const;


### PR DESCRIPTION
Proposal 4 of the set following the mechanics discussion in #23 — the *"rooms claimable"* (DK2-style) side of the "claimable or destructible" question, as a **prototype to play-test, off by default**.

Builds on top of the square-by-square bridge PR (#34) and generalizes its tile-transfer machinery: enemy workers can dance enemy **room** tiles down one at a time, exactly like ground tiles and (now) bridge tiles. When a room tile falls it moves into a room of the same type owned by the claimer — merging with an adjacent room of theirs when there is one — and the victim's room splits if it was cut in two. Room-level state is shared out through the existing `splitRoom` hook, so e.g. a treasury tile takes its share of the stored gold with it (and merges it back into the claimer's treasury on absorption).

Because Tom explicitly wanted a community discussion on this one, the whole mechanic is gated behind a config switch in `rooms.cfg`, with three settings:

```
RoomsClaimableByEnemies	0    # rooms cannot be claimed, only destroyed (pristine ODP, shipped default)
RoomsClaimableByEnemies	1    # workers can claim room tiles, fighters can still destroy rooms
RoomsClaimableByEnemies	2    # only workers can take a room, tile by tile; fighters leave rooms alone
```

`0` keeps today's behaviour. `1` is the DK2-ish mode where conquest is possible and reversible — you can dance your dormitory back after driving the enemy out — while rooms can still be razed. `2` (Tom's request below) takes destruction off the table: a room in this mode is not attackable, so fighters skip it when picking targets and stray damage (boulders, area spells) is dropped in `Room::takeDamage`; the only way it changes hands is being danced away. Workers still only reach tiles at the border of fully-claimed ground, so a room deep in enemy territory erodes from the edge inward, which in practice makes claiming slower than destruction unless the area is secured.

Portals keep their own whole-room claiming, bridges their per-tile claiming; the dungeon temple is excluded from claiming (losing it means defeat and that path expects destruction).

Points for the Discord/community discussion this is meant to feed:
- Tom's concern that claimability handicaps aggressive players cuts both ways: with the switch on, what you lose can be danced back; with it off, destruction is final for the *owner* but the attacker gains nothing either. Having both mechanics live (rooms destructible *and* claimable, like DK2) and tuning HP/claim speed may be the sweeter spot — this PR plus the room-HP one (#33) makes that combination available for testing.
- Claim speed per room type could be made configurable later (`<RoomName>ClaimValue`) if the flat 1.0-per-tile feels wrong.

Validated: builds, full test suite passes via `ctest`, both with the switch off (default behaviour unchanged) and on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

