### PR TITLE
Tint room floors with the owning seat's colour

### DIFF
--- a/materials/scripts/Treasury.material
+++ b/materials/scripts/Treasury.material
@@ -1,34 +1,72 @@
-// Treasury genrated by blender2ogre 0.6.0
-import RTSS/NormalMapping_MultiPass from "RTShaderSystem.material"
-material Treasury : RTSS/NormalMapping_MultiPass
+// Treasury - ported from the blender2ogre RTSS export to the shared Room
+// shaders so the floor can carry the owning seat's colour tint like every
+// other room floor (the RTSS fixed-function pipeline has no seatColor).
+
+vertex_program myTreasuryVertexShader glsl
 {
-    receive_shadows on
+  source Room.vert
+    default_params
+    {
+        param_named_auto projectionMatrix projection_matrix
+        param_named_auto viewMatrix view_matrix
+        param_named_auto worldMatrix world_matrix
+        param_named_auto lightMatrix texture_worldviewproj_matrix
+    }
+
+}
+
+fragment_program myTreasuryFragmentShader glsl
+{
+  source Room.frag
+    default_params
+    {
+        param_named_auto ambientLightColour ambient_light_colour
+        param_named_auto lightDiffuseColour light_diffuse_colour 0.0
+        param_named_auto lightSpecularColour light_specular_colour 0.0
+        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto cameraPosition camera_position
+        param_named shadowingEnabled bool false
+    }
+}
+
+
+material Treasury
+{
 
     technique
     {
-        pass lighting
-        {
-            // Override the normal map.
-            rtshader_system
-            {
-                lighting_stage normal_map TreasuryNormal.png object_space 
-            }
-        }
 
-        pass decal
+        pass
         {
-            ambient 0.8 0.8 0.8 1.0
-            diffuse 0.65 0.65 0.65 1.0
-            specular 0.1 0.1 0.1 0.0 2.0
-            emissive 0.0 0.0 0.0 0.0
+            vertex_program_ref myTreasuryVertexShader
+            {
+
+            }
+            fragment_program_ref myTreasuryFragmentShader
+            {
+                param_named decalmap int 0
+                param_named normalmap int 1
+                param_named shadowmap int 2
+            }
+
 
             texture_unit decalmap
             {
                 texture Treasury.png
-                tex_address_mode wrap
-                scale 1.0 1.0
-                colour_op modulate
+            }
+
+            texture_unit normalmap
+            {
+                texture TreasuryNormal.png
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode clamp
+                filtering bilinear
+
             }
         }
+
     }
 }

--- a/shaders/Room.frag
+++ b/shaders/Room.frag
@@ -10,6 +10,11 @@ uniform vec4 lightDiffuseColour;
 uniform vec4 lightSpecularColour;
 uniform vec4 lightPos;
 uniform vec4 cameraPosition;
+// The owning seat's colour, set by RenderManager::colourizeMaterial on the
+// cloned per-seat material. The stock material never sets it, and OpenGL
+// zero-initialises uniforms at link time, so alpha stays 0.0 there and the
+// tint below stays off.
+uniform vec4 seatColor;
 uniform bool shadowingEnabled;
 in vec2 out_UV0;
 in vec2 out_UV1;
@@ -60,6 +65,10 @@ void main (void)
     // precompute the lighting term
     vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
