### PR TITLE
Stop nagging and taking orders from a defeated player

### DIFF
--- a/source/creatureaction/CreatureActionDigTile.cpp
+++ b/source/creatureaction/CreatureActionDigTile.cpp
@@ -204,8 +204,7 @@ bool CreatureActionDigTile::handleDigTile(Creature& creature, Tile& tileDig, Til
         }
 
         if((creature.getSeat()->getPlayer() != nullptr) &&
-            creature.getSeat()->getPlayer()->getIsHuman() &&
-            !creature.getSeat()->getPlayer()->getHasLost())
+            creature.getSeat()->getPlayer()->getIsHuman())
         {
             creature.getSeat()->getPlayer()->notifyNoTreasuryAvailable();
         }

--- a/source/creatureaction/CreatureActionFindHome.cpp
+++ b/source/creatureaction/CreatureActionFindHome.cpp
@@ -126,8 +126,7 @@ bool CreatureActionFindHome::handleFindHome(Creature& creature, bool forced)
     {
         // If we got here there are no reachable dormitory that are unclaimed so we quit trying to find one.
         if((creature.getSeat()->getPlayer() != nullptr) &&
-            creature.getSeat()->getPlayer()->getIsHuman() &&
-            !creature.getSeat()->getPlayer()->getHasLost())
+            creature.getSeat()->getPlayer()->getIsHuman())
         {
             creature.getSeat()->getPlayer()->notifyCreatureCannotFindBed(creature);
         }

--- a/source/creatureaction/CreatureActionSearchFood.cpp
+++ b/source/creatureaction/CreatureActionSearchFood.cpp
@@ -99,8 +99,7 @@ bool CreatureActionSearchFood::handleSearchFood(Creature& creature, bool forced)
     if (hatcheries.empty())
     {
         if((creature.getSeat()->getPlayer() != nullptr) &&
-            creature.getSeat()->getPlayer()->getIsHuman() &&
-            !creature.getSeat()->getPlayer()->getHasLost())
+            creature.getSeat()->getPlayer()->getIsHuman())
         {
             creature.getSeat()->getPlayer()->notifyCreatureCannotFindFood(creature);
         }
@@ -134,8 +133,7 @@ bool CreatureActionSearchFood::handleSearchFood(Creature& creature, bool forced)
     if(hatcheriesTiles.empty())
     {
         if((creature.getSeat()->getPlayer() != nullptr) &&
-            creature.getSeat()->getPlayer()->getIsHuman() &&
-            !creature.getSeat()->getPlayer()->getHasLost())
+            creature.getSeat()->getPlayer()->getIsHuman())
         {
             creature.getSeat()->getPlayer()->notifyCreatureCannotFindFood(creature);
         }

--- a/source/creatureaction/CreatureActionSearchTileToDig.cpp
+++ b/source/creatureaction/CreatureActionSearchTileToDig.cpp
@@ -188,8 +188,7 @@ bool CreatureActionSearchTileToDig::handleSearchTileToDig(Creature& creature, in
             creature.pushAction(Utils::make_unique<CreatureActionGrabEntity>(creature, *obj));
             return true;
         }
-        else if(creature.getSeat()->getPlayer()->getIsHuman() &&
-                !creature.getSeat()->getPlayer()->getHasLost())
+        else if(creature.getSeat()->getPlayer()->getIsHuman())
         {
             creature.getSeat()->getPlayer()->notifyNoTreasuryAvailable();
         }

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -486,8 +486,8 @@ void Player::notifyTeamFighting(Player* player, Tile* tile)
 void Player::notifyNoSkillInQueue()
 {
     // The advisory messages below (and their voice lines) are meaningless once
-    // the player has lost; without these guards the keeper keeps nagging a
-    // defeated player about beds, food and empty queues.
+    // the player has lost. This is the one place that checks it - callers just
+    // call, they do not test getHasLost() themselves.
     if(mHasLost)
         return;
 
@@ -733,7 +733,6 @@ void Player::upkeepPlayer(double timeSinceLastUpkeep)
 
     // Do not notify skill queue empty if no library
     if(getIsHuman() &&
-       !getHasLost() &&
        (getSeat()->getNbRooms(RoomType::library) > 0))
     {
         if(mNoSkillInQueueTime > timeSinceLastUpkeep)
@@ -748,8 +747,7 @@ void Player::upkeepPlayer(double timeSinceLastUpkeep)
         }
     }
 
