### PR TITLE
Make the camera pan speed adjustable and zoom towards the screen centre

### DIFF
--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -114,6 +114,22 @@
                         <Property name="Text" value="Autoscroll" />
                         <Property name="TooltipText" value="When checked, if the mouse cousor is on the screen border it will make camera fly " />
                     </Window>
+                    <Window type="OD/StaticText" name="PanSpeedText" >
+                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,180}}" />
+                        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                        <Property name="Text" value="Camera pan speed: 100%" />
+                        <Property name="BackgroundEnabled" value="False" />
+                        <Property name="FrameEnabled" value="False" />
+                    </Window>
+                    <Window type="OD/HorizontalSlider" name="PanSpeedSlider" >
+                        <Property name="Area" value="{{0,32},{0,180},{0,327},{0,193}}" />
+                        <Property name="Text" value="" />
+                        <Property name="VerticalSlider" value="False" />
+                        <Property name="AutoRenderingSurface" value="True" />
+                        <Property name="MaximumValue" value="290" />
+                        <Property name="ClickStepSize" value="10" />
+                        <Property name="TooltipText" value="How fast the arrow keys and autoscroll pan the camera (100% is the default speed)." />
+                    </Window>
                 </Window>
             </Window>
             <Window type="DefaultWindow" name="Game" >

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -24,6 +24,8 @@
 #include "gamemap/TileContainer.h"
 #include "sound/SoundEffectsManager.h"
 #include "camera/CullingManager.h"
+#include "utils/ConfigManager.h"
+#include "utils/Helper.h"
 #include "utils/LogManager.h"
 #include "gamemap/GameMap.h"
 
@@ -74,6 +76,7 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mCameraRollDestination(0.0),
     mCurrentDefaultViewMode(ViewModes::defaultView),
     mZChange(0.0),
+    mPanSpeedFactor(1.0),
     mSwivelDegrees(0.0),
     mTranslateVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mTranslateVectorAccel(Ogre::Vector3(0.0, 0.0, 0.0)),