+    // Tint owned room floors towards the owner's colour so it is visible at a
+    // glance whose room a square is, the way claimed ground already shows it.
+    if (seatColor.a > 0.0)
+        texelColor = mix(texelColor, texelColor * seatColor.rgb, 0.5);
     result =  lightingTerm * texelColor;
 
     color  = vec4(result.xyz,  1.0);

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -1113,12 +1113,30 @@ void Tile::setTeamsNumber(uint32_t nbTeams)
 
 bool Tile::shouldColorTileMesh() const
 {
-    // We only set color for claimed tiles
+    // Claimed tiles and room floors carry their owner's colour: a room square
+    // must be tellable from an enemy's at a glance, especially once rooms can
+    // change hands square by square. The materials that do not know how to
+    // tint themselves (no seatColor uniform) are skipped where the colour is
+    // applied, so listing a visual here is safe even before its material has
+    // been taught the tint.
     switch(getTileVisual())
     {
         case TileVisual::claimedGround:
         case TileVisual::claimedFull:
-        case TileVisual::portalRoom:    
+        case TileVisual::dungeonTempleRoom:
+        case TileVisual::dormitoryRoom:
+        case TileVisual::treasuryRoom:
+        case TileVisual::portalRoom:
+        case TileVisual::workshopRoom:
+        case TileVisual::trainingHallRoom:
+        case TileVisual::libraryRoom:
+        case TileVisual::hatcheryRoom:
+        case TileVisual::cryptRoom:
+        case TileVisual::portalWaveRoom:
+        case TileVisual::prisonRoom:
+        case TileVisual::arenaRoom:
+        case TileVisual::casinoRoom:
+        case TileVisual::tortureRoom:
             return true;
         default:
             return false;

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -2069,13 +2069,21 @@ std::string RenderManager::colourizeMaterial(const std::string& materialName, co
         }
         if (seat != nullptr)
         {
-            // Color the material with the Seat's color.
-            Ogre::ColourValue color = seat->getColorValue();
-            color.a = 1.0;
-            technique->getPass(technique->getNumPasses() -1 )->getFragmentProgramParameters()->setNamedConstant("seatColor", color) ;
-
-            
-
+            // Color the material with the Seat's color. Only the materials
+            // whose fragment shader takes a seatColor can carry it; the rest
+            // (fixed-function or RTSS-generated ones) are left untinted
+            // rather than aborted on.
+            Ogre::Pass* lastPass = technique->getPass(technique->getNumPasses() - 1);
+            if(lastPass->hasFragmentProgram())
+            {
+                const Ogre::GpuProgramParametersSharedPtr& params = lastPass->getFragmentProgramParameters();
+                if(params->_findNamedConstantDefinition("seatColor", false) != nullptr)
+                {
+                    Ogre::ColourValue color = seat->getColorValue();
+                    color.a = 1.0;
+                    params->setNamedConstant("seatColor", color);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Addresses the concern raised on #35: *"one cannot visually estimate which room belongs to whom when playing game"*. This makes room ownership readable at a glance, per square — which matters already today (enemy rooms seen through vision all look alike) and becomes essential if rooms ever change hands square by square.

**How**: the engine already has the machinery — claimed ground gets a per-seat material clone whose `seatColor` uniform tints the cross pattern. This PR extends it to room floors:

- `Room.frag` (the shader behind every room floor material) gains a `seatColor` uniform and blends the floor texture halfway towards the owner's colour. The stock material never sets it — OpenGL zero-initialises uniforms at link time, so alpha 0 keeps the tint off — while the per-seat clone from `colourizeMaterial` sets it, exactly like the claimed-ground path.
- `Tile::shouldColorTileMesh()` now lists the room visuals so those clones get made for room floors.
- `colourizeMaterial` checks that a material's fragment program actually **takes** a `seatColor` before setting it, so any floor material that hasn't been taught the tint renders untinted instead of raising an Ogre exception.
- `Treasury.material` (also the dungeon temple's floor) was the one floor still on the fixed-function RTSS path with nowhere to put a tint — it moves onto the shared `Room.vert`/`Room.frag` like every other room floor.

**Verified** on the two-keeper ForgottenTreasures2 level (the one from #34): in the editor, seat 1's temple + treasury floors shade red where seat 2's shade green; in a skirmish the local keeper's floors carry their colour under normal lighting and fog, and the log shows no material errors.

| Seat 1 (red) | Seat 2 (green) | In-game |
|---|---|---|
| ![seat1](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/a8f6fbcf512174cc91283e80d01b9c2bfdde6931/room-tint-seat1-editor.png) | ![seat2](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/a8f6fbcf512174cc91283e80d01b9c2bfdde6931/room-tint-seat2-editor.png) | ![skirmish](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/a8f6fbcf512174cc91283e80d01b9c2bfdde6931/room-tint-skirmish.png) |

The 0.5 blend weight is one knob to taste — lower keeps more of the original texture, higher shouts the owner louder. Happy to tune it (or switch to the claimed-style cross-pattern overlay instead of a whole-floor tint) if you prefer another look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hrk8PiEUMgjYJnTxLF2PU