-    if(getIsHuman() &&
-       !getHasLost())
+    if(getIsHuman())
     {
         if(mNoWorkerTime > timeSinceLastUpkeep)
             mNoWorkerTime -= timeSinceLastUpkeep;

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -443,6 +443,11 @@ void Player::notifyNoMoreDungeonTemple()
 
 void Player::notifyTeamFighting(Player* player, Tile* tile)
 {
+    // A defeated player has nothing left to defend: no "we are under attack"
+    // and no battle music for fights that are no longer theirs.
+    if(mHasLost)
+        return;
+
     // We check if there is a fight event currently near this tile. If yes, we update
     // the time event. If not, we create a new fight event
     bool isFirstFight = true;
@@ -480,6 +485,12 @@ void Player::notifyTeamFighting(Player* player, Tile* tile)
 
 void Player::notifyNoSkillInQueue()
 {
+    // The advisory messages below (and their voice lines) are meaningless once
+    // the player has lost; without these guards the keeper keeps nagging a
+    // defeated player about beds, food and empty queues.
+    if(mHasLost)
+        return;
+
     if(mNoSkillInQueueTime == 0.0f)
     {
         mNoSkillInQueueTime = NO_RESEARCH_TIME_COUNT;
@@ -494,6 +505,9 @@ void Player::notifyNoSkillInQueue()
 
 void Player::notifyNoWorker()
 {
+    if(mHasLost)
+        return;
+
     if(mNoWorkerTime > 0.0f)
         return;
 
@@ -508,6 +522,9 @@ void Player::notifyNoWorker()
 
 void Player::notifyNoTreasuryAvailable()
 {
+    if(mHasLost)
+        return;
+
     if(mNoTreasuryAvailableTime == 0.0f)
     {
         mNoTreasuryAvailableTime = NO_TREASURY_TIME_COUNT;
@@ -522,6 +539,9 @@ void Player::notifyNoTreasuryAvailable()
 
 void Player::notifyCreatureCannotFindBed(Creature& creature)
 {
+    if(mHasLost)
+        return;
+
     if(mCreatureCannotFindBed <= 0.0f)
     {
         mCreatureCannotFindBed = CREATURE_CANNOT_FIND_BED_TIME_COUNT;
@@ -540,6 +560,9 @@ void Player::notifyCreatureCannotFindBed(Creature& creature)
 
 void Player::notifyCreatureCannotFindFood(Creature& creature)
 {
+    if(mHasLost)
+        return;
+
     if(mCreatureCannotFindFood <= 0.0f)
     {
         mCreatureCannotFindFood = CREATURE_CANNOT_FIND_FOOD_TIME_COUNT;

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -1506,8 +1506,6 @@ void Seat::setNextSkill(SkillType skilledType)
             return;
         if(!getPlayer()->getIsHuman())
             return;
-        if(getPlayer()->getHasLost())
-            return;
         if(getNbRooms(RoomType::library) <= 0)
             return;
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1425,8 +1425,6 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // If the player is human and do not own a workshop, we warn him
             if(!player->getIsHuman())
                 break;
-            if(player->getHasLost())
-                break;
 
             std::vector<Room*> rooms = gameMap->getRoomsByTypeAndSeat(RoomType::workshop, player->getSeat());
             if(!rooms.empty())

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -635,6 +635,26 @@ void ODServer::processServerNotifications()
     }
 }
 
+namespace
+{
+//! \brief A defeated player cannot act any more. Refuses the action and tells
+//! them why - without this the game silently accepts orders (build, cast,
+//! summon) from a keeper whose dungeon is gone, which reads as "maybe I can
+//! still come back".
+bool refuseIfDefeated(Player* player)
+{
+    if(!player->getHasLost())
+        return false;
+
+    ServerNotification *serverNotification = new ServerNotification(
+        ServerNotificationType::chatServer, player);
+    std::string msg = "You have been defeated and can no longer give orders";
+    serverNotification->mPacket << msg << EventShortNoticeType::majorGameEvent;
+    ODServer::getSingleton().queueServerNotification(serverNotification);
+    return true;
+}
+}
+
 bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 {
     if (!clientSocket)
@@ -1334,6 +1354,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
             OD_ASSERT_TRUE(packetReceived >> type);
             Player* player = clientSocket->getPlayer();
+            if(refuseIfDefeated(player))
+                break;
 
             // We check if the room is available. It is not normal to receive a message
             // asking to build an unbuildable room since the client should only display
@@ -1380,6 +1402,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
             OD_ASSERT_TRUE(packetReceived >> type);
             Player* player = clientSocket->getPlayer();
+            if(refuseIfDefeated(player))
+                break;
 
             // We check if the trap is available. It is not normal to receive a message
             // asking to build an unbuildable trap since the client should only display
@@ -1423,6 +1447,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
             OD_ASSERT_TRUE(packetReceived >> spellType);
             Player* player = clientSocket->getPlayer();
+            if(refuseIfDefeated(player))
+                break;
 
             // We check if the spell is available. It is not normal to receive a message
             // asking to cast an uncastable spell since the client should only display


### PR DESCRIPTION
Part of issue #5 (*"Improve failure sequence"*), the mechanically-wrong items: after defeat the keeper *"said 'We are under attack' and changed music to battle music about 5 minutes after I was defeated"*, and *"I can summon workers after defeated, so it isn't clear that I can't make a comeback"*.

Confirmed in code: `GameMap::playerIsFighting` → `Player::notifyTeamFighting` never checks `mHasLost`, and the server accepts `askBuildRoom` / `askBuildTrap` / `askCastSpell` from a defeated player — summon worker is a spell, so a beaten keeper can indeed keep summoning.

Now:
- the team-fighting alarm (voice + battle-music event) returns early for a player who has lost;
- the server refuses room builds, trap builds and spell casts from a defeated player, answering **"You have been defeated and can no longer give orders"** instead of silently obeying;
- the "has this player lost?" test for the advisory nags (no bed / no food / no worker / no treasury / empty skill queue) is done in one place — inside `Player::notify*()` — instead of being repeated at every call site (review follow-up, 08d32934). The earlier version of this PR wrongly claimed those advisories were unguarded; their callers already checked, so the in-method guards only duplicated them.

Verified by forcing the defeated state in a test build and printing the chat text client-side: a normal GreedOrMight start produces exactly two advisories in the first ~35 s ("You have no worker to fulfill your dark wishes.", "Rat1 cannot find room for a bed"); with `mHasLost` forced `true` on the same run there are zero, and the game otherwise runs normally. The defeat-dialog / restart-options part of #5 is UI design work and intentionally not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hrk8PiEUMgjYJnTxLF2PU