### PR TITLE
Spell out the types that the recent changes had left to auto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Notes for AI coding assistants
+
+These instructions apply to every change made to this repository with an AI assistant.
+
+## Coding style
+
+- Write variable types out explicitly. Do not use `auto`, not even for iterators or
+  return values (see issue #42):
+
+  ```cpp
+  std::map<Tile*, TileData*>::iterator it = mTileData.find(tile);
+  Command::Result result = interface.tryExecuteClientCommand(cmd, mode, modeManager);
+  ```
+
+  When a closure is needed, give it a `std::function<...>` type; otherwise prefer a
+  named function over a lambda.
+- The project is built as C++11 (see `CMakeLists.txt`); do not rely on newer language
+  features.
+- Match the surrounding code: four-space indentation, braces on their own line,
+  `if(condition)` without a space before the parenthesis, member variables prefixed
+  with `m`, `OD_LOG_*` for logging and `OD_ASSERT_TRUE_MSG` for invariants.
+- Keep changes focused on what was asked; do not reformat or restyle code that the
+  change does not need to touch.

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -1650,7 +1650,7 @@ void Seat::setSkillTree(const std::vector<SkillType>& skills)
 
 TileStateNotified* Seat::getTileStateNotified(Tile* tile)
 {
-    auto it = mTilesStates.find(tile);
+    std::map<Tile*, TileStateNotified>::iterator it = mTilesStates.find(tile);
     if(it != mTilesStates.end())
         return &it->second;
 

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -256,7 +256,7 @@ void Room::checkForSplit()
 
             for(Tile* neigh : tile->getAllNeighbors())
             {
-                auto it = remaining.find(neigh);
+                std::set<Tile*>::iterator it = remaining.find(neigh);
                 if(it == remaining.end())
                     continue;
 
@@ -309,20 +309,20 @@ void Room::checkForSplit()
         // other room now covers cannot be built upon.
         for(Tile* tile : group)
         {
-            auto itData = mTileData.find(tile);
+            std::map<Tile*, TileData*>::iterator itData = mTileData.find(tile);
             if(itData != mTileData.end())
             {
                 newRoom->mTileData[tile] = itData->second->cloneTileData();
                 itData->second->mHP = 0.0;
             }
 
-            auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
+            std::vector<Tile*>::iterator itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
             if(itTile != mCoveredTiles.end())
                 mCoveredTiles.erase(itTile);
 
             // Whatever was built on the tile goes with it, the way absorbRoom() hands over
             // everything a room had built. It stands on ground the other room owns now.
-            auto itObject = mBuildingObjects.find(tile);
+            std::map<Tile*, BuildingObject*>::iterator itObject = mBuildingObjects.find(tile);
             if(itObject != mBuildingObjects.end())
             {
                 newRoom->mBuildingObjects[tile] = itObject->second;

--- a/source/rooms/RoomBridge.cpp
+++ b/source/rooms/RoomBridge.cpp
@@ -302,7 +302,7 @@ void RoomBridge::restoreInitialEntityState()
         double claimedValuePerTile = mClaimedValue / static_cast<double>(nbTiles);
         for(Tile* tile : mCoveredTiles)
         {
-            auto it = mTileData.find(tile);
+            std::map<Tile*, TileData*>::iterator it = mTileData.find(tile);
             if(it == mTileData.end())
                 continue;
 
@@ -321,7 +321,7 @@ void RoomBridge::exportToStream(std::ostream& os) const
     double claimedValue = 0.0;
     for(Tile* tile : mCoveredTiles)
     {
-        auto it = mTileData.find(tile);
+        std::map<Tile*, TileData*>::const_iterator it = mTileData.find(tile);
         if(it == mTileData.end())
             continue;
 
@@ -361,7 +361,7 @@ void RoomBridge::claimForSeat(Seat* seat, Tile* tile, double danceRate)
 {
     // The dance only counts against the tile being danced on, so a bridge is
     // taken square by square, not all at once from one square.
-    auto it = mTileData.find(tile);
+    std::map<Tile*, TileData*>::iterator it = mTileData.find(tile);
     if(it == mTileData.end())
     {
         OD_LOG_ERR("bridge=" + getName() + ", tile=" + Tile::displayAsString(tile));
@@ -399,7 +399,7 @@ void RoomBridge::claimTileForSeat(Seat* seat, Tile* tile)
     // destroyed so seats that still think this bridge covers the tile can keep
     // asking it. The tile stays a bridge tile throughout, so pathing across it
     // is never interrupted for anybody and no flood fill has to change.
-    auto itData = mTileData.find(tile);
+    std::map<Tile*, TileData*>::iterator itData = mTileData.find(tile);
     if(itData != mTileData.end())
     {
         BridgeTileData* newData = static_cast<BridgeTileData*>(itData->second->cloneTileData());
@@ -410,11 +410,11 @@ void RoomBridge::claimTileForSeat(Seat* seat, Tile* tile)
         itData->second->mHP = 0.0;
     }
 
-    auto itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
+    std::vector<Tile*>::iterator itTile = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), tile);
     if(itTile != mCoveredTiles.end())
         mCoveredTiles.erase(itTile);
 
-    auto itObject = mBuildingObjects.find(tile);
+    std::map<Tile*, BuildingObject*>::iterator itObject = mBuildingObjects.find(tile);
     if(itObject != mBuildingObjects.end())
     {
         newBridge->mBuildingObjects[tile] = itObject->second;

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -315,7 +315,7 @@ void RoomTreasury::splitRoom(Room& newRoom, const std::vector<Tile*>& tiles)
     // would make gold rather than cost it.
     for(Tile* tile : tiles)
     {
-        auto it = mTileData.find(tile);
+        std::map<Tile*, TileData*>::iterator it = mTileData.find(tile);
         if(it == mTileData.end())
             continue;
 

--- a/source/tests/test_ConsoleInterface.cpp
+++ b/source/tests/test_ConsoleInterface.cpp
@@ -18,6 +18,7 @@
 #include "modes/AbstractModeManager.h"
 #include "modes/ConsoleInterface.h"
 
+#include <functional>
 #include <string>
 
 #define BOOST_TEST_MODULE ConsoleInterface
@@ -116,9 +117,9 @@ BOOST_AUTO_TEST_CASE(test_ConsoleInterface)
 
     // Executing a command does not record it: the history belongs to whoever owns the
     // prompt, and the game console records what was typed itself. Do the same here.
-    auto execute = [&interface, &modeManager, &count](const std::string& cmd, TestModeManager::ModeType mode)
+    std::function<Command::Result(const std::string&, TestModeManager::ModeType)> execute = [&interface, &modeManager, &count](const std::string& cmd, TestModeManager::ModeType mode)
     {
-        auto result = interface.tryExecuteClientCommand(cmd, mode, modeManager);
+        Command::Result result = interface.tryExecuteClientCommand(cmd, mode, modeManager);
         interface.getCommandHistoryBuffer().emplace_back(cmd);
         ++count;
         return result;


### PR DESCRIPTION
Addresses #42: every `auto` that the changes merged over the last month introduced is written out as its real type, and a `CLAUDE.md` at the repository root tells the assistant to keep doing so.

## What changed

The 14 `auto` declarations added by the recent merged PRs (#23 room split, #24 seat fixes, #26 console test, #34 per-tile bridge claiming) are now explicit:

| File | Before | After |
|---|---|---|
| `source/rooms/RoomBridge.cpp` (6) | `auto it = mTileData.find(tile)` etc. | `std::map<Tile*, TileData*>::iterator` / `::const_iterator` in `exportToStream() const`, `std::vector<Tile*>::iterator`, `std::map<Tile*, BuildingObject*>::iterator` |
| `source/rooms/Room.cpp` (4) | `auto it = remaining.find(neigh)` etc. | `std::set<Tile*>::iterator`, `std::map<Tile*, TileData*>::iterator`, `std::vector<Tile*>::iterator`, `std::map<Tile*, BuildingObject*>::iterator` |
| `source/rooms/RoomTreasury.cpp` (1) | `auto it = mTileData.find(tile)` | `std::map<Tile*, TileData*>::iterator` |
| `source/game/Seat.cpp` (1) | `auto it = mTilesStates.find(tile)` | `std::map<Tile*, TileStateNotified>::iterator` |
| `source/tests/test_ConsoleInterface.cpp` (2) | `auto execute = [...]`, `auto result = ...` | `std::function<Command::Result(const std::string&, TestModeManager::ModeType)>`, `Command::Result` |

No behaviour changes: each replacement is the type the expression already had.

`CLAUDE.md` is picked up automatically by Claude Code at the start of every session; it states the no-`auto` rule with examples, the C++11 baseline and the surrounding style conventions (indentation, braces, `if(`, `m` prefix, `OD_LOG_*`).

## Not touched

The 195 `auto` declarations that predate these PRs (hwoarangmy, 2015, spread over 59 files) are left as they are, since the issue is about what the assistant added. Converting those too is mechanical and can be a follow-up PR if wanted.

The still-open PRs #20, #32, #33 and #35 each got a commit of their own doing the same for the `auto`s in their diffs; #16 is the umbrella branch the split PRs were cut from and is left alone.

## Verification

Full build (`RelWithDebInfo`, GCC) and the console test run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
