### PR TITLE
Clear the client game map before loading a level into it

### DIFF
--- a/source/modes/MenuModeEditorLoad.cpp
+++ b/source/modes/MenuModeEditorLoad.cpp
@@ -245,6 +245,7 @@ bool MenuModeEditorLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     {
         OD_LOG_ERR("Could not start server for editor !!!");
         window->getChild(Gui::EDM_TEXT_LOADING)->setText("ERROR: Could not start server for editor !!!");
+        return true;
     }
 
     int port = ODServer::getSingleton().getNetworkPort();

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -93,6 +93,12 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
     {
         case ServerNotificationType::loadLevel:
         {
+            // The map may still hold a previous session (a reconnection, or launching a
+            // level twice from the same menu). createNewMap only rebuilds the tiles, so
+            // without this the seats, creature classes and weapons pile up, and the
+            // duplicated class names crash the editor when it fills its creatures menu.
+            gameMap->clearAll();
+
             std::string odVersion;
             OD_ASSERT_TRUE(packetReceived >> odVersion);
 


### PR DESCRIPTION
Fixes the editor crash on startup:

```
CEGUI::AlreadyExistsException : Failed to add Element named: Adventurer to element at:
EDITORGUI/Menubar/Creatures/PopupMenu4 since an Element with that name is already attached.
```

**What happens**: when the client receives `loadLevel`, it rebuilds the map with `createNewMap`, which only recreates the tiles. Everything else — creature classes, seats, weapons — is just appended on top of whatever the map already holds, trusting that whoever started the connection called `clearAll()` first. Some paths break that promise (pressing Launch a second time from the editor load menu, reconnecting after a failed start), and then the client ends up with **two copies of every creature class**. The editor names its Creatures menu items after the classes, so the second "Adventurer" (alphabetically the first class, hence the first duplicate hit) makes CEGUI throw, and nothing catches it before `main()` — the game aborts before the editor even appears. The earlier fix that empties the menus before filling them (8ec6c20d) cannot help here, because both copies are added within a single fill.

**The fix**: clear the client game map at the start of the `loadLevel` handler, the same way the `newMap` notification already does. This makes the handler correct no matter which flow delivered the message.

Also, `MenuModeEditorLoad` was the only launch menu that did **not** return after "Could not start server" — it fell through and connected to whatever server was already running. Added the missing `return true;` to match its five sibling menus.

**Verified**: full build clean; all 10 tests pass, including the five server-backed ones (`aa-*`/`ab-*` run against a headless server on port 32222 with `aa.level`/`ab.level`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)