### PR TITLE
Say what the quit buttons do, and add one that actually exits

### DIFF
--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -45,7 +45,7 @@
             <Property name="Area" value="{{0.5,-80},{0,321},{0.5,80},{0,354}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="IconImageColour" value="FFBB0000" />
-            <Property name="Text" value="Exit OpenDungeons" />
+            <Property name="Text" value="Exit to System" />
             <Property name="TooltipText" value="Leave this game and exit to the desktop..." />
         </Window>
     </Window>

--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="GameOptionsWindow" >
-        <Property name="Area" value="{{0.5,-110},{0.5,-167},{0.5,110},{0.5,167}}" />
+        <Property name="Area" value="{{0.5,-110},{0.5,-190},{0.5,110},{0.5,190}}" />
         <Property name="Text" value="Options" />
         <Property name="SizingEnabled" value="False" />
         <Window type="OD/IconButton" name="ObjectivesButton" >
@@ -38,9 +38,15 @@
         <Window type="OD/IconButton" name="QuitGameButton" >
             <Property name="Area" value="{{0.5,-80},{0,278},{0.5,80},{0,311}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
+            <Property name="Text" value="Quit to Menu" />
+            <Property name="TooltipText" value="Leave this game and return to the main menu..." />
+        </Window>
+        <Window type="OD/IconButton" name="ExitGameButton" >
+            <Property name="Area" value="{{0.5,-80},{0,321},{0.5,80},{0,354}}" />
+            <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="IconImageColour" value="FFBB0000" />
-            <Property name="Text" value="Quit Game" />
-            <Property name="TooltipText" value="Quit the current game..." />
+            <Property name="Text" value="Exit OpenDungeons" />
+            <Property name="TooltipText" value="Leave this game and exit to the desktop..." />
         </Window>
     </Window>
 </GUILayout>

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -222,6 +222,12 @@ GameMode::GameMode(ModeManager *modeManager):
             CEGUI::Event::Subscriber(&GameMode::showQuitMenuFromOptions, this)
         )
     );
+    addEventConnection(
+        guiSheet->getChild("GameOptionsWindow/ExitGameButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&GameMode::showExitApplicationFromOptions, this)
+        )
+    );
 
     //Exit confirmation box
     addEventConnection(
@@ -930,6 +936,7 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
 
     // Quit the game
     case OIS::KC_ESCAPE:
+        mExitToDesktop = false;
         popupExit(!mGameMap->getGamePaused());
         break;
 
@@ -1215,7 +1222,10 @@ void GameMode::notifyGuiAction(GuiAction guiAction)
 
 bool GameMode::onClickYesQuitMenu(const CEGUI::EventArgs& /*arg*/)
 {
-    mModeManager->requestMode(AbstractModeManager::MENU_MAIN);
+    if(mExitToDesktop)
+        ODFrameListener::getSingleton().requestExit();
+    else
+        mModeManager->requestMode(AbstractModeManager::MENU_MAIN);
     return true;
 }
 
@@ -1366,6 +1376,15 @@ bool GameMode::toggleOptionsWindow(const CEGUI::EventArgs& e)
 
 bool GameMode::showQuitMenuFromOptions(const CEGUI::EventArgs& /*e*/)
 {
+    mExitToDesktop = false;
+    mRootWindow->getChild("GameOptionsWindow")->hide();
+    popupExit(!mGameMap->getGamePaused());
+    return true;
+}
+
+bool GameMode::showExitApplicationFromOptions(const CEGUI::EventArgs& /*e*/)
+{
+    mExitToDesktop = true;
     mRootWindow->getChild("GameOptionsWindow")->hide();
     popupExit(!mGameMap->getGamePaused());
     return true;

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -204,6 +204,7 @@ protected:
 
     //! \brief The different Game Options Menu handlers
     bool showQuitMenuFromOptions(const CEGUI::EventArgs& e = {});
+    bool showExitApplicationFromOptions(const CEGUI::EventArgs& e = {});
     bool showObjectivesFromOptions(const CEGUI::EventArgs& e = {});
     bool showSkillFromOptions(const CEGUI::EventArgs& e = {});
     bool saveGame(const CEGUI::EventArgs& e = {});
@@ -219,6 +220,11 @@ protected:
     virtual bool keyReleasedNormal  (const OIS::KeyEvent &arg);
 
 private:
+    //! \brief Whether the pending exit confirmation should leave to the desktop
+    //! rather than back to the main menu. Set by the button that opened the
+    //! confirmation popup.
+    bool mExitToDesktop = false;
+
     //! \brief Sets whether a tile must marked or unmarked for digging.
     //! this value is based on the first marked flag tile selected.
     bool mDigSetBool;


### PR DESCRIPTION
Part of the interface review in #6: *"'Quit Game' is misleading — It doesn't quit the game. It should say 'Quit to Menu' and there should be a separate button … that actually exits the game."* Confirmed in code: the button's confirmation ran `requestMode(MENU_MAIN)`, and there was no way to leave to the desktop from inside a game.

The in-game options now say what they do:

![options](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/8d1e5bdf577f7927befc6f467b47467cd123bd29/quit-buttons-options.png)

- **Quit to Menu** keeps the old behaviour, honestly labelled;
- **Exit to System** leaves to the desktop, through the same confirmation popup.

Which path the popup confirms is armed by the button that opened it, and the Escape shortcut arms the menu path — so a confirmation abandoned with "No" can't make a later Escape-quit fall out of the program.

(The screenshot above still shows the button with its first label, "Exit OpenDungeons"; it now reads "Exit to System".)

Verified in a running game: options window shows both buttons; clicking Exit to System → Yes tears the application down cleanly, and Quit to Menu → Yes still returns to the main menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hrk8PiEUMgjYJnTxLF2PU