@@ -81,6 +84,14 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mSceneManager(sceneManager),
     mViewport(nullptr)
 {
+    const std::string panSpeedStr = ConfigManager::getSingleton().getInputValue(Config::PAN_SPEED, "100", false);
+    float panSpeedPercent = panSpeedStr.empty() ? 100.0f : Helper::toFloat(panSpeedStr);
+    if(panSpeedPercent < 10.0f)
+        panSpeedPercent = 10.0f;
+    else if(panSpeedPercent > 300.0f)
+        panSpeedPercent = 300.0f;
+    mPanSpeedFactor = panSpeedPercent / 100.0f;
+
     createViewport(renderWindow);
     createCamera("RTS", 0.02, 300.0);
     createCameraNode("RTS");
@@ -266,7 +277,7 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     if (!isCameraMovingAtAll())
         return;
 
-    mMoveSpeed = getActiveCameraNode()->getPosition().z / 16.0f;
+    mMoveSpeed = getActiveCameraNode()->getPosition().z / 16.0f * mPanSpeedFactor;
     mMoveSpeedAcceleration = 2.0f * mMoveSpeed;
     
     // Carry out the acceleration/deceleration calculations on the camera translation.
@@ -301,7 +312,22 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     // to the movement keys on the keyboard (the arrow keys and/or WASD).
     if (mZChange != 0)
     {
-        newPosition.z += static_cast<Ogre::Real>(mZChange * frameTime * ZOOM_SPEED);
+        // Zoom towards what is in the middle of the screen, not towards the
+        // ground under the camera: the camera looks ahead at an angle, so a
+        // plain height change slides the view target while zooming. Keeping
+        // the ground point at the screen centre fixed means shifting the
+        // camera base by the difference of its ground offsets at the two
+        // heights.
+        Ogre::Real newZ = newPosition.z + static_cast<Ogre::Real>(mZChange * frameTime * ZOOM_SPEED);
+        if (newZ <= MIN_CAMERA_Z)
+            newZ = MIN_CAMERA_Z;
+        else if (newZ >= MAX_CAMERA_Z)
+            newZ = MAX_CAMERA_Z;
+        Ogre::Vector3 offsetBefore = getGroundOffset(newPosition.z);
+        Ogre::Vector3 offsetAfter = getGroundOffset(newZ);
+        newPosition.x += offsetBefore.x - offsetAfter.x;
+        newPosition.y += offsetBefore.y - offsetAfter.y;
+        newPosition.z = newZ;
         // We also stow and stop the movement here, as the keyboard release events
         // and mouse wheel event are otherwise colliding on handling the zoom.
         if (mZChange > 0)

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -69,6 +69,9 @@ public:
     CameraManager(Ogre::SceneManager* sceneManager, GameMap* gameMap, Ogre::RenderWindow* renderWindow);
     virtual ~CameraManager();
 
+    inline void setPanSpeedFactor(Ogre::Real factor)
+    { mPanSpeedFactor = factor; }
+
     inline void circleAround(int x, int y, unsigned int radius)
     {
         mCenterX = x;
@@ -262,6 +265,10 @@ private:
 
     Ogre::Real mMoveSpeed;
     Ogre::Real mMoveSpeedAcceleration;
+
+    //! \brief User-tunable multiplier on the keyboard/autoscroll pan speed
+    //! (1.0 keeps the historic speed). Set from the settings window.
+    Ogre::Real mPanSpeedFactor;
 };
 
 #endif // CAMERAMANAGER_H_

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -18,6 +18,8 @@
 #include "modes/SettingsWindow.h"
 
 #include "gamemap/MiniMap.h"
+#include "camera/CameraManager.h"
+#include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
 #include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
@@ -104,6 +106,16 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
         lightFactorSlider->subscribeEvent(
             CEGUI::Slider::EventValueChanged,
             CEGUI::Event::Subscriber(&SettingsWindow::onLightFactorChanged, this)
+        )
+    );
+
+    // Camera pan speed slider
+    CEGUI::Slider* panSpeedSlider = static_cast<CEGUI::Slider*>(
+        mSettingsWindow->getChild("MainTabControl/Input/InputSP/PanSpeedSlider"));
+    addEventConnection(
+        panSpeedSlider->subscribeEvent(
+            CEGUI::Slider::EventValueChanged,
+            CEGUI::Event::Subscriber(&SettingsWindow::onPanSpeedChanged, this)
         )
     );
 
@@ -217,6 +229,10 @@ void SettingsWindow::initConfig()
     std::string lightStr = config.getGameValue(Config::LIGHT_FACTOR, std::string(), false);
     float lightFactor = lightStr.empty() ? 0.0f : Helper::toFloat(lightStr);
     setLightFactorValue(lightFactor);
+
+    std::string panSpeedStr = config.getInputValue(Config::PAN_SPEED, "100", false);
+    float panSpeedPercent = panSpeedStr.empty() ? 100.0f : Helper::toFloat(panSpeedStr);
+    setPanSpeedValue(panSpeedPercent);
 
     // Input
     CEGUI::ToggleButton* keyboardGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
@@ -416,6 +432,11 @@ void SettingsWindow::saveConfig()
     CEGUI::Slider* lightSlider = static_cast<CEGUI::Slider*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/LightSlider"));
     config.setGameValue(Config::LIGHT_FACTOR, Helper::toString(lightSlider->getCurrentValue()));
+
+    CEGUI::Slider* panSpeedSlider = static_cast<CEGUI::Slider*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/PanSpeedSlider"));
+    config.setInputValue(Config::PAN_SPEED,
+        Helper::toString(static_cast<int32_t>(10.0f + panSpeedSlider->getCurrentValue())));
 
     // Input
     CEGUI::ToggleButton* keyboardGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
@@ -644,6 +665,33 @@ void SettingsWindow::setMusicVolumeValue(float volume)
     // Set the music volume text
     CEGUI::Window* volumeText = mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicText");
     volumeText->setText("Music: " + Helper::toString(static_cast<int32_t>(volume)) + "%");
+}
+
+bool SettingsWindow::onPanSpeedChanged(const CEGUI::EventArgs&)
+{
+    CEGUI::Slider* panSpeedSlider = static_cast<CEGUI::Slider*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/PanSpeedSlider"));
+    setPanSpeedValue(10.0f + panSpeedSlider->getCurrentValue());
+    return true;
+}
+
+void SettingsWindow::setPanSpeedValue(float panSpeedPercent)
+{
+    if(panSpeedPercent < 10.0f)
+        panSpeedPercent = 10.0f;
+    else if(panSpeedPercent > 300.0f)
+        panSpeedPercent = 300.0f;
+
+    // Apply immediately so the effect can be felt while the window is open.
+    ODFrameListener::getSingleton().getCameraManager()->setPanSpeedFactor(panSpeedPercent / 100.0f);
+
+    // The slider itself starts at the minimum usable speed rather than zero.
+    CEGUI::Slider* panSpeedSlider = static_cast<CEGUI::Slider*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/PanSpeedSlider"));
+    panSpeedSlider->setCurrentValue(panSpeedPercent - 10.0f);
+
+    CEGUI::Window* panSpeedText = mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/PanSpeedText");
+    panSpeedText->setText("Camera pan speed: " + Helper::toString(static_cast<int32_t>(panSpeedPercent)) + "%");
 }
 
 bool SettingsWindow::onLightFactorChanged(const CEGUI::EventArgs&)

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -99,9 +99,11 @@ private:
 
     //! \brief Called when changing the ambient light factor value.
     bool onLightFactorChanged(const CEGUI::EventArgs&);
+    bool onPanSpeedChanged(const CEGUI::EventArgs&);
 
     //! \brief Set the volume value in the ambient light factor setting text and slider.
     void setLightFactorValue(float lightFactor);
+    void setPanSpeedValue(float panSpeedPercent);
 
     bool dynamicShadowsChanged;
 };

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -62,6 +62,7 @@ const std::string MUSIC_VOLUME = "Music Volume";
 const std::string KEYBOARD_GRAB = "Keyboard Grab";
 const std::string MOUSE_GRAB = "Mouse Grab";
 const std::string AUTOSCROLL = "Autoscroll";
+const std::string PAN_SPEED = "Pan Speed";
 // Game
 const std::string NICKNAME = "Nickname";
 const std::string KEEPERVOICE = "KeeperVoice";


### PR DESCRIPTION
Implements the two camera fixes you offered in issue #11 (*"I can make the pan speed to be adjustable. I can make the zoom zooming to the middle of the camera, if you wish."*):

**Adjustable pan speed.** The height-derived speed cap now goes through a user multiplier with a slider on the settings window's Input tab — 10% to 300%, default 100% keeps the historic speed. It applies live while the window is open and is saved with the other input settings (`Pan Speed` in the config).

![slider](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/8d1e5bdf577f7927befc6f467b47467cd123bd29/pan-speed-slider.png)

**Zoom towards the screen centre.** Zooming used to move the camera straight down; since the camera looks ahead at an angle, whatever was in the middle of the screen slid towards the bottom while zooming — Poikilos's *"zooming in zooms to the bottom instead of the middle"*. The zoom now keeps the ground point at the screen centre fixed by shifting the camera base by the difference of its ground offsets at the old and new heights (the existing `getGroundOffset` helper). Height clamps are applied to the target height first, so hitting the zoom range's floor or ceiling can't shear the view sideways.

Before/after of a full zoom-in with the portal at the screen centre — it now stays centred all the way down:

| zoomed out | after full zoom-in |
|---|---|
| ![before](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/8d1e5bdf577f7927befc6f467b47467cd123bd29/zoom-before-center.png) | ![after](https://raw.githubusercontent.com/Upabjojr/OpenDungeonsPlus/8d1e5bdf577f7927befc6f467b47467cd123bd29/zoom-after-center.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hrk8PiEUMgjYJnTxLF2PU