### PR TITLE
Windows support, live settings, edge scrolling and GUI scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,13 @@ Before working on this project, read:
    workflow and task notes when relevant to the request.
 
 Windows development is organized on `feature/windows-support` in this fork.
+The related work is split into a local branch stack: `feature/windows-support`,
+`fix/dynamic-shadows`, `fix/settings-option-duplicates`, then
+`feature/live-settings`. Continue each task on its matching branch; see
+[live settings and verification](docs/development/LIVE-SETTINGS.md).
 Read the current setup in [the contribution workflow](docs/development/CONTRIBUTING-WORKFLOW.md)
 before Git operations: `origin` is the fork and `upstream` is the original project.
-Preserve the existing default branch; continue this Windows task on its work branch.
+Preserve the existing default branch; continue each task on its own work branch.
 The work branch includes local notes and is not the final upstream PR branch;
 prepare that later from upstream using only the reviewed, reusable changes.
 Do not push without explicit user authorization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,19 @@ The maintained instructions and scripts live in this repository under
 Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
 
 At the verified state on 2026-09-05, dependency builds, game CMake configuration
-and both Windows x64 game builds (Release and Debug) succeeded; game startup,
-manual gameplay tests and packaging remain unverified.
+and both Windows x64 game builds (Release and Debug) succeeded.
+User startup attempts exposed a Windows resource-path bug; both binaries now
+include its correction. A subsequent Release run loaded the main-menu scene and
+shut down normally without the earlier loading errors; the user subsequently
+confirmed that the Release executable starts without errors.
+Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
+before investigating further startup issues; broader gameplay tests and packaging
+remain unverified.
+The Release executable now has its runtime DLLs staged beside it for direct
+File Explorer startup; the configuration script maintains this through
+`scripts/win32/prepare-windows-runtime.ps1`. Python's standard library and OGRE
+media still use the external installation. Read BUILDING.md for the static
+verification results and the remaining Debug runtime/plugin limitations.
 Read the [Windows build fixes](docs/development/WINDOWS-BUILD-FIXES.md) for the four
 diagnosed failures and verification logs; the CEGUI source now includes a
 repository-managed compatibility patch applied by its installation script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,15 @@ That confirmation predates enabling dynamic shadows: a later startup failure was
 traced to OGRE's internal shadow programs being registered only in Graphics.
 The resource template now also exposes Media/Main through OgreInternal while
 retaining Graphics access for shader includes; the headless OGRE resource test
-fails before and passes after this correction, while actual startup verification
-with shadows enabled is pending. Check the latest evidence in the startup notes.
+fails before and passes after this correction, and the user's 14:52 run reached
+the main menu with shadows enabled. That run later failed while entering
+TestLegacyNoScripts.level. Added exception logging captured the cause during the
+user's 15:05 reproduction: automatic additive illumination splitting removed
+DirtInstanced's fragment shader, which GL3Plus requires. RenderManager now uses
+integrated additive texture shadows to retain the custom shader passes. Release
+and Debug rebuilt successfully; the isolated OGRE pass test fails with splitting
+and passes without it. The user must still retest the map and shadow appearance
+with the rebuilt executable; check the latest evidence in the startup notes.
 Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
 before investigating further startup issues; broader gameplay tests and packaging
 remain unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Project context for future sessions
 
+## Language
+
+Communicate with the user in German.
+Write and maintain all project documentation in English.
+Use English for Git-related text, including commit messages, pull request titles,
+descriptions and review comments.
+
+## Project setup
+
 Before working on this project, read:
 
 1. [Windows environment and current status](docs/development/WINDOWS-DEV-SETUP.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Project context for future sessions
+
+Before working on this project, read:
+
+1. [Windows environment and current status](docs/development/WINDOWS-DEV-SETUP.md).
+2. [Configure and build commands](docs/development/BUILDING.md).
+3. [Development documentation index](docs/development/README.md); follow the
+   workflow and task notes when relevant to the request.
+
+Windows development is organized on `feature/windows-support` in this fork.
+Read the current setup in [the contribution workflow](docs/development/CONTRIBUTING-WORKFLOW.md)
+before Git operations: `origin` is the fork and `upstream` is the original project.
+Preserve the existing default branch; continue this Windows task on its work branch.
+The work branch includes local notes and is not the final upstream PR branch;
+prepare that later from upstream using only the reviewed, reusable changes.
+Do not push without explicit user authorization.
+
+The Windows prerequisites are already installed in `C:\Users\mario\od-deps`;
+their sources, binaries and logs deliberately live outside the repository.
+The maintained instructions and scripts live in this repository under
+`docs/development/` and `scripts/win32/`.
+Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
+
+At the documented handover on 2026-09-05, dependency builds and game CMake
+configuration succeeded; compiling and starting the game were still unverified.
+Read the current status document and check the actual files before making claims.
+Do not reinstall dependencies or switch versions just because a new session starts.
+Use the repository's environment helper and configuration script; the scripts
+currently target Mario's Windows installation, with paths recorded in the docs.
+
+Keep changes within the user's request and preserve existing work.
+Do not read `.env` or other secret files.
+Manual game tests, QA and visual acceptance are performed by the user.
+When changing setup paths, versions, commands or verified build status, update the
+linked documentation in the same task so the next session has the current state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ descriptions and review comments.
 
 ## Project setup
 
+Always implement new requirements on the user's latest complete fork state,
+including all newer fork commits, local work and project documentation. Never
+start implementation work directly from `upstream` unless the user explicitly
+overrides this rule. Use `upstream` only to compare changes and to assemble a
+separate contribution branch after the fork implementation has been completed
+and reviewed.
+
 Before working on this project, read:
 
 1. [Windows environment and current status](docs/development/WINDOWS-DEV-SETUP.md).
@@ -18,14 +25,16 @@ Before working on this project, read:
 
 Windows development is organized on `feature/windows-support` in this fork.
 The related work is split into a local branch stack: `feature/windows-support`,
-`fix/dynamic-shadows`, `fix/settings-option-duplicates`, then
-`feature/live-settings`. Continue each task on its matching branch; see
+`fix/dynamic-shadows`, `fix/settings-option-duplicates`, `feature/live-settings`,
+`feature/progressive-edge-scrolling`, `docs/improvement-roadmap`, then
+`feature/gui-scaling`. Continue each task from the latest complete fork state; see
 [live settings and verification](docs/development/LIVE-SETTINGS.md).
 Read the current setup in [the contribution workflow](docs/development/CONTRIBUTING-WORKFLOW.md)
 before Git operations: `origin` is the fork and `upstream` is the original project.
 Preserve the existing default branch; continue each task on its own work branch.
 The work branch includes local notes and is not the final upstream PR branch;
-prepare that later from upstream using only the reviewed, reusable changes.
+assemble that separate contribution branch later using only the reviewed,
+reusable changes.
 Do not push without explicit user authorization.
 
 The Windows prerequisites are already installed in `C:\Users\mario\od-deps`;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ User startup attempts exposed a Windows resource-path bug; both binaries now
 include its correction. A subsequent Release run loaded the main-menu scene and
 shut down normally without the earlier loading errors; the user subsequently
 confirmed that the Release executable starts without errors.
+That confirmation predates enabling dynamic shadows: a later startup failure was
+traced to OGRE's internal shadow programs being registered only in Graphics.
+The resource template now also exposes Media/Main through OgreInternal while
+retaining Graphics access for shader includes; the headless OGRE resource test
+fails before and passes after this correction, while actual startup verification
+with shadows enabled is pending. Check the latest evidence in the startup notes.
 Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
 before investigating further startup issues; broader gameplay tests and packaging
 remain unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,12 @@ The maintained instructions and scripts live in this repository under
 `docs/development/` and `scripts/win32/`.
 Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
 
-At the documented handover on 2026-09-05, dependency builds and game CMake
-configuration succeeded; compiling and starting the game were still unverified.
+At the verified state on 2026-09-05, dependency builds, game CMake configuration
+and both Windows x64 game builds (Release and Debug) succeeded; game startup,
+manual gameplay tests and packaging remain unverified.
+Read the [Windows build fixes](docs/development/WINDOWS-BUILD-FIXES.md) for the four
+diagnosed failures and verification logs; the CEGUI source now includes a
+repository-managed compatibility patch applied by its installation script.
 Read the current status document and check the actual files before making claims.
 Do not reinstall dependencies or switch versions just because a new session starts.
 Use the repository's environment helper and configuration script; the scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,9 @@ ENDIF ()
 # Adds the Windows icon resource file when building on windows.
 IF (WIN32)
     SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/icon.rc)
+    IF (MSVC)
+        SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/opendungeons.manifest)
+    ENDIF ()
 ENDIF ()
 
 ##################################
@@ -968,4 +971,3 @@ elseif(WIN32)
     install(FILES ${EXT_LIBS}
             DESTINATION ${OD_BIN_PATH})
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +660,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You will find us on the following channels:
 For this fork's local Windows setup, see the maintained
 [development environment](docs/development/WINDOWS-DEV-SETUP.md) and
 [configure/build commands](docs/development/BUILDING.md), including verified status.
+Diagnosed Windows compiler and linker failures are recorded in the
+[build fixes and validation notes](docs/development/WINDOWS-BUILD-FIXES.md).
 
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You will find us on the following channels:
 
 ### Build instructions
 
+For this fork's local Windows setup, see the maintained
+[development environment](docs/development/WINDOWS-DEV-SETUP.md) and
+[configure/build commands](docs/development/BUILDING.md), including verified status.
+
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions
 on our wiki: https://github.com/OpenDungeons/OpenDungeons/wiki/Compile

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For this fork's local Windows setup, see the maintained
 [configure/build commands](docs/development/BUILDING.md), including verified status.
 Diagnosed Windows compiler and linker failures are recorded in the
 [build fixes and validation notes](docs/development/WINDOWS-BUILD-FIXES.md).
+Direct Windows startup and its verification are covered in the
+[startup fixes](docs/development/WINDOWS-STARTUP-FIXES.md).
 
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions

--- a/cmake/config/resources.cfg.in
+++ b/cmake/config/resources.cfg.in
@@ -12,6 +12,11 @@ FileSystem=models
 FileSystem=particles
 FileSystem=shaders
 
+# Internal shadow programs must also be visible to OGRE's global resource pool.
+# Keep Main in Graphics above for game shader includes with strict group lookup.
+[OgreInternal]
+FileSystem=@CMAKE_INSTALL_PREFIX@/share/OGRE/Media/RTShaderLib/../Main
+
 [GUI]
 FileSystem=gui
 FileSystem=gui/fonts

--- a/dist/icon.rc
+++ b/dist/icon.rc
@@ -1,1 +1,5 @@
 1 ICON "OD-Logo.ico"
+
+#ifdef __GNUC__
+1 24 "opendungeons.manifest"
+#endif

--- a/dist/opendungeons.manifest
+++ b/dist/opendungeons.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,24 +1,24 @@
-# Unter Windows konfigurieren und kompilieren
+# Configuring and compiling on Windows
 
-Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
-und CMake sowie die Spielbuilds für Windows x64 in Release und Debug wurden
-erfolgreich ausgeführt; der Spielstart ist noch nicht praktisch geprüft.
-Die vier behobenen Buildfehler und ihre Nachweise stehen in
+As of September 5, 2026. The [prerequisites](WINDOWS-DEV-SETUP.md) are installed
+and CMake and the Windows x64 game builds in Release and Debug have
+completed successfully; game startup has not yet been tested in practice.
+The four resolved build errors and their evidence are recorded in
 [WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
 
-## 1. PowerShell-Sitzung vorbereiten
+## 1. Prepare the PowerShell session
 
-In einer neuen PowerShell-Konsole:
+In a new PowerShell console:
 
 ```powershell
 Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
 . .\scripts\win32\Enter-OpenDungeonsPlus.ps1
 ```
 
-Der Punkt am Anfang lädt Compiler und Suchpfade in dieselbe Sitzung; in dieser
-Konsole anschließend konfigurieren und bauen. Erwartet sind CMake 3.31.8,
-Python 3.10.11 und der x64-Compiler der Visual Studio 2022 Build Tools.
-Bei Bedarf ohne Build prüfen:
+The dot at the start loads the compiler and search paths into the same session;
+then configure and build in this console. CMake 3.31.8,
+Python 3.10.11 and the x64 compiler from Visual Studio 2022 Build Tools are expected.
+If needed, check without building:
 
 ```powershell
 Get-Command cl.exe, cmake.exe, python.exe | Select-Object Name, Source
@@ -26,57 +26,57 @@ cmake --version
 python --version
 ```
 
-## 2. CMake konfigurieren
+## 2. Configure CMake
 
 ```powershell
 & .\scripts\win32\configure-windows-prereqs.ps1
 ```
 
-Das Skript lädt auch selbst den Starthelfer und verwendet:
+The script also loads the environment helper itself and uses:
 
-- Quelle: Projektstamm, aus dem Skriptpfad abgeleitet.
-- Buildordner: `build\windows`.
-- Generator: `Visual Studio 17 2022`, Architektur `x64`.
-- `OD_BUILD_TESTING=OFF` und `BUILD_TESTING=OFF`.
-- Installationsziel: `build\windows\install`.
-- Python unter `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
+- Source: project root, derived from the script path.
+- Build directory: `build\windows`.
+- Generator: `Visual Studio 17 2022`, architecture `x64`.
+- `OD_BUILD_TESTING=OFF` and `BUILD_TESTING=OFF`.
+- Installation target: `build\windows\install`.
+- Python under `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
   `python.exe`, `include`, `libs\python310.lib`, `libs\python310_d.lib`.
 
-Das Konfigurationsprotokoll wird bei jedem Aufruf ersetzt:
+The configuration log is replaced on every invocation:
 `C:\Users\mario\od-deps\logs\opendungeons-configure.log`.
-Bei Fehlern gibt das Skript die letzten Zeilen aus und bricht ab.
-Nach Änderungen an CMake-Dateien oder Quelllisten erneut konfigurieren;
-für gewöhnliche Änderungen bestehender C++-Dateien den vorhandenen Build verwenden.
+On errors, the script prints the last lines and aborts.
+Reconfigure after changes to CMake files or source lists;
+for ordinary changes to existing C++ files, use the existing build.
 
-## 3. Spiel bauen
+## 3. Build the game
 
-Release aus derselben vorbereiteten Konsole:
+Release from the same prepared console:
 
 ```powershell
 cmake --build .\build\windows --config Release --parallel 4
-if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Release fehlgeschlagen' }
+if ($LASTEXITCODE -ne 0) { throw 'Release game build failed' }
 ```
 
-Für Debug stattdessen:
+For Debug instead:
 
 ```powershell
 cmake --build .\build\windows --config Debug --parallel 4
-if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
+if ($LASTEXITCODE -ne 0) { throw 'Debug game build failed' }
 ```
 
-Die erfolgreich erzeugten Ausgabedateien sind
-`build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
-direkt im Buildordner. Beide Dateien wurden auf ihre AMD64-PE-Kennung und die
-jeweils passende Python-DLL geprüft, ohne das Spiel zu starten.
-Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
-Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
-Die protokollierten erfolgreichen Verifikationsläufe dieser Einrichtung liegen
-unter `build\windows\game-Release-pass3.log` und `game-Debug-pass3.log`.
+The successfully generated output files are
+`build\windows\opendungeons-plus.exe` and `build\windows\opendungeons-plus_d.exe`,
+directly in the build directory. Both files were checked for their AMD64 PE signature and
+the corresponding Python DLL without starting the game.
+The build output appears in the console; if an error occurs, record the first specific
+compiler/linker message and the configuration used.
+The logged successful verification runs for this setup are located
+under `build\windows\game-Release-pass3.log` and `game-Debug-pass3.log`.
 
-## 4. Spielstart und manuelle Prüfung
+## 4. Game startup and manual verification
 
-Erst nach erfolgreichem Build durch den Nutzer prüfen; der folgende Startbefehl
-ist noch nicht praktisch verifiziert und setzt dieselbe geladene Umgebung voraus:
+The user should only test after a successful build; the following startup command
+has not yet been verified in practice and requires the same loaded environment:
 
 ```powershell
 Push-Location -LiteralPath .\build\windows
@@ -87,23 +87,23 @@ try {
 }
 ```
 
-Für Debug die Datei `opendungeons-plus_d.exe` verwenden.
-CMake erzeugt hier `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` und Verbindungen
-zu den Spieldaten. Bei fehlenden DLLs oder Plugins den tatsächlichen Startfehler
-prüfen; DLL-Verteilung, Plugin-Laden und Spielstart sind noch offen.
-Manuelle Spieltests und die visuelle Abnahme führt der Nutzer durch.
+For Debug, use the file `opendungeons-plus_d.exe`.
+CMake generates `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` and links
+to the game data here. If DLLs or plugins are missing, examine the actual startup error;
+DLL distribution, plugin loading and game startup are still pending.
+The user performs manual game tests and visual acceptance.
 
-## Protokolle und Wiederaufnahme
+## Logs and resuming work
 
-- Aktueller Installations- und Prüfstand: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
-- Bibliotheksprotokolle: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
-  `<name>-Release.log`, `<name>-Debug.log`; Boost verwendet
-  `boost-bootstrap.log` und `boost-build.log`.
-- Abhängigkeiten nur bei tatsächlichem Bedarf nach
-  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md) neu bauen.
+- Current installation and verification status: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
+- Library logs: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
+  `<name>-Release.log`, `<name>-Debug.log`; Boost uses
+  `boost-bootstrap.log` and `boost-build.log`.
+- Rebuild dependencies only when actually needed, following
+  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
 
-`build` ist von Git ausgeschlossen und enthält generierte Dateien;
-`build\windows` enthält außerdem Verzeichnisverbindungen zu Projektressourcen.
-Diese Verbindungen beim Aufräumen beachten und keine Quellverzeichnisse über sie löschen.
-Nach einem neuen Ergebnis Datum, verwendete Konfiguration, Fehler bzw. Erfolg
-und verbleibende Prüfungen im Windows-Status nachtragen.
+`build` is excluded from Git and contains generated files;
+`build\windows` also contains directory junctions to project resources.
+Take these junctions into account when cleaning up and do not delete source directories through them.
+After a new result, add the date, configuration used, error or success
+and remaining checks to the Windows status document.

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,8 +1,10 @@
 # Unter Windows konfigurieren und kompilieren
 
 Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
-und CMake wurde erfolgreich ausgeführt; die folgenden Spielbuilds und der
-Spielstart sind noch nicht praktisch geprüft.
+und CMake sowie die Spielbuilds für Windows x64 in Release und Debug wurden
+erfolgreich ausgeführt; der Spielstart ist noch nicht praktisch geprüft.
+Die vier behobenen Buildfehler und ihre Nachweise stehen in
+[WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
 
 ## 1. PowerShell-Sitzung vorbereiten
 
@@ -62,12 +64,14 @@ cmake --build .\build\windows --config Debug --parallel 4
 if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
 ```
 
-Laut generiertem Visual-Studio-Projekt sind die erwarteten Ausgabedateien
+Die erfolgreich erzeugten Ausgabedateien sind
 `build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
-direkt im Buildordner. Diese Pfade wurden aus der Konfiguration geprüft;
-ein erfolgreicher Spielbuild ist damit noch nicht belegt.
+direkt im Buildordner. Beide Dateien wurden auf ihre AMD64-PE-Kennung und die
+jeweils passende Python-DLL geprüft, ohne das Spiel zu starten.
 Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
 Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
+Die protokollierten erfolgreichen Verifikationsläufe dieser Einrichtung liegen
+unter `build\windows\game-Release-pass3.log` und `game-Debug-pass3.log`.
 
 ## 4. Spielstart und manuelle Prüfung
 

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -78,6 +78,7 @@ Release from the same prepared console:
 ```powershell
 cmake --build .\build\windows --config Release --parallel 4
 if ($LASTEXITCODE -ne 0) { throw 'Release game build failed' }
+& .\scripts\win32\prepare-windows-runtime.ps1
 ```
 
 After changing a class layout in a header, or after an interrupted rebuild, create
@@ -87,7 +88,15 @@ previous layout:
 ```powershell
 cmake --build .\build\windows --config Release --target opendungeons-plus --clean-first --parallel 4
 if ($LASTEXITCODE -ne 0) { throw 'Clean Release game build failed' }
+& .\scripts\win32\prepare-windows-runtime.ps1
 ```
+
+Keep the game and its error dialogs closed while preparing the runtime. CMake
+can regenerate `resources.cfg` during a build and restore paths that do not exist
+in this local Windows installation. Run runtime preparation after the successful
+Release build, including a clean build, before handing the executable to the user.
+The September 5 GUI-scaling startup failure from this omitted step is recorded in
+[startup fixes](WINDOWS-STARTUP-FIXES.md#resource-path-regression-after-the-gui-scaling-clean-build).
 
 For Debug instead:
 

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,0 +1,105 @@
+# Unter Windows konfigurieren und kompilieren
+
+Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
+und CMake wurde erfolgreich ausgeführt; die folgenden Spielbuilds und der
+Spielstart sind noch nicht praktisch geprüft.
+
+## 1. PowerShell-Sitzung vorbereiten
+
+In einer neuen PowerShell-Konsole:
+
+```powershell
+Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
+. .\scripts\win32\Enter-OpenDungeonsPlus.ps1
+```
+
+Der Punkt am Anfang lädt Compiler und Suchpfade in dieselbe Sitzung; in dieser
+Konsole anschließend konfigurieren und bauen. Erwartet sind CMake 3.31.8,
+Python 3.10.11 und der x64-Compiler der Visual Studio 2022 Build Tools.
+Bei Bedarf ohne Build prüfen:
+
+```powershell
+Get-Command cl.exe, cmake.exe, python.exe | Select-Object Name, Source
+cmake --version
+python --version
+```
+
+## 2. CMake konfigurieren
+
+```powershell
+& .\scripts\win32\configure-windows-prereqs.ps1
+```
+
+Das Skript lädt auch selbst den Starthelfer und verwendet:
+
+- Quelle: Projektstamm, aus dem Skriptpfad abgeleitet.
+- Buildordner: `build\windows`.
+- Generator: `Visual Studio 17 2022`, Architektur `x64`.
+- `OD_BUILD_TESTING=OFF` und `BUILD_TESTING=OFF`.
+- Installationsziel: `build\windows\install`.
+- Python unter `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
+  `python.exe`, `include`, `libs\python310.lib`, `libs\python310_d.lib`.
+
+Das Konfigurationsprotokoll wird bei jedem Aufruf ersetzt:
+`C:\Users\mario\od-deps\logs\opendungeons-configure.log`.
+Bei Fehlern gibt das Skript die letzten Zeilen aus und bricht ab.
+Nach Änderungen an CMake-Dateien oder Quelllisten erneut konfigurieren;
+für gewöhnliche Änderungen bestehender C++-Dateien den vorhandenen Build verwenden.
+
+## 3. Spiel bauen
+
+Release aus derselben vorbereiteten Konsole:
+
+```powershell
+cmake --build .\build\windows --config Release --parallel 4
+if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Release fehlgeschlagen' }
+```
+
+Für Debug stattdessen:
+
+```powershell
+cmake --build .\build\windows --config Debug --parallel 4
+if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
+```
+
+Laut generiertem Visual-Studio-Projekt sind die erwarteten Ausgabedateien
+`build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
+direkt im Buildordner. Diese Pfade wurden aus der Konfiguration geprüft;
+ein erfolgreicher Spielbuild ist damit noch nicht belegt.
+Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
+Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
+
+## 4. Spielstart und manuelle Prüfung
+
+Erst nach erfolgreichem Build durch den Nutzer prüfen; der folgende Startbefehl
+ist noch nicht praktisch verifiziert und setzt dieselbe geladene Umgebung voraus:
+
+```powershell
+Push-Location -LiteralPath .\build\windows
+try {
+    & .\opendungeons-plus.exe
+} finally {
+    Pop-Location
+}
+```
+
+Für Debug die Datei `opendungeons-plus_d.exe` verwenden.
+CMake erzeugt hier `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` und Verbindungen
+zu den Spieldaten. Bei fehlenden DLLs oder Plugins den tatsächlichen Startfehler
+prüfen; DLL-Verteilung, Plugin-Laden und Spielstart sind noch offen.
+Manuelle Spieltests und die visuelle Abnahme führt der Nutzer durch.
+
+## Protokolle und Wiederaufnahme
+
+- Aktueller Installations- und Prüfstand: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
+- Bibliotheksprotokolle: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
+  `<name>-Release.log`, `<name>-Debug.log`; Boost verwendet
+  `boost-bootstrap.log` und `boost-build.log`.
+- Abhängigkeiten nur bei tatsächlichem Bedarf nach
+  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md) neu bauen.
+
+`build` ist von Git ausgeschlossen und enthält generierte Dateien;
+`build\windows` enthält außerdem Verzeichnisverbindungen zu Projektressourcen.
+Diese Verbindungen beim Aufräumen beachten und keine Quellverzeichnisse über sie löschen.
+Nach einem neuen Ergebnis Datum, verwendete Konfiguration, Fehler bzw. Erfolg
+und verbleibende Prüfungen im Windows-Status nachtragen.

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -89,10 +89,20 @@ loading and normal shutdown without the earlier loading errors; the user then
 confirmed an error-free direct startup on September 5, 2026.
 That confirmation predates the dynamic-shadow startup failure. The resource
 template now also registers OGRE's `Media/Main` in `OgreInternal`, while retaining
-its `Graphics` entry for game shader includes; startup verification with shadows
-enabled is pending as described in [startup fixes](WINDOWS-STARTUP-FIXES.md).
+its `Graphics` entry for game shader includes; the user's subsequent run reached
+the main menu with shadows enabled, as recorded in
+[startup fixes](WINDOWS-STARTUP-FIXES.md).
 The corrected configuration has been generated beside the executable and passed
 the isolated OGRE resource test; no C++ rebuild is needed for this template change.
+The user's later Legacy test-map reproduction identified a fragment shader removed
+by OGRE's automatic illumination splitting. RenderManager now selects integrated
+additive texture shadows, preserving the existing custom shader passes. Release
+and Debug rebuilt successfully; the isolated OGRE pass test reproduces the missing
+fragment programs with splitting and retains the original pass without it.
+The Release executable is ready for the user to retest the same map with shadows
+enabled; gameplay and shadow appearance have not yet been verified after this fix.
+Build logs: `game-Release-integrated-shadows.log` and
+`game-Debug-integrated-shadows.log` under `build/windows`.
 
 The configuration script now calls
 [prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,5 +1,9 @@
 # Configuring and compiling on Windows
 
+For the completed `feature/live-settings` work, see [LIVE-SETTINGS.md](LIVE-SETTINGS.md)
+for its build and runtime evidence. The baseline startup verification below
+predates those settings changes.
+
 As of September 5, 2026. The [prerequisites](WINDOWS-DEV-SETUP.md) are installed
 and CMake and the Windows x64 game builds in Release and Debug have
 completed successfully; the user's startup attempts exposed a resource-path error,
@@ -22,6 +26,21 @@ Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
 The dot at the start loads the compiler and search paths into the same session;
 then configure and build in this console. CMake 3.31.8,
 Python 3.10.11 and the x64 compiler from Visual Studio 2022 Build Tools are expected.
+
+Some automated shells provide both `PATH` and `Path`. MSBuild then fails before
+starting `CL.exe` with `System.ArgumentException: An item with the same key has
+already been added`. Normalize the process environment before loading the helper:
+
+```powershell
+$taskCurrentPath = $env:Path
+[System.Environment]::SetEnvironmentVariable('PATH', $null, 'Process')
+[System.Environment]::SetEnvironmentVariable('Path', $taskCurrentPath, 'Process')
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+. .\scripts\win32\Enter-OpenDungeonsPlus.ps1
+```
+
+This changes only the current build process. A normal PowerShell console with one
+path variable does not need this step.
 If needed, check without building:
 
 ```powershell
@@ -59,6 +78,15 @@ Release from the same prepared console:
 ```powershell
 cmake --build .\build\windows --config Release --parallel 4
 if ($LASTEXITCODE -ne 0) { throw 'Release game build failed' }
+```
+
+After changing a class layout in a header, or after an interrupted rebuild, create
+the next test executable with a clean build so that no object file can retain the
+previous layout:
+
+```powershell
+cmake --build .\build\windows --config Release --target opendungeons-plus --clean-first --parallel 4
+if ($LASTEXITCODE -ne 0) { throw 'Clean Release game build failed' }
 ```
 
 For Debug instead:

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -87,6 +87,12 @@ The files have been prepared and checked, and the executable includes the fix fo
 absolute Windows resource paths. The 14:07 startup logs confirm main-menu scene
 loading and normal shutdown without the earlier loading errors; the user then
 confirmed an error-free direct startup on September 5, 2026.
+That confirmation predates the dynamic-shadow startup failure. The resource
+template now also registers OGRE's `Media/Main` in `OgreInternal`, while retaining
+its `Graphics` entry for game shader includes; startup verification with shadows
+enabled is pending as described in [startup fixes](WINDOWS-STARTUP-FIXES.md).
+The corrected configuration has been generated beside the executable and passed
+the isolated OGRE resource test; no C++ rebuild is needed for this template change.
 
 The configuration script now calls
 [prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -2,9 +2,13 @@
 
 As of September 5, 2026. The [prerequisites](WINDOWS-DEV-SETUP.md) are installed
 and CMake and the Windows x64 game builds in Release and Debug have
-completed successfully; game startup has not yet been tested in practice.
+completed successfully; the user's startup attempts exposed a resource-path error,
+which has been corrected and rebuilt; a subsequent run reached the main-menu scene
+and shut down normally, and the user confirmed that Release starts without errors.
 The four resolved build errors and their evidence are recorded in
 [WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
+The startup evidence and subsequent correction are recorded in
+[WINDOWS-STARTUP-FIXES.md](WINDOWS-STARTUP-FIXES.md).
 
 ## 1. Prepare the PowerShell session
 
@@ -73,24 +77,66 @@ compiler/linker message and the configuration used.
 The logged successful verification runs for this setup are located
 under `build\windows\game-Release-pass3.log` and `game-Debug-pass3.log`.
 
-## 4. Game startup and manual verification
+## 4. Direct Release startup and manual verification
 
-The user should only test after a successful build; the following startup command
-has not yet been verified in practice and requires the same loaded environment:
+For the current local setup, double-click
+`C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\opendungeons-plus.exe`
+in File Explorer; no PowerShell session is needed to test the Release build.
+Keep the executable in that directory with its DLLs, configuration and resource links.
+The files have been prepared and checked, and the executable includes the fix for
+absolute Windows resource paths. The 14:07 startup logs confirm main-menu scene
+loading and normal shutdown without the earlier loading errors; the user then
+confirmed an error-free direct startup on September 5, 2026.
+
+The configuration script now calls
+[prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).
+It copies 20 installed Release library/plugin DLLs and the two Python runtime DLLs
+next to the executable, and replaces the generated Unix-style OGRE media paths
+with the existing Windows installation's `Media/RTShaderLib`,
+`Media/RTShaderLib/GLSL` and `Media/Main` directories.
+The missing HLSL, HLSL_Cg and materials subdirectories are not registered.
+The other game resource entries and their existing junctions are preserved.
+
+The generated `python310._pth` points to the existing Python installation, its
+`Lib` and `DLLs` directories and the executable directory, with `import site` enabled;
+Python documents this application-local module path mechanism in
+[Finding modules on Windows](https://docs.python.org/3.10/using/windows.html#finding-modules).
+This is a local development setup: OGRE media and the Python standard library
+still reside outside the repository, and the installed Visual C++ runtime is used.
+It is not a standalone distribution package.
+
+If dependencies change or CMake regenerates the resource configuration outside
+the configuration script, refresh the prepared files with:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\win32\prepare-windows-runtime.ps1
+```
+
+The execution-policy option applies only to that process; it does not change the
+system's policy. The setup has already been performed for the current Release executable.
+
+As of September 5, 2026, static checks covered the executable and 22 DLLs,
+all four configured OGRE plugins and all 14 resource directories, with no missing
+DLL dependencies or incorrect CPU architectures; evidence is stored in
+`build\windows\runtime-validation.json`. These checks do not start the game.
+
+Debug still requires the prepared development environment; its direct-start
+runtime files have not been staged. An optional console startup from the loaded
+environment is:
 
 ```powershell
 Push-Location -LiteralPath .\build\windows
 try {
-    & .\opendungeons-plus.exe
+    & .\opendungeons-plus_d.exe
 } finally {
     Pop-Location
 }
 ```
 
-For Debug, use the file `opendungeons-plus_d.exe`.
-CMake generates `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` and links
-to the game data here. If DLLs or plugins are missing, examine the actual startup error;
-DLL distribution, plugin loading and game startup are still pending.
+The Debug startup command has not been verified in practice; its generated
+`plugins_d.cfg` still names the Release variants of Codec_STBI and RenderSystem_GL3Plus,
+so Debug plugin selection needs correction before its startup can be considered ready.
+If a startup error occurs, record the actual message for diagnosis.
 The user performs manual game tests and visual acceptance.
 
 ## Logs and resuming work

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -1,110 +1,110 @@
-# Am Originalprojekt mitarbeiten
+# Contributing to the original project
 
-## Eigenständig im Fork arbeiten
+## Working independently in the fork
 
-Im eigenen Fork kann das Projekt unabhängig weiterentwickelt werden; eine Aufnahme
-ins Team des Originalprojekts oder dessen Schreibrechte sind dafür nicht nötig.
-Die tatsächlichen persönlichen Schreibrechte am Originalrepository wurden nicht
-geprüft.
+The project can be developed independently in your own fork; joining
+the original project's team or having write permissions there is not necessary.
+The actual personal write permissions to the original repository have not
+been checked.
 
-Das Originalprojekt wird als Upstream benötigt, wenn dessen neue Änderungen
-übernommen oder eigene Änderungen per Pull Request zurückgegeben werden sollen;
-beides ist für die reine Weiterentwicklung im eigenen Fork optional.
+The original project is needed as upstream when you want to incorporate its new
+changes or contribute your own changes back through a pull request;
+both are optional if you only want to continue development in your own fork.
 
-Auch im Fork einen eigenen Arbeitsbranch pro Aufgabe verwenden. Für reine
-Fork-Arbeiten diesen vom aktuellen eigenen Entwicklungsstand erstellen, damit
-bereits vorhandene eigene Änderungen erhalten bleiben. Die nachfolgenden Schritte
-beschreiben dagegen einen Beitrag ans Originalprojekt und starten dessen
-Arbeitsbranch direkt vom Upstream-Stand.
+Use a separate work branch for each task even in the fork. For work solely
+in the fork, create it from your own current development state so that
+existing changes of your own are preserved. The following steps,
+in contrast, describe a contribution to the original project and start its
+work branch directly from the upstream state.
 
-## Repositories und Zielbranch
+## Repositories and target branch
 
-- Eigener Fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
-  lokal als `origin` eingerichtet.
-- Originalprojekt für unsere Beiträge:
+- Own fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
+  configured locally as `origin`.
+- Original project for our contributions:
   [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
-  lokal als `upstream` eingerichtet.
-- Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
-  Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+  configured locally as `upstream`.
+- Target branch in the original project: `shaders-improvement` (as of September 5, 2026).
+  Check the intended target branch on GitHub before a pull request.
 
-## Aktuell eingerichtet: Windows-Unterstützung
+## Currently configured: Windows support
 
-Stand: 5. September 2026. Unser Arbeitsbranch im Fork ist
-`feature/windows-support`; hier setzen wir die Windows-Arbeit fort.
-Auch Dokumentation und die Vorbereitung einer Build-Umgebung gehören auf einen
-Arbeitsbranch; ein Branch ist nicht auf neue Spielfunktionen beschränkt.
+As of September 5, 2026. Our work branch in the fork is
+`feature/windows-support`; we continue the Windows work here.
+Documentation and the preparation of a build environment also belong on a
+work branch; a branch is not limited to new game features.
 
-Der Branch wurde vom vorhandenen Fork-Stand `a8ffa583` erstellt und übernimmt
-die bis dahin uncommittierten Setup-Skripte und Entwicklungsnotizen.
-Der Standardbranch `shaders-improvement` bleibt auf diesem Stand;
-seinen bereits vorhandenen Dokumentationscommit schreiben wir nicht um.
-Beim Abruf zeigte der bestätigte Standardbranch des Originals,
-`upstream/shaders-improvement`, auf den Commit `be44649f`.
-Der Fork-Standardbranch liegt damit zum Einrichtungszeitpunkt einen
-Dokumentationscommit vor dem Original.
+The branch was created from the existing fork state `a8ffa583` and includes
+the setup scripts and development notes that had not yet been committed.
+The default branch `shaders-improvement` remains at that state;
+we do not rewrite its existing documentation commit.
+When fetched, the confirmed default branch of the original project,
+`upstream/shaders-improvement`, pointed to commit `be44649f`.
+The fork's default branch was therefore one documentation commit ahead of
+the original at the time of setup.
 
-Die Einrichtung wird in zwei Commits festgehalten: zuerst die bisherigen lokalen
-Windows-Setup-Skripte, danach die Dokumentation einschließlich dieser Arbeitsweise.
-Es gibt dabei noch keine Änderung am Spielcode oder an der Spielversion;
-README und Entwicklungsdokumentation beschreiben den tatsächlichen Stand,
-ein zusätzlicher Spiele-Changelog-Eintrag ist für diese Einrichtung nicht nötig.
+The setup is recorded in two commits: first the existing local
+Windows setup scripts, then the documentation including this workflow.
+There is no change to the game code or game version at this point;
+README and the development documentation describe the actual state,
+and an additional game changelog entry is not needed for this setup.
 
-### Tägliche Arbeit
+### Daily work
 
-Beim Wiederaufnehmen `git status` prüfen und auf `feature/windows-support`
-weiterarbeiten; Umgebung und Buildbefehle stehen in [BUILDING.md](BUILDING.md).
-Für diese laufende Windows-Aufgabe nicht bei jeder Sitzung einen neuen Branch
-erstellen. Fachlich abgeschlossene Änderungen separat committen und gemeinsam
-mit ihrer zugehörigen allgemeinen Build-Dokumentation prüfen; persönliche
-Rechnernotizen in einem eigenen Dokumentationscommit halten.
+When resuming, check `git status` and continue working on `feature/windows-support`;
+the environment and build commands are in [BUILDING.md](BUILDING.md).
+Do not create a new branch for each session of this ongoing Windows task.
+Commit completed, coherent changes separately and review them together
+with their associated general build documentation; keep personal
+computer notes in a separate documentation commit.
 
-Der Standardbranch wird für diese Arbeit nicht verändert. Neue Originaländerungen
-zunächst mit `git fetch upstream` abrufen und vor einer Übernahme vergleichen;
-ein Abruf allein verändert weder Arbeitsdateien noch lokale Arbeitsbranches.
+The default branch is not changed for this work. First fetch new changes from
+the original with `git fetch upstream` and compare them before incorporating them;
+a fetch alone changes neither working files nor local work branches.
 
-`origin` ist lokal als Standardziel für spätere Pushes gesetzt, für den
-Windows-Arbeitsbranch ebenfalls ausdrücklich als Push-Remote.
-Der neue Branch ist bisher nur lokal vorhanden und hat noch keinen Remote-Tracking-Branch;
-das Hauptprojekt ist als Quelle zum Abrufen und als späteres PR-Ziel eingerichtet.
-Ein Push wird weiterhin nur nach ausdrücklicher Freigabe ausgeführt.
+`origin` is configured locally as the default target for future pushes and is
+also explicitly set as the push remote for the Windows work branch.
+The new branch currently exists only locally and has no remote-tracking branch yet;
+the main project is configured as the source for fetching and as the future PR target.
+A push is still only performed after explicit authorization.
 
-### Weg zum späteren Windows-PR
+### Path to the future Windows PR
 
-Der Arbeitsbranch enthält unseren Fork-Kontext einschließlich persönlicher Pfade
-und Notizen; diese werden durch den Ordnernamen oder einen separaten Commit
-nicht automatisch aus einem Pull Request ausgeschlossen.
-Deshalb wird der fertige Beitrag später auf einem separaten PR-Branch direkt
-vom dann aktuellen `upstream/shaders-improvement` zusammengestellt.
-Dieser PR-Branch ist jetzt noch nicht angelegt.
+The work branch contains our fork context, including personal paths
+and notes; the directory name or a separate commit does not
+automatically exclude them from a pull request.
+The finished contribution will therefore later be assembled on a separate PR branch
+directly from the then-current `upstream/shaders-improvement`.
+This PR branch has not yet been created.
 
-Vorher den Windows-Build tatsächlich zum Laufen bringen, die Setup-Skripte für
-andere Rechner nutzbar machen und die Ergebnisse der Spieltests durch den Nutzer
-dokumentieren. Für den PR nur die geprüften, allgemein nutzbaren Änderungen und
-ihre Anleitung übernehmen; lokale Installationsprotokolle und Agentenvorgaben
-aus diesem Fork bleiben außerhalb des Beitrags.
-Die Auswahl und alle betroffenen Dateiunterschiede vor dem PR ausdrücklich prüfen
-und den zusammengestellten Stand erneut bauen, da er den privaten Fork-Kontext
-nicht voraussetzen darf. Erst nach ausdrücklicher Push-Freigabe den PR-Branch in
-den eigenen Fork veröffentlichen und gegen den Standardbranch des Originals anbieten.
+First get the Windows build actually working, make the setup scripts usable
+on other computers and document the results of the user's game tests.
+Include only the verified, generally reusable changes and their instructions
+in the PR; local installation logs and agent instructions
+from this fork stay outside the contribution.
+Explicitly review the selection and all affected file differences before the PR
+and rebuild the assembled state, since it must not depend on the private
+fork context. Only after explicit push authorization, publish the PR branch
+in your own fork and propose it against the original project's default branch.
 
-## 1. Originalprojekt einmalig als Remote eintragen
+## 1. Add the original project as a remote once
 
-Vorhandene Remotes anzeigen:
+Show existing remotes:
 
 ```powershell
 git remote -v
 ```
 
-Falls `upstream` noch fehlt:
+If `upstream` is still missing:
 
 ```powershell
 git remote add upstream https://github.com/tomluchowski/OpenDungeonsPlus.git
 ```
 
-## 2. Basis aktuell halten
+## 2. Keep the base up to date
 
-Vor einem Branchwechsel mit `git status` prüfen, dass keine ungesicherten Änderungen
-vorliegen; laufende Arbeit zuerst auf ihrem eigenen Branch sichern.
+Before switching branches, use `git status` to check that there are no unsaved changes;
+save ongoing work on its own branch first.
 
 ```powershell
 git fetch upstream
@@ -112,77 +112,76 @@ git switch shaders-improvement
 git merge --ff-only upstream/shaders-improvement
 ```
 
-Damit wird der lokale Basisbranch aktualisiert; auf diesem Branch keine Features
-entwickeln. Falls Git den Fast-Forward ablehnt, die abweichenden Commits prüfen,
-bevor weitere Schritte erfolgen.
+This updates the local base branch; do not develop features on this
+branch. If Git rejects the fast-forward, inspect the divergent commits
+before taking further steps.
 
-Um auch den Basisbranch auf GitHub im eigenen Fork zu aktualisieren:
+To also update the base branch on GitHub in your own fork:
 
 ```powershell
 git push origin shaders-improvement
 ```
 
-## 3. Für jede Änderung einen eigenen Branch erstellen
+## 3. Create a separate branch for each change
 
-Beispiel für eine Arbeit an der GUI-Skalierung:
+Example for work on GUI scaling:
 
 ```powershell
 git switch -c feature/gui-scaling upstream/shaders-improvement
 ```
 
-Den Namen an die konkrete Aufgabe anpassen. Der Branch startet direkt vom zuvor
-abgerufenen Originalstand, damit bestehende Änderungen nur im Fork nicht automatisch
-Teil des Beitrags werden.
+Adapt the name to the specific task. The branch starts directly from the
+previously fetched original state so that existing fork-only changes do not
+automatically become part of the contribution.
 
-## 4. Entwickeln, prüfen und committen
+## 4. Develop, verify and commit
 
-Die Änderung umsetzen und die betroffene Funktion prüfen; im Commit nur Dateien
-aufnehmen, die zu dieser Aufgabe gehören. Vor jedem Commit prüfen, ob Version,
-README, Änderungsprotokoll oder weitere Dokumentation angepasst werden müssen.
+Implement the change and verify the affected functionality; include only files
+belonging to this task in the commit. Before each commit, check whether the version,
+README, changelog or other documentation needs to be updated.
 
-Mit `git diff` die Änderungen prüfen, die gewünschten Dateien gezielt mit `git add`
-vormerken und anschließend mit `git diff --cached` den vollständigen Commit-Inhalt
-kontrollieren.
+Review the changes with `git diff`, stage the intended files explicitly with `git add`
+and then check the full commit content with `git diff --cached`.
 
 ```powershell
 git commit -m "Describe the change"
 ```
 
-Die Beispielnachricht durch eine konkrete Beschreibung der Änderung ersetzen.
+Replace the example message with a specific description of the change.
 
-## 5. Branch in den eigenen Fork pushen
+## 5. Push the branch to your own fork
 
-Für den Beispielbranch:
+For the example branch:
 
 ```powershell
 git push -u origin feature/gui-scaling
 ```
 
-Wenn Codex die Arbeit ausführt, benötigt jeder Push eine ausdrückliche Freigabe;
-die Befehle in dieser Anleitung sind selbst keine Freigabe.
+When Codex performs the work, every push requires explicit authorization;
+the commands in this guide do not themselves constitute authorization.
 
-## 6. Pull Request ans Originalprojekt erstellen
+## 6. Create a pull request to the original project
 
-Auf GitHub einen Pull Request mit diesen Einstellungen öffnen:
+On GitHub, open a pull request with these settings:
 
-- Zielrepository (base repository): `tomluchowski/OpenDungeonsPlus`.
-- Zielbranch (base): `shaders-improvement`.
-- Quellrepository (head repository): `Rokk001/OpenDungeonsPlus`.
-- Quellbranch (compare): der eigene Arbeitsbranch, im Beispiel `feature/gui-scaling`.
+- Target repository (base repository): `tomluchowski/OpenDungeonsPlus`.
+- Target branch (base): `shaders-improvement`.
+- Source repository (head repository): `Rokk001/OpenDungeonsPlus`.
+- Source branch (compare): your own work branch, `feature/gui-scaling` in the example.
 
-Problem, Änderung und durchgeführte Prüfungen beschreiben; vor dem Erstellen unter
-"Files changed" kontrollieren, dass ausschließlich die vorgesehenen Änderungen
-enthalten sind.
+Describe the problem, change and checks performed; before creating the PR,
+check under "Files changed" that only the intended changes
+are included.
 
-## 7. Review-Kommentare bearbeiten
+## 7. Address review comments
 
-Korrekturen auf demselben Arbeitsbranch umsetzen, prüfen und committen; anschließend
-denselben Branch erneut in den eigenen Fork pushen, wodurch sich der bestehende
-Pull Request automatisch aktualisiert.
+Implement, verify and commit corrections on the same work branch; then
+push that branch to your own fork again, which automatically updates the existing
+pull request.
 
-## Dokumentation im Fork und im Pull Request
+## Documentation in the fork and in the pull request
 
-Eigene Entwicklungsnotizen liegen unter `docs/development/`. Für einen Beitrag ans
-Originalprojekt nur die dafür relevante Dokumentation ausdrücklich auf den
-Arbeitsbranch übernehmen; der Ordnername allein schließt Dateien nicht aus einem
-Pull Request aus.
+Personal development notes are stored under `docs/development/`. For a contribution to
+the original project, explicitly include only the relevant documentation on the
+work branch; the directory name alone does not exclude files from a
+pull request.

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -1,0 +1,128 @@
+# Am Originalprojekt mitarbeiten
+
+## Eigenständig im Fork arbeiten
+
+Im eigenen Fork kann das Projekt unabhängig weiterentwickelt werden; eine Aufnahme
+ins Team des Originalprojekts oder dessen Schreibrechte sind dafür nicht nötig.
+Die tatsächlichen persönlichen Schreibrechte am Originalrepository wurden nicht
+geprüft.
+
+Das Originalprojekt wird als Upstream benötigt, wenn dessen neue Änderungen
+übernommen oder eigene Änderungen per Pull Request zurückgegeben werden sollen;
+beides ist für die reine Weiterentwicklung im eigenen Fork optional.
+
+Auch im Fork einen eigenen Arbeitsbranch pro Aufgabe verwenden. Für reine
+Fork-Arbeiten diesen vom aktuellen eigenen Entwicklungsstand erstellen, damit
+bereits vorhandene eigene Änderungen erhalten bleiben. Die nachfolgenden Schritte
+beschreiben dagegen einen Beitrag ans Originalprojekt und starten dessen
+Arbeitsbranch direkt vom Upstream-Stand.
+
+## Repositories und Zielbranch
+
+- Eigener Fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
+  lokal als `origin` eingerichtet.
+- Originalprojekt für unsere Beiträge:
+  [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
+  lokal als `upstream` einzurichten.
+- Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
+  Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+
+## 1. Originalprojekt einmalig als Remote eintragen
+
+Vorhandene Remotes anzeigen:
+
+```powershell
+git remote -v
+```
+
+Falls `upstream` noch fehlt:
+
+```powershell
+git remote add upstream https://github.com/tomluchowski/OpenDungeonsPlus.git
+```
+
+## 2. Basis aktuell halten
+
+Vor einem Branchwechsel mit `git status` prüfen, dass keine ungesicherten Änderungen
+vorliegen; laufende Arbeit zuerst auf ihrem eigenen Branch sichern.
+
+```powershell
+git fetch upstream
+git switch shaders-improvement
+git merge --ff-only upstream/shaders-improvement
+```
+
+Damit wird der lokale Basisbranch aktualisiert; auf diesem Branch keine Features
+entwickeln. Falls Git den Fast-Forward ablehnt, die abweichenden Commits prüfen,
+bevor weitere Schritte erfolgen.
+
+Um auch den Basisbranch auf GitHub im eigenen Fork zu aktualisieren:
+
+```powershell
+git push origin shaders-improvement
+```
+
+## 3. Für jede Änderung einen eigenen Branch erstellen
+
+Beispiel für eine Arbeit an der GUI-Skalierung:
+
+```powershell
+git switch -c feature/gui-scaling upstream/shaders-improvement
+```
+
+Den Namen an die konkrete Aufgabe anpassen. Der Branch startet direkt vom zuvor
+abgerufenen Originalstand, damit bestehende Änderungen nur im Fork nicht automatisch
+Teil des Beitrags werden.
+
+## 4. Entwickeln, prüfen und committen
+
+Die Änderung umsetzen und die betroffene Funktion prüfen; im Commit nur Dateien
+aufnehmen, die zu dieser Aufgabe gehören. Vor jedem Commit prüfen, ob Version,
+README, Änderungsprotokoll oder weitere Dokumentation angepasst werden müssen.
+
+Mit `git diff` die Änderungen prüfen, die gewünschten Dateien gezielt mit `git add`
+vormerken und anschließend mit `git diff --cached` den vollständigen Commit-Inhalt
+kontrollieren.
+
+```powershell
+git commit -m "Describe the change"
+```
+
+Die Beispielnachricht durch eine konkrete Beschreibung der Änderung ersetzen.
+
+## 5. Branch in den eigenen Fork pushen
+
+Für den Beispielbranch:
+
+```powershell
+git push -u origin feature/gui-scaling
+```
+
+Wenn Codex die Arbeit ausführt, benötigt jeder Push eine ausdrückliche Freigabe;
+die Befehle in dieser Anleitung sind selbst keine Freigabe.
+
+## 6. Pull Request ans Originalprojekt erstellen
+
+Auf GitHub einen Pull Request mit diesen Einstellungen öffnen:
+
+- Zielrepository (base repository): `tomluchowski/OpenDungeonsPlus`.
+- Zielbranch (base): `shaders-improvement`.
+- Quellrepository (head repository): `Rokk001/OpenDungeonsPlus`.
+- Quellbranch (compare): der eigene Arbeitsbranch, im Beispiel `feature/gui-scaling`.
+
+Problem, Änderung und durchgeführte Prüfungen beschreiben; vor dem Erstellen unter
+"Files changed" kontrollieren, dass ausschließlich die vorgesehenen Änderungen
+enthalten sind.
+
+## 7. Review-Kommentare bearbeiten
+
+Korrekturen auf demselben Arbeitsbranch umsetzen, prüfen und committen; anschließend
+denselben Branch erneut in den eigenen Fork pushen, wodurch sich der bestehende
+Pull Request automatisch aktualisiert.
+
+## Dokumentation im Fork und im Pull Request
+
+Eigene Entwicklungsnotizen liegen unter `docs/development/`. Für einen Beitrag ans
+Originalprojekt nur die dafür relevante Dokumentation ausdrücklich auf den
+Arbeitsbranch übernehmen; der Ordnername allein schließt Dateien nicht aus einem
+Pull Request aus.

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -51,7 +51,7 @@ and an additional game changelog entry is not needed for this setup.
 
 ### Daily work
 
-When resuming, check `git status` and continue working on `feature/windows-support`;
+When resuming Windows support work, check `git status` and use `feature/windows-support`;
 the environment and build commands are in [BUILDING.md](BUILDING.md).
 Do not create a new branch for each session of this ongoing Windows task.
 Commit completed, coherent changes separately and review them together
@@ -67,6 +67,17 @@ also explicitly set as the push remote for the Windows work branch.
 The new branch currently exists only locally and has no remote-tracking branch yet;
 the main project is configured as the source for fetching and as the future PR target.
 A push is still only performed after explicit authorization.
+
+### Separate task: live settings
+
+The related work is kept as a local stack so each branch adds one reviewable task:
+`feature/windows-support`, `fix/dynamic-shadows`,
+`fix/settings-option-duplicates`, then `feature/live-settings`. The live-settings
+changes affect shared game code, including Linux paths, so they remain separate
+from installing and building on Windows. Their implementation and verification
+status is in [LIVE-SETTINGS.md](LIVE-SETTINGS.md). Prepare upstream contributions
+from these boundaries after checking their dependencies. Linux validation is
+still pending.
 
 ### Path to the future Windows PR
 

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -23,9 +23,69 @@ Arbeitsbranch direkt vom Upstream-Stand.
   lokal als `origin` eingerichtet.
 - Originalprojekt für unsere Beiträge:
   [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
-  lokal als `upstream` einzurichten.
+  lokal als `upstream` eingerichtet.
 - Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
   Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+
+## Aktuell eingerichtet: Windows-Unterstützung
+
+Stand: 5. September 2026. Unser Arbeitsbranch im Fork ist
+`feature/windows-support`; hier setzen wir die Windows-Arbeit fort.
+Auch Dokumentation und die Vorbereitung einer Build-Umgebung gehören auf einen
+Arbeitsbranch; ein Branch ist nicht auf neue Spielfunktionen beschränkt.
+
+Der Branch wurde vom vorhandenen Fork-Stand `a8ffa583` erstellt und übernimmt
+die bis dahin uncommittierten Setup-Skripte und Entwicklungsnotizen.
+Der Standardbranch `shaders-improvement` bleibt auf diesem Stand;
+seinen bereits vorhandenen Dokumentationscommit schreiben wir nicht um.
+Beim Abruf zeigte der bestätigte Standardbranch des Originals,
+`upstream/shaders-improvement`, auf den Commit `be44649f`.
+Der Fork-Standardbranch liegt damit zum Einrichtungszeitpunkt einen
+Dokumentationscommit vor dem Original.
+
+Die Einrichtung wird in zwei Commits festgehalten: zuerst die bisherigen lokalen
+Windows-Setup-Skripte, danach die Dokumentation einschließlich dieser Arbeitsweise.
+Es gibt dabei noch keine Änderung am Spielcode oder an der Spielversion;
+README und Entwicklungsdokumentation beschreiben den tatsächlichen Stand,
+ein zusätzlicher Spiele-Changelog-Eintrag ist für diese Einrichtung nicht nötig.
+
+### Tägliche Arbeit
+
+Beim Wiederaufnehmen `git status` prüfen und auf `feature/windows-support`
+weiterarbeiten; Umgebung und Buildbefehle stehen in [BUILDING.md](BUILDING.md).
+Für diese laufende Windows-Aufgabe nicht bei jeder Sitzung einen neuen Branch
+erstellen. Fachlich abgeschlossene Änderungen separat committen und gemeinsam
+mit ihrer zugehörigen allgemeinen Build-Dokumentation prüfen; persönliche
+Rechnernotizen in einem eigenen Dokumentationscommit halten.
+
+Der Standardbranch wird für diese Arbeit nicht verändert. Neue Originaländerungen
+zunächst mit `git fetch upstream` abrufen und vor einer Übernahme vergleichen;
+ein Abruf allein verändert weder Arbeitsdateien noch lokale Arbeitsbranches.
+
+`origin` ist lokal als Standardziel für spätere Pushes gesetzt, für den
+Windows-Arbeitsbranch ebenfalls ausdrücklich als Push-Remote.
+Der neue Branch ist bisher nur lokal vorhanden und hat noch keinen Remote-Tracking-Branch;
+das Hauptprojekt ist als Quelle zum Abrufen und als späteres PR-Ziel eingerichtet.
+Ein Push wird weiterhin nur nach ausdrücklicher Freigabe ausgeführt.
+
+### Weg zum späteren Windows-PR
+
+Der Arbeitsbranch enthält unseren Fork-Kontext einschließlich persönlicher Pfade
+und Notizen; diese werden durch den Ordnernamen oder einen separaten Commit
+nicht automatisch aus einem Pull Request ausgeschlossen.
+Deshalb wird der fertige Beitrag später auf einem separaten PR-Branch direkt
+vom dann aktuellen `upstream/shaders-improvement` zusammengestellt.
+Dieser PR-Branch ist jetzt noch nicht angelegt.
+
+Vorher den Windows-Build tatsächlich zum Laufen bringen, die Setup-Skripte für
+andere Rechner nutzbar machen und die Ergebnisse der Spieltests durch den Nutzer
+dokumentieren. Für den PR nur die geprüften, allgemein nutzbaren Änderungen und
+ihre Anleitung übernehmen; lokale Installationsprotokolle und Agentenvorgaben
+aus diesem Fork bleiben außerhalb des Beitrags.
+Die Auswahl und alle betroffenen Dateiunterschiede vor dem PR ausdrücklich prüfen
+und den zusammengestellten Stand erneut bauen, da er den privaten Fork-Kontext
+nicht voraussetzen darf. Erst nach ausdrücklicher Push-Freigabe den PR-Branch in
+den eigenen Fork veröffentlichen und gegen den Standardbranch des Originals anbieten.
 
 ## 1. Originalprojekt einmalig als Remote eintragen
 

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -79,6 +79,12 @@ status is in [LIVE-SETTINGS.md](LIVE-SETTINGS.md). Prepare upstream contribution
 from these boundaries after checking their dependencies. Linux validation is
 still pending.
 
+### Separate task: progressive edge scrolling
+
+`feature/progressive-edge-scrolling` continues from `feature/live-settings` and
+contains the mouse-edge camera control change. Its implementation and verification
+status are recorded in [PROGRESSIVE-EDGE-SCROLLING.md](PROGRESSIVE-EDGE-SCROLLING.md).
+
 ### Path to the future Windows PR
 
 The work branch contains our fork context, including personal paths

--- a/docs/development/GUI-SCALING.md
+++ b/docs/development/GUI-SCALING.md
@@ -1,0 +1,96 @@
+# GUI scaling
+
+## Policy
+
+The interface combines automatic resolution scaling with a user-selected scale.
+
+- Window geometry, skin graphics and hit targets use a 1024 x 768 design area.
+- The automatic factor uses the shorter display axis so the interface keeps its
+  proportions and remains inside the window on wide or tall aspect ratios.
+- Fonts use the existing 800 x 600 font reference. This preserves the current
+  text-to-control ratio while making the 10-pixel base fonts approximately 18
+  pixels high at 1920 x 1080 and 36 pixels high at 3840 x 2160.
+- The Video settings page provides 80%, 90%, 100%, 110% and 120% presets.
+- Selecting a preset previews it immediately. Apply saves it; Cancel restores
+  the saved value.
+- The saved value is stored as `UI Scale` in the `[Game]` section of the user
+  configuration. The default is 100%.
+
+The scale is recalculated whenever CEGUI receives a display-size change, so
+resolution and fullscreen changes do not require a restart.
+
+## Implementation
+
+`Gui` records the original area, minimum size, maximum size and tab height of
+each non-generated CEGUI window. It reapplies those original values with the
+current automatic and user factors after a display-size or UI-scale change.
+Scaling from the original values prevents rounding errors from accumulating.
+
+Common OpenDungeons fonts and skin images use CEGUI's shortest-axis automatic
+scaling. Mouse coordinates remain in display pixels; scaling the actual CEGUI
+window rectangles keeps visual controls and hit targets aligned without a
+separate pointer transform.
+
+Explicit image sizes embedded in formatted labels scale with their containing
+windows, so tab and submenu icons do not remain fixed at 28 or 32 pixels on
+high-resolution displays.
+
+The top status bar keeps its existing left and right anchors while its pixel
+metrics scale. The bottom room and spell actions use two compact rows; the wave
+portal joins the room grid so the final action remains visible at the smallest
+supported window size and 120% UI scale. The main-menu root uses the complete
+display area so its final button remains inside the clipping area at the
+high-resolution 120% limit.
+
+Layouts loaded during `Gui` construction are registered automatically. Code
+that creates windows later must register their containing tree after assigning
+the final areas:
+
+```cpp
+getModeManager().getGui().registerWindowHierarchy(parentWindow);
+```
+
+Destroyed windows are removed from the scale registry through the CEGUI window
+manager event.
+
+## Automated verification
+
+The Windows Release target compiled successfully after the scaling changes were
+applied to the user's latest complete fork state. That baseline already includes
+the verified Windows build, runtime, live-settings and edge-scrolling changes.
+
+Before the branch ancestry was corrected, an incremental Windows binary crashed
+before the main menu because stale
+MSVC object files disagreed about the `ModeManager` class layout: the constructor
+stored `mGui` at offset `0x250`, while an old inline accessor read offset `0x260`.
+That upstream-only test binary is not validation for this corrected branch. A
+clean Release rebuild of the corrected fork-based branch regenerated every
+object file and completed successfully. After switching branches that change C++
+class layouts, rebuild this target with `--clean-first` before runtime testing.
+
+All 39 CEGUI layout files parse as XML. Static bounds checks cover the main
+menu, top HUD, bottom action tabs, Settings and Skill Tree at 800 x 660,
+1920 x 1080 and 3840 x 2160 with 80%, 100% and 120% UI scale; all nine
+size-and-scale combinations fit their available areas.
+
+## Manual verification
+
+Run the following checks at 80%, 100% and 120% UI scale for each representative
+window size:
+
+| Size | Purpose |
+| --- | --- |
+| 800 x 660 | Small supported window |
+| 1920 x 1080 | Full HD |
+| 3840 x 2160 | High-resolution display |
+
+At every size, verify:
+
+1. Open every main-menu page.
+2. Open every game HUD tab and click the first and last action in each tab.
+3. Check every Settings page, including dropdown lists and tooltips.
+4. Open Help, Objectives, the Skill Tree and every exit dialog.
+5. Change the resolution while the Settings window is open, then repeat one
+   click near each window edge.
+6. Confirm that text is readable and that no control is clipped, overlaps
+   another control, misses clicks or has an offset pointer target.

--- a/docs/development/GUI-SCALING.md
+++ b/docs/development/GUI-SCALING.md
@@ -68,10 +68,98 @@ clean Release rebuild of the corrected fork-based branch regenerated every
 object file and completed successfully. After switching branches that change C++
 class layouts, rebuild this target with `--clean-first` before runtime testing.
 
+The corrected branch's clean build regenerated `resources.cfg` with nonexistent
+OGRE media paths. The user's 23:21:36 startup on September 5, 2026 then failed
+while initializing CEGUI because `OgreUnifiedShader.h` could not be opened in
+`OgreInternal`. Running the existing Windows runtime preparation script restored
+the installed media paths; the executable was not changed. All configured
+resource directories exist, and the existing isolated OGRE resource probe passes.
+The user's subsequent run reached the main-menu scene at 23:27:27 and shut down
+normally at 23:28:32; the user confirmed startup and reported the settings defects
+described below. See the
+[failure record](WINDOWS-STARTUP-FIXES.md#resource-path-regression-after-the-gui-scaling-clean-build)
+and the updated [Release build commands](BUILDING.md#3-build-the-game).
+
 All 39 CEGUI layout files parse as XML. Static bounds checks cover the main
 menu, top HUD, bottom action tabs, Settings and Skill Tree at 800 x 660,
 1920 x 1080 and 3840 x 2160 with 80%, 100% and 120% UI scale; all nine
-size-and-scale combinations fit their available areas.
+size-and-scale combinations fit their outer available areas. These checks did not
+verify nested font metrics, input handling or renderer clipping and therefore did
+not detect the user's subsequent settings failures.
+
+## Settings geometry and clipping correction
+
+On September 5, 2026, the user reported shifted settings controls, mouse interaction
+that did not follow the displayed interface and a covered confirmation button.
+The source trace and an isolated CEGUI probe identified these causes:
+
+- `Gui::applyScale` resized controls before updating the fonts and skin images.
+  The combobox skin derives its edit field and arrow dimensions from the font.
+  At 3440 x 1440, the field stayed 58 pixels high when changing to 120% instead
+  of growing to 70 pixels; switching to 80% then left it 70 pixels high instead
+  of 47. Updating font and image metrics before applying window geometry fixes
+  this one-change lag, including the generated child controls and their targets.
+- Fixed settings labels were shorter than their scaled fonts, the title and tab
+  strip overlapped, the dynamic-shadow checkbox extended past the page, and
+  dynamically generated renderer option fields overlapped the following row.
+  The settings layout now provides sufficient text height and row spacing,
+  including the nickname field's existing padding, and keeps the title, tabs,
+  page content and footer separate. No settings values or behavior were removed.
+- The installed CEGUI Ogre renderer explicitly disabled scissor clipping for
+  every batch. CEGUI still generated vertices outside the scrollable page while
+  hit testing correctly clipped those controls. At 100%, one off-page option
+  had geometry from y=1076 to y=1134 over the Apply button at y=1086 to y=1142,
+  despite having an empty clip rectangle. This explains the visible control
+  covering a different clickable target. The maintained
+  [CEGUI clipping patch](../../scripts/win32/patches/cegui-ogre-clipping.patch)
+  restores each batch's clipping flag; the existing prerequisite installer
+  applies it before building the library.
+
+### Verification and limits
+
+The local probe uses the installed CEGUI library and its NullRenderer, without a
+game window or GPU renderer. Its generator takes the actual scaling methods,
+settings layout and dynamic option geometry from the selected repository state;
+it substitutes only the game/renderer initialization and a representative set of
+ten two-choice renderer options. The comparison against commit `1822217e` fails;
+the corrected state passes with no failed assertions.
+
+It covers 3440 x 1440, 800 x 660, 1920 x 1080 and 3840 x 2160, each with the
+sequence 100% -> 120% -> 80% -> 100%. Checks cover all four settings pages,
+font/field heights, renderer option row separation, title/tab and page/footer
+bounds, absence of unnecessary horizontal scrolling, scrollbar and slider
+tracking, dragging the dialog, and Apply/UI-scale hit targets after dragging.
+The separate geometry capture proves that scissor clipping is required; this
+NullRenderer test does not verify the patched OpenGL output on the GPU.
+
+Evidence under `build/windows`:
+
+- `generate-settings-scale-probe.py` and `build-settings-scale-probe.ps1`: the
+  reproducible isolated probe; pass `--baseline` to the build script for the
+  comparison with commit `1822217e`.
+- `settings-scale-geometry-before.log`: generated vertices beyond page clipping.
+- `settings-scale-regression-before.log` and `settings-scale-regression-after.log`:
+  failing and passing assertions, respectively.
+- `game-Release-settings-scaling-fix.log`: successful Release rebuild; the EXE
+  was updated at 23:39:49 on September 5, 2026.
+
+The patched CEGUI library built and installed successfully in Release and Debug.
+Runtime preparation then staged the Release DLL beside the executable; its
+SHA-256 matches the installed source. Library logs are in `od-deps/logs` as
+`cegui-Release.log` and `cegui-Debug.log`. The Debug game executable was not
+rebuilt for these GUI corrections.
+
+The user subsequently confirmed that the reported settings problems are fixed
+and requested a commit. The updated game's 23:47:28 run loaded the main-menu
+scene, entered a game map at 23:47:47 and followed the normal shutdown path at
+23:48:31. That log is preserved as
+`build/windows/settings-scaling-user-confirmed-game.log`. This records acceptance
+of the reported settings corrections; the complete menu/HUD/dialog matrix below
+has not been confirmed individually.
+
+The game version remains 0.7.1 because this is an unreleased correction. The root
+README already links the maintained development, build and startup guides; no
+additional README change or separate release changelog entry is needed.
 
 ## Manual verification
 

--- a/docs/development/IMPROVEMENT-ROADMAP.md
+++ b/docs/development/IMPROVEMENT-ROADMAP.md
@@ -15,9 +15,10 @@ implementation branch.
 
 This audit is stored on `docs/improvement-roadmap`, created from the verified
 fork state that already contains the Windows, live-settings and progressive
-edge-scrolling work. The roadmap itself is fork documentation. Future upstream
-contributions must still be assembled from the then-current upstream branch with
-only their required dependencies.
+edge-scrolling work. The roadmap itself is fork documentation. Every new
+implementation branch must continue from the user's latest complete fork state.
+A later upstream contribution may be assembled separately with only the reviewed,
+reusable changes after implementation and verification in the fork.
 
 ## Evidence and limits
 
@@ -103,9 +104,9 @@ Before every feature branch:
 1. Fetch `upstream` and re-query open issues and pull requests.
 2. Check whether PR #29, #41, #45, #21, #16 or #15 has merged, changed scope or
    been replaced.
-3. Compare the exact affected files before choosing a base.
-4. Build the branch from current upstream and add only dependencies it actually
-   needs.
+3. Compare the exact affected files before integrating an upstream dependency.
+4. Create the implementation branch from the user's latest complete fork state
+   and preserve all newer fork commits and documentation.
 
 This gate prevents duplicate fixes and large avoidable merge conflicts.
 
@@ -126,17 +127,16 @@ review decision or status check.
 | [#16](https://github.com/tomluchowski/OpenDungeonsPlus/pull/16) | Open and conflicting at `ab2858da`; its 101 files combine unrelated crash, gameplay, editor, portability and level work. Its spell/room layout change is already available separately in PR #29. | Excluded; use the focused PR #29 dependency instead. |
 | [#15](https://github.com/tomluchowski/OpenDungeonsPlus/pull/15) | Open and mergeable at `efa47d31`, but based on an older upstream commit and changing 317 files for the Ogre 14 port. It also changes the settings window, dialogs, skill tree, `OD.looknfeel` and GUI/render code, and commit `27a6a9bb` implements settings-only automatic scaling from `1.0` to `1.5`. | Excluded because it would add the renderer port and silently choose the still-unresolved scale policy. Recheck and reconcile these GUI files if the port advances. |
 
-The prepared local branch `feature/gui-scaling` starts directly at
-`be44649f`. The PR #29 commit was cherry-picked as its only dependency, producing
-local commit `cfd924f5`. The branch is one commit ahead of upstream, its diff is
-limited to the two layout files above, and both files pass XML parsing.
+The corrected local branch `feature/gui-scaling` starts at the complete fork
+roadmap state `e9a62ce8`, which already contains the verified Windows,
+live-settings and progressive edge-scrolling work and all development
+documentation. The PR #29 commit was then cherry-picked as the focused layout
+dependency, producing local commit `39c91a9a`. Both dependency layouts pass XML
+parsing.
 
-The fork's live-settings commit `d660f8ae` was not added: it changes 31 files and
-is a separate contribution. Current upstream already calls
-`CEGUI::System::notifyDisplaySizeChanged()` from
-`ODFrameListener::windowResized()`, so GUI scaling can react to display-size
-events without importing that feature. The scale policy remains the only
-required decision before Step 1 implementation.
+The existing live-settings path supplies the runtime render-window replacement
+and display-size notification used by GUI scaling. Automatic resolution scaling
+is combined with a user-selected scale from 80% through 120%.
 
 ### 1. `feature/gui-scaling`
 
@@ -147,9 +147,8 @@ clickable across supported window sizes and after live resolution changes.
 reflow the top bar and bottom action area, and adapt fixed dialogs without changing
 their game behavior.
 
-**Required decision before implementation:** automatic scaling, a user-selected
-scale, or both; supported scale limits must also be chosen. The repository does
-not determine that product behavior unambiguously.
+**Scale policy:** combine automatic resolution scaling with a user-selected
+scale; the supported user range is 80% through 120% in 10% steps.
 
 **Dependency and overlap:** resolve PR #29 first because it changes
 `WindowTabSpells.layout`. Use the fork's live display update path where runtime
@@ -321,7 +320,6 @@ depending on it.
 
 ## Recommended next action
 
-The first new implementation branch should be `feature/gui-scaling`, after the
-scale policy is chosen and PR #29 is rechecked. It addresses the most pervasive
-confirmed defect, enables clearer feedback and onboarding, and does not require a
-renderer or asset-pipeline decision.
+Complete the manual verification matrix for `feature/gui-scaling`. It addresses
+the most pervasive confirmed defect, enables clearer feedback and onboarding,
+and does not require a renderer or asset-pipeline decision.

--- a/docs/development/IMPROVEMENT-ROADMAP.md
+++ b/docs/development/IMPROVEMENT-ROADMAP.md
@@ -1,0 +1,298 @@
+# Product improvement audit and roadmap
+
+## Purpose and snapshot
+
+This document turns the current visual and usability concerns into separate,
+reviewable work items. It covers visual presentation, controls, interaction
+feedback and onboarding, and coordinates them with work already open in the
+original repository.
+
+The snapshot was taken on September 5, 2026. The original repository's default
+branch was still `shaders-improvement`; after fetching it locally, its head was
+`be44649f`. GitHub reported 12 open issues and 13 open pull requests. These
+counts and merge states can change and must be refreshed before starting each
+implementation branch.
+
+This audit is stored on `docs/improvement-roadmap`, created from the verified
+fork state that already contains the Windows, live-settings and progressive
+edge-scrolling work. The roadmap itself is fork documentation. Future upstream
+contributions must still be assembled from the then-current upstream branch with
+only their required dependencies.
+
+## Evidence and limits
+
+The findings use four evidence types:
+
+- The user's current Windows play test: the game starts and runs, but the visual
+  presentation and interaction are still perceived as substantially below the
+  intended quality level.
+- The current source, CEGUI layouts, fonts and configuration in this branch.
+- The six repository screenshots from 2021 through 2024, all at 1920x1200.
+- The original repository's open issues, pull requests and remote branches as
+  fetched or queried on September 5, 2026.
+
+The repository screenshots establish recurring composition and readability
+problems, but they are historical and do not prove every pixel of the current
+renderer output. No new screenshots or first-time-player study were captured for
+this audit. Manual visual acceptance and gameplay testing remain with the user.
+
+## Main conclusion
+
+Changing the renderer alone will not solve the reported quality gap. The current
+problems are distributed across four layers:
+
+1. **Readability:** most HUD geometry and fonts are fixed in pixels and remain
+   very small at modern resolutions.
+2. **Interaction:** important actions are represented by icons and hover-only
+   explanations, while action state and invalid-target feedback are weak.
+3. **Guidance:** the game has a long help page but no tutorial level or staged
+   first-run flow.
+4. **Presentation:** the world lacks a consistent hierarchy of materials,
+   lighting, ownership, silhouettes and effects; some improvements are already
+   waiting in upstream pull requests.
+
+The safest order is therefore readability, interaction feedback, onboarding,
+then coordinated visual and asset work. This makes later art improvements visible
+and usable instead of placing them behind the current interface friction.
+
+## Current-state inventory
+
+| Area | Confirmed evidence | Player effect | Priority | Upstream relationship |
+| --- | --- | --- | --- | --- |
+| HUD scale and text | The common fonts are fixed at 10 or 12 pixels with automatic scaling disabled; the top status bar is 23 pixels high, its icons are 30 pixels, and several top buttons are 25 pixels. | Text and targets remain difficult to read and click at high resolutions. | P0 | Directly matches [issue #6](https://github.com/tomluchowski/OpenDungeonsPlus/issues/6). [PR #29](https://github.com/tomluchowski/OpenDungeonsPlus/pull/29) changes one affected spell layout. |
+| Bottom action bar | The bar is fixed at 133 pixels high; room buttons are mostly 40 pixels, while other action buttons are 60 pixels. The screenshots show a large unused dark area beside the icons. | Space is consumed without improving discoverability, and the meaning of the icon grid is unclear without hovering. | P0 | [Issues #4](https://github.com/tomluchowski/OpenDungeonsPlus/issues/4) and [#6](https://github.com/tomluchowski/OpenDungeonsPlus/issues/6); PR #29 partially changes the spell arrangement only. |
+| Settings and modal layouts | The settings window uses a fixed 545x500 pixel rectangle at a fixed offset, with many fixed child coordinates. Other dialogs mix fixed and proportional geometry. | Dialogs do not form a coherent scale system and can feel cramped or misplaced after resolution changes. | P0 | No dedicated open PR; depends on the live display work already completed in the fork. |
+| Action discoverability | Core build, destroy and spell actions are image buttons whose detailed meaning is carried mainly by tooltips. The help text explains controls only after opening the help window. | A new player must experiment, hover or read a long reference page before understanding basic actions. | P0 | Central subject of issues #4 and #6. |
+| Active action and invalid targets | Upstream issue #4 reports that a click can appear to do nothing and that modes such as summoning are mistaken for immediate commands. The current action system selects a mode, then waits for a world click. | The player cannot reliably tell what mode is active, where it can be used or why an attempted action failed. | P0 | No focused open PR; should be fixed before creating a tutorial. |
+| Camera and pointer | The fork now applies resolution changes live, keeps pointer coordinates aligned, makes edge speed progressive and stops edge movement over the GUI. Other camera requests remain open. | The verified fork removes several immediate Windows problems, but centered zoom, alternative drag panning and the remaining requests in issue #11 are not covered. | P0 | [Issue #11](https://github.com/tomluchowski/OpenDungeonsPlus/issues/11); the aggregate PR #16 contains additional camera work and must be checked before implementation. |
+| Event messages | Events are rendered in a fixed rectangle using 16-pixel category icons and coloured inline text. Objective success/failure and defeat are delivered as short event messages plus sound. | Important information competes with routine notices and may be missed or misunderstood. | P1 | Issues #4, [#5](https://github.com/tomluchowski/OpenDungeonsPlus/issues/5) and [#7](https://github.com/tomluchowski/OpenDungeonsPlus/issues/7). |
+| Defeat state | Losing sets the player state and sends messages such as `You lost the game`; no dedicated defeat layout with explicit next actions exists. | The end state lacks visual weight and a clear next step. | P1 | Directly matches issue #5. |
+| Help and onboarding | The help window contains one long, scrollable text assembled in code. The README points to that help and an old external video. No level file contains a tutorial reference. | Basic concepts are presented as reference material instead of being taught through actions and feedback. | P0 | Directly matches issue #4; the 27 levels in PR #30 are additional content, not a tutorial. |
+| World hierarchy | Repository screenshots show strong repeated tile patterns, dark areas, similarly weighted room surfaces and many small props and creatures competing for attention. | Rooms, ownership, creatures, hazards and objectives are not readable at a glance. | P1 | [PR #45](https://github.com/tomluchowski/OpenDungeonsPlus/pull/45) adds coloured room emblems and supersedes PR #37. |
+| Fog of war | The screenshots show visible per-tile fog structure; upstream issue #13 describes the same grid-like result. | Exploration boundaries look assembled from separate pieces rather than one coherent fog mass. | P1 | [Issue #13](https://github.com/tomluchowski/OpenDungeonsPlus/issues/13) is directly addressed by [PR #41](https://github.com/tomluchowski/OpenDungeonsPlus/pull/41). Do not duplicate it. |
+| Materials and environment variety | Floors and walls repeat strongly across rooms and corridors. The editor currently selects the existing visual types rather than a broad material palette per dungeon. | Dungeons lack visual identity and repeated tiles expose the grid. | P2 | [Issues #12](https://github.com/tomluchowski/OpenDungeonsPlus/issues/12) and [#14](https://github.com/tomluchowski/OpenDungeonsPlus/issues/14); no open implementation PR. |
+| Creature readability and animation | The screenshots show small creature silhouettes relative to rooms; upstream reports static bodies during movement and abrupt transitions. | Creatures lack presence and are difficult to read during normal play. | P2 | Issues #11 and [#8](https://github.com/tomluchowski/OpenDungeonsPlus/issues/8). |
+| Voice, captions and music | Voice and sound systems exist, but upstream reports unclear lines, missing captions and repetitive or stuttering ambient music. | Important feedback may be unintelligible, and the soundscape can feel unfinished. | P1 for captions, P2 for replacement audio | [Issues #7](https://github.com/tomluchowski/OpenDungeonsPlus/issues/7) and [#9](https://github.com/tomluchowski/OpenDungeonsPlus/issues/9). |
+| Source assets | Runtime assets are versioned, but upstream asks for editable project sources in a defined location. | Larger art work is harder to review, reproduce and improve consistently without source files. | P2 prerequisite | [Issue #10](https://github.com/tomluchowski/OpenDungeonsPlus/issues/10). |
+
+## Work already completed in this fork
+
+The following verified work should be treated as the current fork baseline and
+not rediscovered as new roadmap tasks:
+
+- Reliable Windows Release and Debug compilation and direct Release startup.
+- Runtime dependency and resource preparation for the local Windows build.
+- Dynamic-shadow startup and shader-pass corrections.
+- Deduplicated renderer setting choices.
+- Live resolution and fullscreen changes with updated render, GUI, camera and
+  input dimensions.
+- Correct pointer alignment after live resolution changes.
+- Progressive edge scrolling and suppression of edge scrolling over the HUD,
+  minimap and top navigation.
+
+These changes are still fork branches rather than merged upstream work. Any pull
+request to the original repository must be assembled and validated against fresh
+upstream state.
+
+## Ordered implementation roadmap
+
+### Gate 0: refresh and reconcile upstream work
+
+Before every feature branch:
+
+1. Fetch `upstream` and re-query open issues and pull requests.
+2. Check whether PR #29, #41, #45, #21, #16 or #15 has merged, changed scope or
+   been replaced.
+3. Compare the exact affected files before choosing a base.
+4. Build the branch from current upstream and add only dependencies it actually
+   needs.
+
+This gate prevents duplicate fixes and large avoidable merge conflicts.
+
+### 1. `feature/gui-scaling`
+
+**Goal:** make the HUD, dialogs, fonts, tooltips and hit targets readable and
+clickable across supported window sizes and after live resolution changes.
+
+**Scope:** establish one scale policy, scale the common fonts and skin metrics,
+reflow the top bar and bottom action area, and adapt fixed dialogs without changing
+their game behavior.
+
+**Required decision before implementation:** automatic scaling, a user-selected
+scale, or both; supported scale limits must also be chosen. The repository does
+not determine that product behavior unambiguously.
+
+**Dependency and overlap:** resolve PR #29 first because it changes
+`WindowTabSpells.layout`. Use the fork's live display update path where runtime
+resize notification is required, but keep unrelated Windows setup out of the
+eventual upstream contribution.
+
+**Verification:** test every main menu, game HUD tab, settings page, help,
+objectives, skill tree and exit dialog at representative small, full-HD and
+high-resolution window sizes; verify no clipping, overlap, missed click target or
+pointer offset.
+
+### 2. `feature/action-state-feedback`
+
+**Goal:** make every two-step action explain its current mode, valid target and
+failure reason.
+
+**Scope:** add a persistent active-action label near the action bar, strengthen
+the selected state, distinguish valid and invalid world targets, and show one
+specific reason when an attempted build, spell or placement cannot proceed.
+
+**Dependency:** GUI scaling should land first so the feedback has a stable visual
+location and text size.
+
+**Verification:** a player must be able to select, cancel and complete digging,
+room building, trap placement, summoning and a targeted spell without consulting
+the help page, and an invalid click must explain why it failed.
+
+### 3. Camera follow-up branches
+
+The verified progressive edge-scrolling branch covers only edge speed and GUI
+suppression. The remaining issue #11 requests should stay separate:
+
+- `fix/camera-zoom-anchor`: keep zoom focused on the intended world position.
+- `feature/camera-drag-pan`: provide an accessible pointer-based pan alternative.
+- `fix/camera-speed-consistency`: reconcile keyboard, edge and configured pan
+  speed after reproducing the remaining discrepancy.
+
+First compare the camera and minimap commits still present in aggregate PR #16.
+Do not claim issue #11 is closed merely because edge scrolling is improved.
+
+### 4. `feature/tutorial-level`
+
+**Goal:** teach the minimum playable loop through actions in a real level.
+
+**Dependency:** action-state feedback must be available first; a tutorial cannot
+teach reliably while valid targets and failed actions remain unclear.
+
+**Required decision before implementation:** approve the lesson sequence and the
+level's completion point. A proposed sequence is camera movement, selecting tiles
+to dig, summoning a worker, mining and storing gold, building basic creature rooms,
+opening the skill system and placing one defensive item.
+
+**Scope:** prefer the existing level, objective and display-text systems; add a
+new framework only if those systems cannot express a verified lesson step.
+
+**Verification:** a first-time player can finish the approved sequence without
+the README, external video or full help page.
+
+### 5. `feature/defeat-screen`
+
+**Goal:** make the end state unmistakable and give the player explicit next
+actions.
+
+**Required decision before implementation:** choose which actions are offered,
+such as retry, return to menu, continue observing or exit.
+
+**Scope:** one modal end-state presentation, correct input blocking and the
+approved actions; gameplay balance remains outside this branch.
+
+**Verification:** defeat appears once, suppresses obsolete combat feedback and
+each offered action leads to the stated destination.
+
+### 6. `feature/voice-captions`
+
+**Goal:** pair every important spoken keeper message with readable text and avoid
+repeating unchanged warnings excessively.
+
+**Scope:** map voice events to captions, route them through the existing event
+system, and suppress exact repeats until the underlying state changes.
+
+**Dependency:** GUI scaling should land first; replacement voice recordings are a
+separate asset task.
+
+**Verification:** each important spoken event has matching text, and repeated
+bed, hunger, combat and objective warnings follow the approved repeat policy.
+
+### 7. Integrate pending upstream visual work before new art changes
+
+Review and test PR #45 for room ownership and PR #41 for fog continuity. The
+newly fetched upstream branch `room-seat-emblems-paul424-improvement` already adds
+another coloured building element on top of the room-emblem work, but it was not
+an open pull request in the captured snapshot. Clarify its intended destination
+before building on it.
+
+PR #37 should not be combined with PR #45 because #45 explicitly supersedes it.
+Renderer-heavy work should also check the status and intended direction of PR #15
+before committing to APIs that may change during the Ogre 14 transition.
+
+### 8. `docs/visual-direction`
+
+**Goal:** define a small, reviewable visual target before replacing individual
+assets.
+
+**Scope:** establish rules for room identity, owner colour, material value range,
+light and shadow hierarchy, creature silhouette size, effect intensity and UI/world
+separation using current game screenshots.
+
+**Verification:** the document includes approved before/target examples and gives
+an artist or implementer enough constraints to make consistent changes.
+
+### 9. Visual implementation branches
+
+After the visual direction and pending upstream PRs are resolved, split work by
+asset family:
+
+- `feature/environment-material-variety`: issues #12 and #14, beginning with one
+  complete corridor or room family and its editor support.
+- `feature/creature-readability`: silhouette, scale, selection and status
+  readability without replacing animation sets.
+- `feature/character-animation-pass`: issue #8, one creature family per reviewable
+  contribution.
+- `feature/ambient-audio-pass`: issue #9, with licensed sources and loop testing.
+- `docs/asset-source-workflow`: issue #10, defining source-file locations,
+  licences and export steps before accepting larger asset replacements.
+
+Animation, modelling, texture painting, voice acting and music require artistic
+quality decisions and licensed source material; they cannot be promised as fully
+automatic implementation tasks.
+
+## Open issue coordination
+
+| Issue | Disposition in this roadmap |
+| --- | --- |
+| [#4 Gameplay is not discoverable](https://github.com/tomluchowski/OpenDungeonsPlus/issues/4) | Primary source for action-state feedback and the tutorial; split its individual failures into focused branches rather than one large fix. |
+| [#5 Improve failure sequence](https://github.com/tomluchowski/OpenDungeonsPlus/issues/5) | Covered by the separate defeat-screen branch after the offered actions are approved. |
+| [#6 Interface and mouse navigation](https://github.com/tomluchowski/OpenDungeonsPlus/issues/6) | GUI scaling is the first remaining branch; current fork cursor and live-resize fixes address only part of the report. |
+| [#7 Voice acting and captions](https://github.com/tomluchowski/OpenDungeonsPlus/issues/7) | Captions and repeat control come before replacement recordings. |
+| [#8 Character animations](https://github.com/tomluchowski/OpenDungeonsPlus/issues/8) | Later asset branch after creature readability and source-asset workflow. |
+| [#9 Ambient music](https://github.com/tomluchowski/OpenDungeonsPlus/issues/9) | Later audio branch requiring licensed sources and manual listening acceptance. |
+| [#10 Project asset sources](https://github.com/tomluchowski/OpenDungeonsPlus/issues/10) | Define the source and export workflow before broad art replacement. |
+| [#11 Camera navigation](https://github.com/tomluchowski/OpenDungeonsPlus/issues/11) | Progressive edge scrolling is only a partial fix; keep zoom, drag pan and remaining speed behavior separate and check PR #16 first. |
+| [#12 Hallway styles](https://github.com/tomluchowski/OpenDungeonsPlus/issues/12) | Part of the later environment-material work. |
+| [#13 Seamless fog](https://github.com/tomluchowski/OpenDungeonsPlus/issues/13) | Already addressed by open PR #41; review rather than duplicate. |
+| [#14 More map materials](https://github.com/tomluchowski/OpenDungeonsPlus/issues/14) | Later environment and editor branch after the visual direction is approved. |
+| [#42 Explicit variable types](https://github.com/tomluchowski/OpenDungeonsPlus/issues/42) | Code-style task outside this product roadmap; never mix it into UI or visual branches. |
+
+## Open pull-request coordination
+
+The GitHub query returned no formal review decision or status-check result for the
+13 open pull requests. Mergeability reported by GitHub was available for some but
+not all and is only a momentary signal. Re-query the individual pull request before
+depending on it.
+
+| PR | Relationship to this roadmap | Action |
+| --- | --- | --- |
+| [#15 Ogre v14.6 v3](https://github.com/tomluchowski/OpenDungeonsPlus/pull/15) | May change rendering APIs and the long-term graphics baseline. | Treat as a decision gate for renderer-heavy work; it does not block layout, feedback or onboarding work. |
+| [#16 Combined crash, UI, portability and level work](https://github.com/tomluchowski/OpenDungeonsPlus/pull/16) | Large aggregate containing cursor, camera and UI changes alongside unrelated work; several parts have been split or merged separately. | Do not use as a clean feature base; inspect its individual commits before camera or pointer work. |
+| [#20 User data folder](https://github.com/tomluchowski/OpenDungeonsPlus/pull/20) | Changes where levels and configuration are read. | Recheck before adding a tutorial level so installed and user data remain correct. |
+| [#21 Cross-platform fixes](https://github.com/tomluchowski/OpenDungeonsPlus/pull/21) | Overlaps parts of the fork's Windows portability work. | Reconcile exact files before preparing the Windows upstream contribution. |
+| [#28 Bridge rerouting](https://github.com/tomluchowski/OpenDungeonsPlus/pull/28) | Gameplay bug fix with no direct roadmap overlap. | Keep independent. |
+| [#29 Two-row spell buttons](https://github.com/tomluchowski/OpenDungeonsPlus/pull/29) | Directly changes a layout required by GUI scaling. | Resolve or use as an explicit dependency before editing that layout. |
+| [#30 New levels](https://github.com/tomluchowski/OpenDungeonsPlus/pull/30) | Adds content but no staged tutorial. | Do not treat it as onboarding; check level-list ordering if both land. |
+| [#31 Integration-test launcher and macOS fixes](https://github.com/tomluchowski/OpenDungeonsPlus/pull/31) | Improves automated validation. | Useful infrastructure, but independent of product behavior. |
+| [#32 Destructible traps](https://github.com/tomluchowski/OpenDungeonsPlus/pull/32) | Gameplay mechanics outside this audit. | Keep independent. |
+| [#33 Configurable room hit points](https://github.com/tomluchowski/OpenDungeonsPlus/pull/33) | Gameplay mechanics outside this audit and currently reported conflicting. | Keep independent and do not mix with visual room work. |
+| [#37 Room ownership tint](https://github.com/tomluchowski/OpenDungeonsPlus/pull/37) | Earlier whole-floor ownership treatment. | Do not integrate; PR #45 explicitly supersedes it. |
+| [#41 Overlapping fog tiles](https://github.com/tomluchowski/OpenDungeonsPlus/pull/41) | Direct visual improvement for issue #13. | Review and test it instead of implementing another fog solution. |
+| [#45 Room ownership emblems](https://github.com/tomluchowski/OpenDungeonsPlus/pull/45) | Directly improves room ownership readability without tinting the whole floor. | Preferred pending direction; test it before further room-material changes. |
+
+## Recommended next action
+
+The first new implementation branch should be `feature/gui-scaling`, after the
+scale policy is chosen and PR #29 is rechecked. It addresses the most pervasive
+confirmed defect, enables clearer feedback and onboarding, and does not require a
+renderer or asset-pipeline decision.

--- a/docs/development/IMPROVEMENT-ROADMAP.md
+++ b/docs/development/IMPROVEMENT-ROADMAP.md
@@ -109,6 +109,35 @@ Before every feature branch:
 
 This gate prevents duplicate fixes and large avoidable merge conflicts.
 
+#### Gate 0 result for `feature/gui-scaling`
+
+Gate 0 was completed on September 5, 2026. After fetching `upstream`,
+`upstream/shaders-improvement` still pointed to `be44649f`. GitHub still
+reported 12 open issues and 13 open pull requests; none of the six pull
+requests checked below had merged or been replaced, and none reported a formal
+review decision or status check.
+
+| PR | Verified state and file overlap | Decision for this branch |
+| --- | --- | --- |
+| [#29](https://github.com/tomluchowski/OpenDungeonsPlus/pull/29) | Open and mergeable at `bab847a6`; its single commit changes only `gui/WindowTabRooms.layout` and `gui/WindowTabSpells.layout` and is patch-equivalent to the corresponding change in PR #16. | Required dependency because GUI scaling must continue from the corrected two-row action layouts. |
+| [#41](https://github.com/tomluchowski/OpenDungeonsPlus/pull/41) | Open and mergeable at `7f408353`; it changes `shaders/Cloud.frag` and `source/render/RenderManager.cpp`. | Excluded because fog rendering is independent of GUI scaling. |
+| [#45](https://github.com/tomluchowski/OpenDungeonsPlus/pull/45) | Open and mergeable at `bcec307c`; its 34 files cover room materials, seat-mask textures, `shaders/Room.frag`, `source/entities/Tile.cpp` and `source/render/RenderManager.cpp`. It still explicitly supersedes PR #37. | Excluded because room ownership rendering is independent of GUI scaling. |
+| [#21](https://github.com/tomluchowski/OpenDungeonsPlus/pull/21) | Open and conflicting at `2e2df09f`; its eight files cover CMake and platform/resource handling, with no GUI layout file. It remains a focused split from PR #16. | Excluded because it is not required for GUI scaling. |
+| [#16](https://github.com/tomluchowski/OpenDungeonsPlus/pull/16) | Open and conflicting at `ab2858da`; its 101 files combine unrelated crash, gameplay, editor, portability and level work. Its spell/room layout change is already available separately in PR #29. | Excluded; use the focused PR #29 dependency instead. |
+| [#15](https://github.com/tomluchowski/OpenDungeonsPlus/pull/15) | Open and mergeable at `efa47d31`, but based on an older upstream commit and changing 317 files for the Ogre 14 port. It also changes the settings window, dialogs, skill tree, `OD.looknfeel` and GUI/render code, and commit `27a6a9bb` implements settings-only automatic scaling from `1.0` to `1.5`. | Excluded because it would add the renderer port and silently choose the still-unresolved scale policy. Recheck and reconcile these GUI files if the port advances. |
+
+The prepared local branch `feature/gui-scaling` starts directly at
+`be44649f`. The PR #29 commit was cherry-picked as its only dependency, producing
+local commit `cfd924f5`. The branch is one commit ahead of upstream, its diff is
+limited to the two layout files above, and both files pass XML parsing.
+
+The fork's live-settings commit `d660f8ae` was not added: it changes 31 files and
+is a separate contribution. Current upstream already calls
+`CEGUI::System::notifyDisplaySizeChanged()` from
+`ODFrameListener::windowResized()`, so GUI scaling can react to display-size
+events without importing that feature. The scale policy remains the only
+required decision before Step 1 implementation.
+
 ### 1. `feature/gui-scaling`
 
 **Goal:** make the HUD, dialogs, fonts, tooltips and hit targets readable and

--- a/docs/development/LIVE-SETTINGS.md
+++ b/docs/development/LIVE-SETTINGS.md
@@ -1,0 +1,232 @@
+# Live settings and fullscreen navigation
+
+Completed September 5, 2026, on `feature/live-settings`, stacked after the
+Windows-support, dynamic-shadow and settings-option branches. Documentation
+describes implementation and evidence separately.
+
+## Requested behavior
+
+All settings exposed by the settings window must take effect after Apply without
+restarting the game. This includes resolution and fullscreen during a running
+game. The in-game main navigation must remain visible at 3440 x 1440 fullscreen.
+Preserve the running game and existing settings functionality.
+
+## Findings and implementation
+
+- The game creates its render window explicitly. The settings code used
+  `getAutoCreatedWindow()`, which does not identify that window. It now obtains
+  the window from the frame listener and notifies the camera, input and CEGUI
+  after changing its size or fullscreen state.
+- VSync was saved from the fullscreen checkbox. It now uses its own checkbox
+  and applies VSync and its interval to the current window.
+- Dynamic shadows can change the scene's shadow technique and the existing
+  materials' `shadowingEnabled` parameter without exiting. This retains the
+  integrated shadow technique required by the earlier shader fix.
+- Mouse and keyboard capture changes recreate OIS devices before the next input
+  capture, outside the Apply callback. Minimap selection recreates the minimap
+  at the next frame; minimap click handling refreshes its screen position.
+- Volume, ambient lighting and camera speed already preview their changes.
+  Autoscroll and keeper voice read current configuration during operation.
+- Opening settings reloads the current configuration into the controls.
+- The keeper-hand projection cache now also tracks the camera aspect ratio so
+  that resizing does not leave its position calculated for the old window shape.
+- Resolution and fullscreen changes now resize or restyle the current render
+  window directly. FSAA, gamma, colour depth, display frequency and other pixel
+  format options create a hidden replacement render window after the current
+  input capture has finished. The active camera viewport, CEGUI render target
+  and OIS devices move to it before the old window is hidden. The original
+  primary OpenGL window remains as a hidden context anchor; later replacement
+  windows are explicitly destroyed.
+- Replacement is transactional. The old window stays usable until the transfer
+  succeeds. A creation or transfer failure restores the previous renderer values
+  and persisted video configuration. Fullscreen windows are changed to windowed
+  state before destruction so that their cleanup cannot reset the display mode
+  selected for the replacement window.
+- Live nickname changes use a separate request and server acknowledgement.
+  The server derives the player from the connection and updates the same player
+  object; it does not create a second player or restart the handshake. An
+  optional capability byte in the existing nickname handshake prevents sending
+  new messages to older peers. Existing message identifiers are preserved by
+  appending the new enum entries. Replay playback does not send rename requests.
+  Servers without this capability retain their existing session nickname; the
+  new configured name remains available for a subsequent connection.
+
+## Setting coverage
+
+| Settings control | Apply behavior in this branch |
+| --- | --- |
+| Music Volume | Changes the active listener while the slider moves and persists on Apply. |
+| Dynamic Shadows | Changes the active scene shadow technique and material shadow state on Apply. |
+| Renderer | The maintained Windows build exposes only the active OpenGL 3+ renderer, so there is no alternative value to apply. |
+| Full Screen | Restyles the current render window and updates camera, input and CEGUI dimensions on Apply. |
+| Video Mode | Resizes the current render window and updates camera, input and CEGUI dimensions on Apply. |
+| VSync and VSync Interval | Update the current render window on Apply. |
+| Reversed Z-Buffer | Updates GL clip control and the active depth convention on Apply. |
+| Debug Layer | Enables or disables GL debug output on Apply. |
+| Separate Shader Objects | Reloads the loaded GPU programs for the selected shader mode on Apply. |
+| FSAA | Replaces the active render window with one using the selected pixel format after Apply. |
+| sRGB Gamma Conversion | Replaces the active render window with one using the selected pixel format after Apply. |
+| Colour Depth | Replaces the active render window when another unique depth is available and selected; this system exposes only 32. |
+| Display Frequency | Replaces the active render window when a fullscreen frequency is available and selected. |
+| Keyboard Grab and Mouse Grab | Recreate the OIS devices before the next input capture after Apply. |
+| Autoscroll | The camera input path reads the persisted value every frame after Apply. |
+| Pan Speed | Updates the active camera while the slider moves and persists on Apply. |
+| Keeper Voice | Subsequent keeper sound requests read the persisted selection after Apply. |
+| Minimap Type | Recreates the active game or editor minimap on the next frame after Apply. |
+| Nickname | Updates the connected session through the negotiated live-rename message and persists for later connections. |
+| Ambient Light | Updates the active scene while the slider moves and persists on Apply. |
+
+## Runtime verification and remaining platform scope
+
+- The user tested the rebuilt Release executable and confirmed that all reported
+  failures are fixed. Resolution and fullscreen changes apply without restarting,
+  mouse input remains aligned, the bottom-edge flicker is gone and the in-game
+  main navigation remains visible at 3440 x 1440 fullscreen.
+- Older-peer and replay packet boundaries are covered by automated tests, but a
+  running mixed-version multiplayer session has not been tested.
+- The maintained build uses Ogre-owned windows because `OD_USE_SFML_WINDOW` is
+  disabled. Runtime window replacement has not been implemented or tested for
+  the optional SFML-owned window path.
+- The installed plugin set exposes only OpenGL 3+; there is no alternative
+  renderer to switch to. In-process replacement of the active render backend is
+  outside this implementation and no longer exits the game if encountered.
+
+## Fullscreen and Windows display scaling
+
+The existing Release executable's embedded manifest contained only its execution
+level, with no DPI declaration. An isolated Windows API probe on this computer
+reported a physical display mode of 3440 x 1440 but a DPI-unaware screen size of
+2752 x 1152. Per-monitor awareness reported 3440 x 1440 at 120 DPI (125%).
+
+The executable now includes [a DPI manifest](../../dist/opendungeons.manifest),
+merged by MSVC and embedded through the icon resource for MinGW. This keeps
+Windows window and input coordinates in physical pixels. Microsoft documents
+the API virtualization and manifest settings in
+[High DPI desktop application development](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows)
+and [Setting default DPI awareness](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process).
+
+The test executable built without the manifest reports the size mismatch and
+exits 1. The same test linked with the manifest extracted from the rebuilt game
+reports matching 3440 x 1440 dimensions and exits 0. This verifies the coordinate
+correction without opening the game. The missing navigation was consistent with
+that mismatch, and the user's final fullscreen test confirmed the correction.
+MinGW and moving the game between monitors have not been tested.
+
+After the final clean Release build, its embedded manifest was extracted again
+and contained `PerMonitorV2, PerMonitor`. The DPI probe still reported matching
+3440 x 1440 screen and display-mode dimensions with per-monitor awareness, and
+the real `ModeGame.layout` probe again placed the main navigation, minimap and
+options button inside the 3440 x 1440 display; both probes exited with code 0.
+
+## Verification
+
+The first Release build of the live-settings changes failed on a leftover shadow
+flag reference and a missing configuration include. Both were corrected. The
+current window-replacement implementation builds successfully in Release and
+Debug. The latest logs are `game-Release-live-settings-final.log` and
+`game-Debug-live-settings-pass3.log`. Earlier builds described in BUILDING.md
+predate this work and do not establish that all live settings work at runtime.
+
+An incremental Release executable built while the input manager's class layout
+was changing crashed in CEGUI before the main menu appeared. Targeted logging
+showed that a GUI lookup was reading an impossible container size, while the same
+GUI instance had just loaded all layouts successfully. This identified mixed
+object files using different class layouts rather than a missing DLL or damaged
+user configuration. A clean-first Release build recompiled every translation
+unit and linked successfully on September 5, 2026. The user confirmed that this
+clean-build executable started successfully and reached the settings window.
+The temporary lookup logging used for this diagnosis was removed from the final
+source.
+
+The first clean-build runtime test then changed a windowed resolution from
+1920 x 1440 to 2048 x 1152. The replacement window was created and the transfer
+completed, but the game appeared frozen while GL3Plus rebuilt graphics programs;
+the process had to be ended manually. Resolution and fullscreen changes do not
+require a new OpenGL context, so they now resize or restyle the current render
+window directly and notify the camera, input and CEGUI about its actual size.
+Window replacement remains reserved for settings that determine the pixel format
+when an OpenGL window is created. A clean Release build containing this correction
+completed successfully on September 5, 2026. The user then confirmed that changing
+the resolution applied immediately without a restart or freeze.
+
+That test changed the running game from 2048 x 1152 windowed to 3440 x 1440
+fullscreen and exposed two related symptoms: mouse hits were below the displayed
+controls and an approximately 1 cm strip flickered along the bottom edge. OGRE's
+Win32 fullscreen path changed the window frame style and resized the window without
+passing `SWP_FRAMECHANGED` to `SetWindowPos`. Microsoft documents that this flag is
+required after changing frame styles with `SetWindowLong`, so the maintained OGRE
+patch now supplies it. The first isolated fullscreen run then measured matching
+3440 x 1440 window and client areas but retained the previous 148 x 72 test
+viewport, because OGRE stored the requested size before refreshing the actual
+window metrics. The patch now refreshes those metrics directly instead. The final
+probe measured 3440 x 1440 for the screen, window, client area and viewport,
+preserved the OpenGL context, rendered successfully and exited with code 0. The
+patched renderer also built and installed successfully in Release and Debug, its
+Release DLL was staged beside the game executable, and all three existing GL3Plus
+regression variants passed. A final clean Release build then linked successfully;
+the staged renderer matched the built and installed DLL by SHA-256, and the rebuilt
+executable retained its per-monitor DPI manifest. The user's final running-game
+test confirmed correct mouse alignment and removal of the bottom-edge flicker.
+
+An isolated GL3Plus test then used the same windowed sequence as the application:
+`setFullscreen(false)`, `resize` and `windowMovedOrResized`. The resize completed
+in 5 ms, preserved the original OpenGL context and rendered the next frame
+correctly. The same runs set VSync interval 1 and then disabled VSync; the WGL
+driver query returned 1 and 0 respectively. The separable and monolithic shader
+runs both exited with code 0. This verifies the engine-level path that avoids the
+observed context rebuild; the user's running-game test confirmed CEGUI and
+gameplay responsiveness after the resolution change.
+
+The existing ODPacket unit tests and a new test for optional handshake fields
+passed: two cases, 15 assertions. This verifies packet boundaries for original
+and extended messages, not a running multiplayer session. The input-device
+rollback now saves the previous capture configuration before attempting to
+recreate the previous devices, so another device failure cannot leave the failed
+selection persisted for the next launch.
+
+An isolated CEGUI test loaded the real `ODSkin.scheme` and `ModeGame.layout`
+using the NullRenderer, without opening the game or a graphics window. At
+1280 x 1024, 3440 x 1440, 1920 x 1080 and 800 x 660, the main navigation tabs,
+minimap and options button were visible in the layout and had nonempty clipping
+rectangles inside the display. At 3440 x 1440, the navigation occupied the
+bottom 133 pixels. This rules out an off-screen rectangle in that isolated
+layout test, but does not verify GPU rendering, fullscreen or the user's failure.
+
+Local, ignored evidence is in `build/windows/gui-layout-probe.cpp`,
+`gui-layout-probe.log`, `gui-layout-probe-CEGUI.log` and
+`game-Release-live-settings-pass1.log`. Subsequent evidence includes
+`game-Release-live-settings-final.log`, `game-Debug-live-settings-pass3.log`,
+`dpi-metrics-before.log`, `dpi-metrics-after.log`, `live-settings-after.manifest`
+and `test-live-packets.log`. The manifest extracted from the current Release
+executable as `live-settings-current.manifest` contains `PerMonitorV2, PerMonitor`.
+The staged Release GL3Plus plugin has the same SHA-256 hash as the patched
+installed plugin. Use the maintained build commands in
+[BUILDING.md](BUILDING.md). The user completed the requested Windows game and
+visual acceptance tests. Linux runtime behavior has not been verified.
+
+## Renderer implementation
+
+The installed renderer is OGRE 13.6.5 GL3Plus. Its configuration setters generally
+update an option map, while `Win32Window::create` selects FSAA, gamma, colour depth
+and display frequency. Its window `setFullscreen` method does not accept those
+extra options. The application therefore recreates a secondary render window for
+creation-time options and keeps the primary context alive.
+
+[ogre-multiwindow-settings.patch](../../scripts/win32/patches/ogre-multiwindow-settings.patch)
+adds the required OGRE 13.6.5 GL3Plus behavior. It keeps a separate program
+pipeline for each OpenGL context and forgets that pipeline when its context is
+destroyed, recognizes both WGL framebuffer-sRGB extension names, and applies
+reversed depth, separate shader objects and debug output when their configuration
+values change at runtime. It also refreshes the Win32 frame and actual render
+dimensions when switching between windowed and fullscreen modes. The Windows
+prerequisite installer applies the patch idempotently before building OGRE.
+
+An isolated GL3Plus probe rendered the primary and two successive hidden windows
+in green, verified FSAA 4 and hardware gamma on the first replacement and the
+return to FSAA 0 without gamma on the second, destroyed the earlier replacement
+while the later context was current, returned to the primary context and shut down
+cleanly. Separate runs covered separable shaders, monolithic shaders and primary
+context configuration changes. All three runs passed with exit code 0 after the
+Release and Debug dependencies were rebuilt. This verifies the renderer mechanisms
+independently of gameplay; the user subsequently confirmed the reported behavior
+in the running game.

--- a/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
+++ b/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
@@ -23,12 +23,19 @@ top, bottom, left and right edges and combines naturally at corners.
 Keyboard camera movement and the Pan Speed setting retain their existing behavior.
 Disabling Autoscroll still disables mouse-edge movement.
 
+Mouse-edge scrolling is also suppressed while the pointer is over the in-game
+GUI. This prevents camera movement while using the bottom navigation, minimap or
+top navigation. Moving the pointer back over the game world restores the normal
+edge-scrolling behavior.
+
 ## Implementation
 
 `GameMode::mouseMoved()` converts the pointer's distance from each edge into a
 value from zero to one and passes it with the existing camera movement command.
 `CameraManager` uses that value as the per-axis maximum pan speed while preserving
-the existing acceleration and deceleration path.
+the existing acceleration and deceleration path. The existing CEGUI hit test sets
+all four edge intensities to zero while the pointer is over an in-game GUI widget,
+which also stops movement already initiated at an edge.
 
 ## Verification
 
@@ -48,6 +55,10 @@ progressive edge scrolling looks much better and that the reported control issue
 is fixed. The runtime logs contain no unhandled exception for that test run and
 end with normal engine shutdown.
 
+The follow-up suppression of edge scrolling over the bottom navigation, minimap
+and top navigation has been implemented and compiled. Manual in-game verification
+of these three GUI areas is pending.
+
 The project version remains 0.7.1 because this feature branch does not define a
-release. The project has no changelog, and the README has no detailed mouse-edge
-control section that requires updating.
+release. The release notes are therefore unchanged, and the README has no
+detailed mouse-edge control section that requires updating.

--- a/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
+++ b/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
@@ -37,7 +37,17 @@ On September 5, 2026, a clean Windows x64 Release build of the
 `build/windows/opendungeons-plus.exe`. The existing compiler warnings remained;
 the changed files produced no errors.
 
-Manual gameplay verification is still required. Enable Autoscroll, enter a
-playable map and check all four edges: movement should begin slowly on entering
-the outer 2%, increase continuously toward the edge and reach the configured Pan
-Speed at the edge. Also check a corner, keyboard movement and Autoscroll disabled.
+The first launch after the clean build failed because CMake regeneration had
+overwritten the prepared Windows resource configuration. Running
+`scripts/win32/prepare-windows-runtime.ps1` restored the installed OGRE media
+paths; this was a generated runtime configuration problem rather than a camera
+control failure.
+
+The user then tested the Release executable in game and confirmed that the
+progressive edge scrolling looks much better and that the reported control issue
+is fixed. The runtime logs contain no unhandled exception for that test run and
+end with normal engine shutdown.
+
+The project version remains 0.7.1 because this feature branch does not define a
+release. The project has no changelog, and the README has no detailed mouse-edge
+control section that requires updating.

--- a/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
+++ b/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
@@ -1,0 +1,43 @@
+# Progressive mouse-edge scrolling
+
+## Branch and scope
+
+The work is isolated on `feature/progressive-edge-scrolling`, based on
+`feature/live-settings`. It changes only in-game camera movement triggered by the
+Autoscroll mouse-edge control.
+
+## Previous behavior
+
+With Autoscroll enabled, entering the outer 2% of any screen edge immediately
+applied full camera acceleration. The camera therefore moved too quickly before
+the pointer could be positioned precisely.
+
+## Current behavior
+
+The existing 2% activation area is retained. Within that area, scrolling now
+starts slowly and increases linearly as the pointer approaches the edge. The
+screen edge still provides the full configured pan speed. Horizontal and vertical
+intensities are calculated independently, so the same behavior applies to the
+top, bottom, left and right edges and combines naturally at corners.
+
+Keyboard camera movement and the Pan Speed setting retain their existing behavior.
+Disabling Autoscroll still disables mouse-edge movement.
+
+## Implementation
+
+`GameMode::mouseMoved()` converts the pointer's distance from each edge into a
+value from zero to one and passes it with the existing camera movement command.
+`CameraManager` uses that value as the per-axis maximum pan speed while preserving
+the existing acceleration and deceleration path.
+
+## Verification
+
+On September 5, 2026, a clean Windows x64 Release build of the
+`opendungeons-plus` target completed successfully and produced
+`build/windows/opendungeons-plus.exe`. The existing compiler warnings remained;
+the changed files produced no errors.
+
+Manual gameplay verification is still required. Enable Autoscroll, enter a
+playable map and check all four edges: movement should begin slowly on entering
+the outer 2%, increase continuously toward the edge and reach the configured Pan
+Speed at the edge. Also check a corner, keyboard movement and Autoscroll disabled.

--- a/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
+++ b/docs/development/PROGRESSIVE-EDGE-SCROLLING.md
@@ -55,9 +55,10 @@ progressive edge scrolling looks much better and that the reported control issue
 is fixed. The runtime logs contain no unhandled exception for that test run and
 end with normal engine shutdown.
 
-The follow-up suppression of edge scrolling over the bottom navigation, minimap
-and top navigation has been implemented and compiled. Manual in-game verification
-of these three GUI areas is pending.
+The user then tested the follow-up suppression in the Release executable and
+confirmed that interaction with the bottom navigation, minimap and top navigation
+looks good without unwanted edge scrolling. The same run entered gameplay and
+ended with normal OGRE shutdown without an unhandled exception.
 
 The project version remains 0.7.1 because this feature branch does not define a
 release. The release notes are therefore unchanged, and the README has no

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,6 +26,9 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
   choices, their cause and verification status.
 - [Live settings](LIVE-SETTINGS.md): applying settings without restarting,
   the fullscreen navigation report and completed Windows verification.
+- [Product improvement audit and roadmap](IMPROVEMENT-ROADMAP.md): confirmed
+  visual and usability gaps, ordered implementation branches and coordination
+  with open upstream issues and pull requests.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -20,6 +20,8 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
   build Release/Debug and find logs.
 - [Windows build errors and fixes](WINDOWS-BUILD-FIXES.md): confirmed
   compiler errors, their causes, targeted fixes and build evidence.
+- [Windows startup errors and fixes](WINDOWS-STARTUP-FIXES.md): actual startup
+  failures, runtime preparation, resource-path correction and outstanding verification.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,6 +24,8 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
   failures, runtime preparation, resource-path correction and outstanding verification.
 - [Windows settings fixes](WINDOWS-SETTINGS-FIXES.md): duplicate colour-depth
   choices, their cause and verification status.
+- [Live settings](LIVE-SETTINGS.md): applying settings without restarting,
+  the fullscreen navigation report and completed Windows verification.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -29,6 +29,8 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
 - [Product improvement audit and roadmap](IMPROVEMENT-ROADMAP.md): confirmed
   visual and usability gaps, ordered implementation branches and coordination
   with open upstream issues and pull requests.
+- [GUI scaling](GUI-SCALING.md): scale policy, implementation details,
+  automated checks and the required manual verification matrix.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 
@@ -38,7 +40,7 @@ Add new files here as needed and link them above, for example:
 
 - `DEBUGGING.md`: traceable error analyses and solutions.
 - `ARCHITECTURE-NOTES.md`: findings about the existing code and its relationships.
-- `GUI-SCALING.md`: findings on GUI scaling once work on it begins.
+- `VISUAL-DIRECTION.md`: approved visual targets and asset constraints.
 
 For technical findings, record the affected code, verification steps and
 open questions; label statements that have not yet been verified accordingly.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -3,20 +3,28 @@
 Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
 mit einer Markdown-Datei pro Thema.
 
+Für eine neue Sitzung zuerst [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md)
+und [Konfigurieren und kompilieren](BUILDING.md) lesen; der Einstieg für Agenten
+ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
+
 ## Vorhandene Anleitungen
 
 - [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
-  Arbeitsbranches, Pull Requests und eigenständige Weiterentwicklung im Fork.
+  eingerichteter Windows-Arbeitsbranch, getrennte Commits und der Weg zum späteren
+  Pull Request ins Originalprojekt.
 - [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
   Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
-- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): besprochene Werkzeuge,
-  im Build-Code bestätigte Abhängigkeiten und noch offene Prüfungen.
+- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): installierte Versionen,
+  genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
+- [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
+  Release/Debug bauen und Protokolle finden.
+- [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
+  Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
 
 ## Weitere Notizen ablegen
 
 Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
 
-- `BUILDING.md`: überprüfte Build-Schritte und Voraussetzungen.
 - `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
 - `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
 - `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,28 @@
+# Entwicklungsdokumentation
+
+Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
+mit einer Markdown-Datei pro Thema.
+
+## Vorhandene Anleitungen
+
+- [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
+  Arbeitsbranches, Pull Requests und eigenständige Weiterentwicklung im Fork.
+- [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
+  Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
+- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): besprochene Werkzeuge,
+  im Build-Code bestätigte Abhängigkeiten und noch offene Prüfungen.
+
+## Weitere Notizen ablegen
+
+Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
+
+- `BUILDING.md`: überprüfte Build-Schritte und Voraussetzungen.
+- `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
+- `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
+- `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.
+
+Bei technischen Erkenntnissen den betroffenen Code, die Schritte zur Prüfung und
+offene Fragen festhalten; noch nicht überprüfte Aussagen entsprechend kennzeichnen.
+
+Die Sammlung ist zunächst für den eigenen Fork gedacht; welche Dokumentation ins
+Originalprojekt übernommen wird, entscheiden wir für den jeweiligen Pull Request.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,38 +1,38 @@
-# Entwicklungsdokumentation
+# Development documentation
 
-Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
-mit einer Markdown-Datei pro Thema.
+Here we collect guides and findings on contributing to OpenDungeonsPlus,
+with one Markdown file per topic.
 
-Für eine neue Sitzung zuerst [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md)
-und [Konfigurieren und kompilieren](BUILDING.md) lesen; der Einstieg für Agenten
-ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
+For a new session, first read [Windows development environment](WINDOWS-DEV-SETUP.md)
+and [Configuring and compiling](BUILDING.md); the entry point for agents
+is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
 
-## Vorhandene Anleitungen
+## Available guides
 
-- [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
-  eingerichteter Windows-Arbeitsbranch, getrennte Commits und der Weg zum späteren
-  Pull Request ins Originalprojekt.
-- [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
-  Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
-- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): installierte Versionen,
-  genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
-- [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
-  Release/Debug bauen und Protokolle finden.
-- [Windows-Buildfehler und Korrekturen](WINDOWS-BUILD-FIXES.md): nachgewiesene
-  Compilerfehler, ihre Ursachen, gezielte Korrekturen und Buildnachweise.
-- [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
-  Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
+- [Contributing to the original project](CONTRIBUTING-WORKFLOW.md): fork, synchronization,
+  the configured Windows work branch, separate commits and the path to a later
+  pull request to the original project.
+- [Tasks and division of work](TASKS.md): assessment so far of autonomous
+  implementation, participation in testing and the suggested starting point.
+- [Windows development environment](WINDOWS-DEV-SETUP.md): installed versions,
+  exact locations, connections to the project and verified status.
+- [Configuring and compiling](BUILDING.md): load the environment, run CMake,
+  build Release/Debug and find logs.
+- [Windows build errors and fixes](WINDOWS-BUILD-FIXES.md): confirmed
+  compiler errors, their causes, targeted fixes and build evidence.
+- [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
+  checksums, installation scripts, order and resolved installation problems.
 
-## Weitere Notizen ablegen
+## Adding further notes
 
-Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
+Add new files here as needed and link them above, for example:
 
-- `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
-- `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
-- `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.
+- `DEBUGGING.md`: traceable error analyses and solutions.
+- `ARCHITECTURE-NOTES.md`: findings about the existing code and its relationships.
+- `GUI-SCALING.md`: findings on GUI scaling once work on it begins.
 
-Bei technischen Erkenntnissen den betroffenen Code, die Schritte zur Prüfung und
-offene Fragen festhalten; noch nicht überprüfte Aussagen entsprechend kennzeichnen.
+For technical findings, record the affected code, verification steps and
+open questions; label statements that have not yet been verified accordingly.
 
-Die Sammlung ist zunächst für den eigenen Fork gedacht; welche Dokumentation ins
-Originalprojekt übernommen wird, entscheiden wir für den jeweiligen Pull Request.
+The collection is initially intended for our own fork; we decide which documentation
+to include in the original project for each pull request.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -18,6 +18,8 @@ ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
   genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
 - [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
   Release/Debug bauen und Protokolle finden.
+- [Windows-Buildfehler und Korrekturen](WINDOWS-BUILD-FIXES.md): nachgewiesene
+  Compilerfehler, ihre Ursachen, gezielte Korrekturen und Buildnachweise.
 - [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
   Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -22,6 +22,8 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
   compiler errors, their causes, targeted fixes and build evidence.
 - [Windows startup errors and fixes](WINDOWS-STARTUP-FIXES.md): actual startup
   failures, runtime preparation, resource-path correction and outstanding verification.
+- [Windows settings fixes](WINDOWS-SETTINGS-FIXES.md): duplicate colour-depth
+  choices, their cause and verification status.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 

--- a/docs/development/TASKS.md
+++ b/docs/development/TASKS.md
@@ -8,8 +8,9 @@ Codex should handle implementation as independently as possible; the user wants
 to focus mainly on testing and visual assessment.
 
 The following assessments reflect the conversation so far, not a
-guarantee of fully autonomous implementation. A detailed technical review of
-the individual tasks and their specific requirements is still pending.
+guarantee of fully autonomous implementation. The detailed technical findings,
+priorities, branch boundaries and upstream overlap are recorded in the
+[product improvement audit and roadmap](IMPROVEMENT-ROADMAP.md).
 
 ## Tasks discussed
 

--- a/docs/development/TASKS.md
+++ b/docs/development/TASKS.md
@@ -1,41 +1,41 @@
-# Aufgaben und Arbeitsteilung
+# Tasks and division of work
 
-Stand: 5. September 2026, festgehalten aus dem bisherigen Gespräch.
+As of September 5, 2026, recorded from the conversation so far.
 
-## Ziel der Zusammenarbeit
+## Goal of the collaboration
 
-Codex soll die Umsetzung möglichst selbstständig übernehmen; der Nutzer möchte
-hauptsächlich das Testen und die visuelle Beurteilung übernehmen.
+Codex should handle implementation as independently as possible; the user wants
+to focus mainly on testing and visual assessment.
 
-Die folgenden Bewertungen sind die bisherige Einschätzung aus dem Gespräch, keine
-Garantie einer vollständig autonomen Umsetzung. Eine technische Detailprüfung der
-einzelnen Aufgaben und ihrer konkreten Anforderungen steht noch aus.
+The following assessments reflect the conversation so far, not a
+guarantee of fully autonomous implementation. A detailed technical review of
+the individual tasks and their specific requirements is still pending.
 
-## Besprochene Aufgaben
+## Tasks discussed
 
-| Nr. | Aufgabe | Bisherige Einschätzung | Beteiligung oder offene Voraussetzung |
+| No. | Task | Assessment so far | Participation or outstanding prerequisite |
 | --- | --- | --- | --- |
-| 1 | Windows-Build zuverlässig machen | Sehr gut machbar, aber vollständige Autonomie nicht garantiert. | Lokale Windows- oder Abhängigkeitsprobleme können Eingriffe des Nutzers erfordern. |
-| 2 | Ogre-14-Port stabilisieren | Machbar eingeschätzt, aber großer Architektur- und Kompatibilitätsbereich ohne belastbare Vollständigkeitsgarantie. | Umfang und Hindernisse müssen zunächst am Code geprüft werden. |
-| 3 | GUI skalierbar machen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer testet insbesondere die Darstellung; eine lokal baubare und startende Spielversion wird für die Ergebnisprüfung benötigt. |
-| 4 | Maus/Cursor sauber lösen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer prüft das Verhalten im Spiel; der konkrete Änderungsumfang ist noch festzulegen. |
-| 5 | UI verständlicher machen | Größtenteils durch Codex umsetzbar eingeschätzt. | Offene Entscheidungen zu Bedienung und Texten müssen geklärt oder ausdrücklich delegiert werden. |
-| 6 | Tutorial / Onboarding | Durch Codex umsetzbar eingeschätzt, sofern Inhalt und Ablauf selbst definiert werden dürfen. | Die dafür notwendige Entscheidungsfreiheit wurde bisher nur als Voraussetzung genannt und noch nicht erteilt. |
+| 1 | Make the Windows build reliable | Very feasible, but full autonomy is not guaranteed. | Local Windows or dependency problems may require user intervention. |
+| 2 | Stabilize the Ogre 14 port | Assessed as feasible, but a large architecture and compatibility area without a reliable guarantee of completeness. | The scope and obstacles must first be examined in the code. |
+| 3 | Make the GUI scalable | Assessed as likely to be fully implementable by Codex. | The user tests the visual presentation in particular; a game version that builds and starts locally is needed to verify the result. |
+| 4 | Resolve mouse/cursor handling cleanly | Assessed as likely to be fully implementable by Codex. | The user checks the behavior in the game; the specific scope of changes still needs to be defined. |
+| 5 | Make the UI easier to understand | Assessed as largely implementable by Codex. | Open decisions about interaction and wording must be clarified or explicitly delegated. |
+| 6 | Tutorial / onboarding | Assessed as implementable by Codex, provided it may define the content and flow itself. | The necessary decision-making authority has so far only been mentioned as a prerequisite and has not yet been granted. |
 
-## Vorgeschlagener Einstieg
+## Suggested starting point
 
-Im Gespräch wurden Aufgabe 3 und 4 als Einstieg für möglichst wenig Eigenaufwand
-vorgeschlagen; das ist noch kein Auftrag zur Umsetzung dieser Aufgaben.
+In the conversation, tasks 3 and 4 were suggested as a starting point to minimize
+the user's own effort; this is not yet an instruction to implement these tasks.
 
-Für die GUI-Skalierung zuerst eine Umgebung herstellen, in der das Spiel lokal
-kompiliert und startet; die besprochenen Voraussetzungen stehen in der
-[Windows-Dokumentation](WINDOWS-DEV-SETUP.md).
+For GUI scaling, first establish an environment in which the game
+compiles and starts locally; the prerequisites discussed are in the
+[Windows documentation](WINDOWS-DEV-SETUP.md).
 
-## Offene Entscheidungen und Prüfung
+## Open decisions and verification
 
-Fehlende funktionale, gestalterische oder inhaltliche Entscheidungen werden nicht
-stillschweigend getroffen; sie müssen aus dem Projekt eindeutig hervorgehen, vom
-Nutzer beantwortet oder ausdrücklich an Codex delegiert werden.
+Missing functional, design or content decisions are not made
+silently; they must be unambiguously determined from the project, answered by the
+user or explicitly delegated to Codex.
 
-Manuelle Spieltests, QA und die visuelle Abnahme übernimmt der Nutzer; Ergebnisse
-und dabei gefundene Fehler werden anschließend gemeinsam ausgewertet.
+The user handles manual game tests, QA and visual acceptance; results
+and any errors found are then evaluated together.

--- a/docs/development/TASKS.md
+++ b/docs/development/TASKS.md
@@ -1,0 +1,41 @@
+# Aufgaben und Arbeitsteilung
+
+Stand: 5. September 2026, festgehalten aus dem bisherigen Gespräch.
+
+## Ziel der Zusammenarbeit
+
+Codex soll die Umsetzung möglichst selbstständig übernehmen; der Nutzer möchte
+hauptsächlich das Testen und die visuelle Beurteilung übernehmen.
+
+Die folgenden Bewertungen sind die bisherige Einschätzung aus dem Gespräch, keine
+Garantie einer vollständig autonomen Umsetzung. Eine technische Detailprüfung der
+einzelnen Aufgaben und ihrer konkreten Anforderungen steht noch aus.
+
+## Besprochene Aufgaben
+
+| Nr. | Aufgabe | Bisherige Einschätzung | Beteiligung oder offene Voraussetzung |
+| --- | --- | --- | --- |
+| 1 | Windows-Build zuverlässig machen | Sehr gut machbar, aber vollständige Autonomie nicht garantiert. | Lokale Windows- oder Abhängigkeitsprobleme können Eingriffe des Nutzers erfordern. |
+| 2 | Ogre-14-Port stabilisieren | Machbar eingeschätzt, aber großer Architektur- und Kompatibilitätsbereich ohne belastbare Vollständigkeitsgarantie. | Umfang und Hindernisse müssen zunächst am Code geprüft werden. |
+| 3 | GUI skalierbar machen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer testet insbesondere die Darstellung; eine lokal baubare und startende Spielversion wird für die Ergebnisprüfung benötigt. |
+| 4 | Maus/Cursor sauber lösen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer prüft das Verhalten im Spiel; der konkrete Änderungsumfang ist noch festzulegen. |
+| 5 | UI verständlicher machen | Größtenteils durch Codex umsetzbar eingeschätzt. | Offene Entscheidungen zu Bedienung und Texten müssen geklärt oder ausdrücklich delegiert werden. |
+| 6 | Tutorial / Onboarding | Durch Codex umsetzbar eingeschätzt, sofern Inhalt und Ablauf selbst definiert werden dürfen. | Die dafür notwendige Entscheidungsfreiheit wurde bisher nur als Voraussetzung genannt und noch nicht erteilt. |
+
+## Vorgeschlagener Einstieg
+
+Im Gespräch wurden Aufgabe 3 und 4 als Einstieg für möglichst wenig Eigenaufwand
+vorgeschlagen; das ist noch kein Auftrag zur Umsetzung dieser Aufgaben.
+
+Für die GUI-Skalierung zuerst eine Umgebung herstellen, in der das Spiel lokal
+kompiliert und startet; die besprochenen Voraussetzungen stehen in der
+[Windows-Dokumentation](WINDOWS-DEV-SETUP.md).
+
+## Offene Entscheidungen und Prüfung
+
+Fehlende funktionale, gestalterische oder inhaltliche Entscheidungen werden nicht
+stillschweigend getroffen; sie müssen aus dem Projekt eindeutig hervorgehen, vom
+Nutzer beantwortet oder ausdrücklich an Codex delegiert werden.
+
+Manuelle Spieltests, QA und die visuelle Abnahme übernimmt der Nutzer; Ergebnisse
+und dabei gefundene Fehler werden anschließend gemeinsam ausgewertet.

--- a/docs/development/WINDOWS-BUILD-FIXES.md
+++ b/docs/development/WINDOWS-BUILD-FIXES.md
@@ -117,6 +117,18 @@ linker optimization remain, as does the warning in the Debug linking step about
 combining `/INCREMENTAL` and `/FORCE`. This work fixes the confirmed build failures;
 it does not disable warnings.
 
+## Later GUI-scaling runtime correction
+
+The September 5 settings report required a second maintained CEGUI patch,
+[cegui-ogre-clipping.patch](../../scripts/win32/patches/cegui-ogre-clipping.patch).
+It restores per-batch scissor clipping in the Ogre renderer; it addresses
+rendered controls extending outside their input clip rectangles, rather than a
+compiler error. The CEGUI installer now applies both patches idempotently.
+Release and Debug library builds and installation succeeded, and the rebuilt
+Release renderer DLL was staged with a matching SHA-256. The Release game build
+also succeeded; detailed reproduction, probe coverage and remaining visual
+verification are in [GUI-SCALING.md](GUI-SCALING.md#settings-geometry-and-clipping-correction).
+
 ## Version and scope
 
 The game version remains 0.7.1; this work fixes build errors and does not

--- a/docs/development/WINDOWS-BUILD-FIXES.md
+++ b/docs/development/WINDOWS-BUILD-FIXES.md
@@ -1,125 +1,125 @@
-# Windows-Build: Fehler und Korrekturen
+# Windows build: errors and fixes
 
-Stand: 5. September 2026. Die Fehler wurden beim tatsächlichen Build mit
-Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 und x64
-untersucht. Die verwendeten Bibliotheken und die lokale Umgebung sind in
-[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md) dokumentiert.
+As of September 5, 2026. The errors were investigated during the actual build with
+Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 and x64.
+The libraries used and the local environment are documented in
+[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
 
-## Fenster-Icon: ungeeignete 32-Bit-Schnittstelle
+## Window icon: unsuitable 32-bit interface
 
-Der erste Release-Build scheiterte in [ODApplication.cpp](../../source/ODApplication.cpp)
-beim Setzen des Fenster-Icons:
+The first Release build failed in [ODApplication.cpp](../../source/ODApplication.cpp)
+when setting the window icon:
 
 ```text
-error C2065: GCL_HICON: nichtdeklarierter Bezeichner
-warning C4311 / C4302: Zeigerverkürzung von HICON zu LONG
+error C2065: GCL_HICON: undeclared identifier
+warning C4311 / C4302: pointer truncation from HICON to LONG
 ```
 
-Der betroffene Windows-Code verwendete `SetClassLong`, `GCL_HICON` und eine
-Umwandlung des Icon-Handles in `LONG`. Der installierte Windows-SDK-Header
-`um/WinUser.h` entfernt `GCL_HICON` ausdrücklich bei gesetztem `_WIN64`;
-außerdem ist `LONG` nicht breit genug für einen 64-Bit-Zeiger.
+The affected Windows code used `SetClassLong`, `GCL_HICON` and a
+cast of the icon handle to `LONG`. The installed Windows SDK header
+`um/WinUser.h` explicitly removes `GCL_HICON` when `_WIN64` is defined;
+in addition, `LONG` is not wide enough for a 64-bit pointer.
 
-Die Korrektur verwendet an derselben Stelle `SetClassLongPtr`, `GCLP_HICON`
-und `LONG_PTR`. Das bestehende Icon und der Zeitpunkt seiner Zuweisung bleiben
-erhalten; die Änderung liegt weiterhin ausschließlich im Windows-Codepfad.
+The fix uses `SetClassLongPtr`, `GCLP_HICON`
+and `LONG_PTR` at the same location. The existing icon and the timing of its assignment
+are preserved; the change remains exclusively in the Windows code path.
 
-Nachweis des Ausgangsfehlers: `build/windows/game-Release-initial.log`.
-Die ursprüngliche Buildausgabe bleibt zur Nachvollziehbarkeit lokal erhalten.
+Evidence of the original error: `build/windows/game-Release-initial.log`.
+The original build output is retained locally for traceability.
 
-## CEGUI-Makro verändert Boost-Header
+## CEGUI macro changes Boost headers
 
-Derselbe Build meldete `C2039: _snprintf ist kein Member von std`, unter anderem
-beim Übersetzen von `ODClient.cpp`, `SettingsWindow.cpp` und `ModeManager.cpp`.
-Die Fehlermeldung zeigt auf `boost/assert/source_location.hpp`;
-dort verwendet Boost auf aktuellen MSVC-Versionen korrekt `std::snprintf`.
+The same build reported `C2039: _snprintf is not a member of std`, including
+when compiling `ODClient.cpp`, `SettingsWindow.cpp` and `ModeManager.cpp`.
+The error message points to `boost/assert/source_location.hpp`;
+there, Boost correctly uses `std::snprintf` on current MSVC versions.
 
-Die Ursache liegt im zuvor eingebundenen `CEGUI/PropertyHelper.h` des verwendeten
-CEGUI-Tags: Ein für alle MSVC-Versionen gesetztes Makro ersetzt `snprintf` durch
-`_snprintf` und verändert damit auch den späteren Boost-Code zu `std::_snprintf`.
-Das Projekt selbst definiert dieses Makro nicht.
+The cause is in `CEGUI/PropertyHelper.h` from the CEGUI tag in use, which was included
+earlier: a macro defined for all MSVC versions replaces `snprintf` with
+`_snprintf`, also changing the subsequent Boost code to `std::_snprintf`.
+The project itself does not define this macro.
 
-Der [CEGUI-Patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) begrenzt
-diesen Ersatz auf `_MSC_VER < 1900`; für neuere Compiler bleibt die vorhandene
-Standardfunktion verwendbar. Das
-[Installationsskript](../../scripts/win32/install-cegui-prereq.ps1) wendet den
-Patch vor dem CEGUI-Build an und erkennt einen bereits angewendeten Patch.
-CEGUI wurde anschließend in Release und Debug erfolgreich neu gebaut und
-installiert; der installierte Header ist per SHA-256 mit der gepatchten Quelle
-abgeglichen. Die Erkennung des bereits angewendeten Patches wurde mit
-`git apply --reverse --check` erfolgreich geprüft.
-Protokolle: `build/windows/cegui-rebuild-driver.log` im Projekt und
-`cegui-Release.log` / `cegui-Debug.log` im externen Bibliotheks-Logordner.
+The [CEGUI patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) limits
+this replacement to `_MSC_VER < 1900`; for newer compilers, the existing
+standard function remains usable. The
+[installation script](../../scripts/win32/install-cegui-prereq.ps1) applies the
+patch before the CEGUI build and recognizes a patch that has already been applied.
+CEGUI was subsequently rebuilt and installed successfully in Release and Debug;
+the installed header has been compared with the patched source using SHA-256.
+Detection of the already-applied patch was successfully verified with
+`git apply --reverse --check`.
+Logs: `build/windows/cegui-rebuild-driver.log` in the project and
+`cegui-Release.log` / `cegui-Debug.log` in the external library log directory.
 
-## Boost-Linkerpfad zeigt in den Headerordner
+## Boost linker path points to the header directory
 
-Nach den beiden Compilerkorrekturen erreichte Release den Linker und scheiterte
-mit `LNK1104` für `libboost_filesystem-vc143-mt-x64-1_82.lib`.
-Die passende Datei war installiert und im CMake-Cache bereits korrekt gefunden.
-Das generierte Visual-Studio-Projekt enthielt jedoch als zusätzlichen Suchpfad
-`include/boost-1_82/stage/lib`, wo diese Bibliothek nicht liegt.
+After the two compiler fixes, Release reached the linker and failed
+with `LNK1104` for `libboost_filesystem-vc143-mt-x64-1_82.lib`.
+The matching file was installed and had already been found correctly in the CMake cache.
+However, the generated Visual Studio project contained the additional search path
+`include/boost-1_82/stage/lib`, where this library is not located.
 
-Ursache war in [CMakeLists.txt](../../CMakeLists.txt) die Ableitung des
-MSVC-Linkerpfads aus `Boost_INCLUDE_DIRS`. Stattdessen wird jetzt das von
-der Paketsuche ermittelte `Boost_LIBRARY_DIRS` verwendet; so benötigt die
-Korrektur keinen rechnerabhängigen Pfad und erhält die bisherige automatische
-Boost-Verknüpfung unter MSVC.
-Nachweis des Linkerfehlers: `build/windows/game-Release-pass1.log`.
+The cause in [CMakeLists.txt](../../CMakeLists.txt) was deriving the
+MSVC linker path from `Boost_INCLUDE_DIRS`. It now uses
+`Boost_LIBRARY_DIRS`, determined by the package search, instead; this means the
+fix does not require a computer-specific path and preserves the existing automatic
+Boost linking under MSVC.
+Evidence of the linker error: `build/windows/game-Release-pass1.log`.
 
-## Python-Debug-Bibliothek und Headerauswahl widersprechen sich
+## Python debug library and header selection conflict
 
-Der vollständige Debug-Compilerlauf war erfolgreich, der Linker brach jedoch
-mit `LNK1104` für `python310.lib` ab. CMake hatte bereits die vorhandene
-`python310_d.lib` als explizite Debug-Abhängigkeit eingetragen.
+The full Debug compiler run succeeded, but the linker aborted
+with `LNK1104` for `python310.lib`. CMake had already added the existing
+`python310_d.lib` as an explicit Debug dependency.
 
-`pybind11/detail/common.h` setzt beim Einbinden von Python unter MSVC das Makro
-`_DEBUG` vorübergehend außer Kraft, solange `Py_DEBUG` nicht definiert ist.
-Dadurch erzeugt `Python/include/pyconfig.h` eine zusätzliche automatische
-Linkanforderung für `python310.lib`, obwohl CMake die Debug-Bibliothek auswählt.
+When including Python under MSVC, `pybind11/detail/common.h` temporarily
+undefines the `_DEBUG` macro unless `Py_DEBUG` is defined.
+As a result, `Python/include/pyconfig.h` generates an additional automatic
+link request for `python310.lib`, even though CMake selects the debug library.
 
-Wenn eine Python-Debug-Bibliothek konfiguriert ist und pybind11 den Debug-Modus
-nicht bereits aktiviert hat, definiert das Spieltarget unter MSVC deshalb
-`Py_DEBUG` ausschließlich für die Debug-Konfiguration.
-Der leere Makrowert entspricht der Definition im Windows-Python-Header;
-Release und Konfigurationen ohne gefundene Debug-Bibliothek bleiben unverändert.
-Damit werden Header und Bibliotheksvariante konsistent ausgewählt, statt die
-gleichzeitige Verwendung beider Varianten durch einen zusätzlichen Suchpfad zu ermöglichen.
-Nachweis: `build/windows/game-Debug-pass2.log`.
+If a Python debug library is configured and pybind11 has not already
+activated debug mode, the game target under MSVC therefore defines
+`Py_DEBUG` exclusively for the Debug configuration.
+The empty macro value matches the definition in the Windows Python header;
+Release and configurations without a detected debug library remain unchanged.
+This selects headers and the library variant consistently instead of allowing
+both variants to be used simultaneously through an additional search path.
+Evidence: `build/windows/game-Debug-pass2.log`.
 
-## Verifikation
+## Verification
 
-Nach erneutem Konfigurieren enthält das generierte Visual-Studio-Projekt für
-Release und Debug den tatsächlichen Boost-Library-Ordner.
+After reconfiguring, the generated Visual Studio project contains the
+actual Boost library directory for Release and Debug.
 
-| Prüfung | Ergebnis / Nachweis |
+| Check | Result / evidence |
 | --- | --- |
-| CEGUI mit Patch, Release und Debug | Erfolgreich gebaut und installiert; Treiberprotokoll `build/windows/cegui-rebuild-driver.log` |
-| Spiel Release nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Release-pass3.log`, Ausgabe `build/windows/opendungeons-plus.exe` |
-| Spiel Debug nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Debug-pass3.log`, Ausgabe `build/windows/opendungeons-plus_d.exe` |
-| Binärdateien | PE-Kennung und AMD64-Maschinenkennung beider erzeugter Programme geprüft |
-| Python-Varianten | Statische Importprüfung: Release verwendet ausschließlich `python310.dll`, Debug ausschließlich `python310_d.dll` als Python-Laufzeit; `build/windows/game-Release-dependencies.log` und `game-Debug-dependencies.log` |
+| CEGUI with patch, Release and Debug | Successfully built and installed; driver log `build/windows/cegui-rebuild-driver.log` |
+| Release game build after all four fixes | Exit code 0, `build/windows/game-Release-pass3.log`, output `build/windows/opendungeons-plus.exe` |
+| Debug game build after all four fixes | Exit code 0, `build/windows/game-Debug-pass3.log`, output `build/windows/opendungeons-plus_d.exe` |
+| Binaries | PE signature and AMD64 machine identifier checked for both generated programs |
+| Python variants | Static import check: Release uses only `python310.dll`, Debug only `python310_d.dll` as the Python runtime; `build/windows/game-Release-dependencies.log` and `game-Debug-dependencies.log` |
 
-Beide abschließenden Buildprotokolle enthalten keine Compiler- oder Linkerfehler.
-Die vorherigen Fehlversuche bleiben bewusst als getrennte Protokolle erhalten.
-Die Python-DLL-Prüfung erfolgte mit `dumpbin /dependents` auf beiden Programmen;
-es wurde keine Spielinstanz gestartet.
+Both final build logs contain no compiler or linker errors.
+The earlier failed attempts are deliberately retained as separate logs.
+The Python DLL check was performed with `dumpbin /dependents` on both programs;
+no game instance was started.
 
-Die Spielbuilds werden über `cmake --build build/windows --config Release --parallel 4`
-bzw. dieselbe Anweisung mit `--config Debug` ausgeführt, nach dem Konfigurieren
-mit dem [Windows-Konfigurationsskript](../../scripts/win32/configure-windows-prereqs.ps1).
-Spielstart, manuelle QA und die sichtbare Darstellung des Icons sind davon
-getrennte Prüfungen durch den Nutzer.
+The game builds are run using `cmake --build build/windows --config Release --parallel 4`
+or the same command with `--config Debug`, after configuring
+with the [Windows configuration script](../../scripts/win32/configure-windows-prereqs.ps1).
+Game startup, manual QA and the visible appearance of the icon are
+separate checks performed by the user.
 
-Die Builds sind nicht warnungsfrei: Unter anderem
-bleiben Warnungen zu numerischen Konvertierungen, die veraltete Option `/Gm` und
-im Release-Linkschritt `LNK4075` zur Kombination von Edit-and-Continue mit
-Linkeroptimierung sowie im Debug-Linkschritt zur Kombination von `/INCREMENTAL`
-und `/FORCE` bestehen. Diese Arbeit behebt die nachgewiesenen Buildabbrüche;
-sie schaltet keine Warnungen ab.
+The builds are not warning-free: among other things,
+warnings about numeric conversions, the deprecated `/Gm` option and,
+in the Release linking step, `LNK4075` for combining Edit-and-Continue with
+linker optimization remain, as does the warning in the Debug linking step about
+combining `/INCREMENTAL` and `/FORCE`. This work fixes the confirmed build failures;
+it does not disable warnings.
 
-## Version und Umfang
+## Version and scope
 
-Die Spielversion bleibt 0.7.1; diese Arbeit behebt Buildfehler und veröffentlicht
-keine neue Spielversion. Die technische Änderung wird zusammen mit diesem
-Fehlerprotokoll committed; lokale Status- und Einstiegshinweise werden in einem
-separaten Dokumentationscommit aktualisiert.
+The game version remains 0.7.1; this work fixes build errors and does not
+publish a new game version. The technical change is committed together with this
+error log; local status and getting-started notes are updated in a
+separate documentation commit.

--- a/docs/development/WINDOWS-BUILD-FIXES.md
+++ b/docs/development/WINDOWS-BUILD-FIXES.md
@@ -1,0 +1,125 @@
+# Windows-Build: Fehler und Korrekturen
+
+Stand: 5. September 2026. Die Fehler wurden beim tatsächlichen Build mit
+Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 und x64
+untersucht. Die verwendeten Bibliotheken und die lokale Umgebung sind in
+[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md) dokumentiert.
+
+## Fenster-Icon: ungeeignete 32-Bit-Schnittstelle
+
+Der erste Release-Build scheiterte in [ODApplication.cpp](../../source/ODApplication.cpp)
+beim Setzen des Fenster-Icons:
+
+```text
+error C2065: GCL_HICON: nichtdeklarierter Bezeichner
+warning C4311 / C4302: Zeigerverkürzung von HICON zu LONG
+```
+
+Der betroffene Windows-Code verwendete `SetClassLong`, `GCL_HICON` und eine
+Umwandlung des Icon-Handles in `LONG`. Der installierte Windows-SDK-Header
+`um/WinUser.h` entfernt `GCL_HICON` ausdrücklich bei gesetztem `_WIN64`;
+außerdem ist `LONG` nicht breit genug für einen 64-Bit-Zeiger.
+
+Die Korrektur verwendet an derselben Stelle `SetClassLongPtr`, `GCLP_HICON`
+und `LONG_PTR`. Das bestehende Icon und der Zeitpunkt seiner Zuweisung bleiben
+erhalten; die Änderung liegt weiterhin ausschließlich im Windows-Codepfad.
+
+Nachweis des Ausgangsfehlers: `build/windows/game-Release-initial.log`.
+Die ursprüngliche Buildausgabe bleibt zur Nachvollziehbarkeit lokal erhalten.
+
+## CEGUI-Makro verändert Boost-Header
+
+Derselbe Build meldete `C2039: _snprintf ist kein Member von std`, unter anderem
+beim Übersetzen von `ODClient.cpp`, `SettingsWindow.cpp` und `ModeManager.cpp`.
+Die Fehlermeldung zeigt auf `boost/assert/source_location.hpp`;
+dort verwendet Boost auf aktuellen MSVC-Versionen korrekt `std::snprintf`.
+
+Die Ursache liegt im zuvor eingebundenen `CEGUI/PropertyHelper.h` des verwendeten
+CEGUI-Tags: Ein für alle MSVC-Versionen gesetztes Makro ersetzt `snprintf` durch
+`_snprintf` und verändert damit auch den späteren Boost-Code zu `std::_snprintf`.
+Das Projekt selbst definiert dieses Makro nicht.
+
+Der [CEGUI-Patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) begrenzt
+diesen Ersatz auf `_MSC_VER < 1900`; für neuere Compiler bleibt die vorhandene
+Standardfunktion verwendbar. Das
+[Installationsskript](../../scripts/win32/install-cegui-prereq.ps1) wendet den
+Patch vor dem CEGUI-Build an und erkennt einen bereits angewendeten Patch.
+CEGUI wurde anschließend in Release und Debug erfolgreich neu gebaut und
+installiert; der installierte Header ist per SHA-256 mit der gepatchten Quelle
+abgeglichen. Die Erkennung des bereits angewendeten Patches wurde mit
+`git apply --reverse --check` erfolgreich geprüft.
+Protokolle: `build/windows/cegui-rebuild-driver.log` im Projekt und
+`cegui-Release.log` / `cegui-Debug.log` im externen Bibliotheks-Logordner.
+
+## Boost-Linkerpfad zeigt in den Headerordner
+
+Nach den beiden Compilerkorrekturen erreichte Release den Linker und scheiterte
+mit `LNK1104` für `libboost_filesystem-vc143-mt-x64-1_82.lib`.
+Die passende Datei war installiert und im CMake-Cache bereits korrekt gefunden.
+Das generierte Visual-Studio-Projekt enthielt jedoch als zusätzlichen Suchpfad
+`include/boost-1_82/stage/lib`, wo diese Bibliothek nicht liegt.
+
+Ursache war in [CMakeLists.txt](../../CMakeLists.txt) die Ableitung des
+MSVC-Linkerpfads aus `Boost_INCLUDE_DIRS`. Stattdessen wird jetzt das von
+der Paketsuche ermittelte `Boost_LIBRARY_DIRS` verwendet; so benötigt die
+Korrektur keinen rechnerabhängigen Pfad und erhält die bisherige automatische
+Boost-Verknüpfung unter MSVC.
+Nachweis des Linkerfehlers: `build/windows/game-Release-pass1.log`.
+
+## Python-Debug-Bibliothek und Headerauswahl widersprechen sich
+
+Der vollständige Debug-Compilerlauf war erfolgreich, der Linker brach jedoch
+mit `LNK1104` für `python310.lib` ab. CMake hatte bereits die vorhandene
+`python310_d.lib` als explizite Debug-Abhängigkeit eingetragen.
+
+`pybind11/detail/common.h` setzt beim Einbinden von Python unter MSVC das Makro
+`_DEBUG` vorübergehend außer Kraft, solange `Py_DEBUG` nicht definiert ist.
+Dadurch erzeugt `Python/include/pyconfig.h` eine zusätzliche automatische
+Linkanforderung für `python310.lib`, obwohl CMake die Debug-Bibliothek auswählt.
+
+Wenn eine Python-Debug-Bibliothek konfiguriert ist und pybind11 den Debug-Modus
+nicht bereits aktiviert hat, definiert das Spieltarget unter MSVC deshalb
+`Py_DEBUG` ausschließlich für die Debug-Konfiguration.
+Der leere Makrowert entspricht der Definition im Windows-Python-Header;
+Release und Konfigurationen ohne gefundene Debug-Bibliothek bleiben unverändert.
+Damit werden Header und Bibliotheksvariante konsistent ausgewählt, statt die
+gleichzeitige Verwendung beider Varianten durch einen zusätzlichen Suchpfad zu ermöglichen.
+Nachweis: `build/windows/game-Debug-pass2.log`.
+
+## Verifikation
+
+Nach erneutem Konfigurieren enthält das generierte Visual-Studio-Projekt für
+Release und Debug den tatsächlichen Boost-Library-Ordner.
+
+| Prüfung | Ergebnis / Nachweis |
+| --- | --- |
+| CEGUI mit Patch, Release und Debug | Erfolgreich gebaut und installiert; Treiberprotokoll `build/windows/cegui-rebuild-driver.log` |
+| Spiel Release nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Release-pass3.log`, Ausgabe `build/windows/opendungeons-plus.exe` |
+| Spiel Debug nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Debug-pass3.log`, Ausgabe `build/windows/opendungeons-plus_d.exe` |
+| Binärdateien | PE-Kennung und AMD64-Maschinenkennung beider erzeugter Programme geprüft |
+| Python-Varianten | Statische Importprüfung: Release verwendet ausschließlich `python310.dll`, Debug ausschließlich `python310_d.dll` als Python-Laufzeit; `build/windows/game-Release-dependencies.log` und `game-Debug-dependencies.log` |
+
+Beide abschließenden Buildprotokolle enthalten keine Compiler- oder Linkerfehler.
+Die vorherigen Fehlversuche bleiben bewusst als getrennte Protokolle erhalten.
+Die Python-DLL-Prüfung erfolgte mit `dumpbin /dependents` auf beiden Programmen;
+es wurde keine Spielinstanz gestartet.
+
+Die Spielbuilds werden über `cmake --build build/windows --config Release --parallel 4`
+bzw. dieselbe Anweisung mit `--config Debug` ausgeführt, nach dem Konfigurieren
+mit dem [Windows-Konfigurationsskript](../../scripts/win32/configure-windows-prereqs.ps1).
+Spielstart, manuelle QA und die sichtbare Darstellung des Icons sind davon
+getrennte Prüfungen durch den Nutzer.
+
+Die Builds sind nicht warnungsfrei: Unter anderem
+bleiben Warnungen zu numerischen Konvertierungen, die veraltete Option `/Gm` und
+im Release-Linkschritt `LNK4075` zur Kombination von Edit-and-Continue mit
+Linkeroptimierung sowie im Debug-Linkschritt zur Kombination von `/INCREMENTAL`
+und `/FORCE` bestehen. Diese Arbeit behebt die nachgewiesenen Buildabbrüche;
+sie schaltet keine Warnungen ab.
+
+## Version und Umfang
+
+Die Spielversion bleibt 0.7.1; diese Arbeit behebt Buildfehler und veröffentlicht
+keine neue Spielversion. Die technische Änderung wird zusammen mit diesem
+Fehlerprotokoll committed; lokale Status- und Einstiegshinweise werden in einem
+separaten Dokumentationscommit aktualisiert.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,63 +1,124 @@
 # Windows-Entwicklungsumgebung
 
-Stand: 5. September 2026. Diese Notiz hält die besprochene Vorbereitung für
-Aufgabe 3, GUI-Skalierung, fest; sie ist noch keine praktisch verifizierte
-Installations- oder Build-Anleitung.
+Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
+Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
+CMake-Konfiguration des Spiels waren erfolgreich.
+Der vollständige Spielbuild, Spielstart und die Paketierung sind noch ungeprüft.
 
-## Reicht VS Code allein?
+## Einstieg und Zuständigkeit der Dateien
 
-Nein. VS Code dient als Editor; um die Änderungen im Spiel zu prüfen, müssen
-zusätzlich Compiler, Build-Werkzeuge und Projektabhängigkeiten verfügbar sein,
-sodass das Spiel lokal kompiliert und startet.
+Diese Dokumentation und die Skripte unter [scripts/win32](../../scripts/win32)
+sind der gepflegte Projektbezug zur externen Installation.
+Für die tägliche Arbeit [BUILDING.md](BUILDING.md) verwenden;
+Quellen und Neuaufbau stehen in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
+[AGENTS.md](../../AGENTS.md) verweist neue Agentensitzungen auf diese Dateien.
 
-## Im Gespräch vorgeschlagene Werkzeuge
+Die großen Downloads, Bibliotheksquellen und kompilierten Dateien liegen außerhalb
+des Git-Repositories, damit sie unabhängig vom Arbeitsbranch wiederverwendbar sind.
+Die Skripte enthalten bewusst die konkreten Pfade dieser lokalen Installation;
+auf einem anderen Rechner müssen diese Pfade geprüft und angepasst werden.
+VS Code ist der Editor; Compiler, SDK und Bibliotheken werden zusätzlich benötigt.
 
-- VS Code als Editor.
-- Git für die Versionsverwaltung.
-- CMake für die Build-Konfiguration.
-- Visual Studio 2022 Build Tools mit dem Workload "Desktop development with C++",
-  MSVC-Compiler und Windows SDK.
-- Der lokale Klon des eigenen OpenDungeonsPlus-Forks.
+## Speicherorte
 
-Visual Studio 2022 wurde im Gespräch vorgeschlagen; eine funktionierende
-Kombination mit diesem Projekt und seinen Abhängigkeiten ist noch nicht bestätigt.
-Die vorhandene [Windows-Build-Konfiguration](../../appveyor.yml) enthält stattdessen
-ältere Einträge für Visual Studio 12 und MinGW, die keinen erfolgreichen Build mit
-Visual Studio 2022 belegen.
+| Zweck | Tatsächlicher Pfad |
+| --- | --- |
+| Projekt | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
+| Externer Entwicklungsordner | `C:\Users\mario\od-deps` |
+| Installationspräfix der Bibliotheken | `C:\Users\mario\od-deps\install` |
+| Header / Linkbibliotheken / DLLs | Unter `install\include`, `install\lib`, `install\bin`; einige DLLs liegen auch unter `install\lib` |
+| Bibliotheksquellen | `C:\Users\mario\od-deps\src` |
+| Bibliotheksbuilds | `C:\Users\mario\od-deps\build` |
+| Archive und Prüfsummen | `C:\Users\mario\od-deps\downloads` |
+| Konfigurations- und Bibliotheksprotokolle | `C:\Users\mario\od-deps\logs` |
+| CMake | `C:\Users\mario\od-deps\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` |
+| Visual Studio Build Tools | `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools` |
+| Python | `C:\Users\mario\AppData\Local\Programs\Python\Python310` |
+| 7-Zip für die Quellarchive | `C:\Users\mario\scoop\shims\7z.exe` |
+| Generierter Spielbuild | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
+| Vorgesehener Installationsordner des Spiels | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (noch nicht installiert) |
 
-## Im aktuellen Build-Code bestätigte Abhängigkeiten
+Unter `od-deps\setup-scripts`, `od-deps\Enter-OpenDungeonsPlus.ps1`,
+`od-deps\INSTALLATION.md` und dem ignorierten Projektordner `build` liegen noch
+Kopien aus der Installation; für weitere Arbeit die gepflegten Projektdateien
+verwenden, da die alten Kopien nicht automatisch aktualisiert werden.
+Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Installation.
 
-Die [Build-Datei](../../CMakeLists.txt) sucht folgende Bibliotheken:
+## Installierter Stand
 
-- OGRE, einschließlich der vom Spiel verknüpften Komponenten.
-- CEGUI einschließlich des OGRE-Renderers.
-- SFML.
-- OIS.
-- Boost.
-- Python-Entwicklungsbibliotheken und Header.
-- pybind11 für die Python-Einbettung.
+| Komponente | Version / Konfiguration |
+| --- | --- |
+| Visual Studio 2022 Build Tools | 17.14.39, MSVC-Toolsetordner 14.44.35207, von CMake erkannter Compiler 19.44.35228.0, Ziel und Host x64 |
+| Windows SDK | 10.0.26100.0 |
+| CMake | 3.31.8, portable Installation |
+| Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
+| OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
+| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer und Expat |
+| OIS | 1.5.1 |
+| SFML | 2.5.1 |
+| Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
+| pybind11 | 2.10.4 |
+| FreeType | 2.12.1 |
+| Expat | 2.8.4 |
+| PCRE | 8.45 mit UTF und Unicode-Properties |
 
-Die Build-Datei nennt CMake 3.5 als Mindestversion, prüft OGRE ab 1.9 und CEGUI ab
-0.8 und sucht SFML 2. Diese Angaben beschreiben die vorhandenen Build-Prüfungen;
-sie belegen keine konkret funktionierende Kombination aktueller Paketversionen
-und keinen stabilen Ogre-14-Port.
+Die kompilierten Bibliotheken liegen für x64 in Release und Debug vor;
+Boost zusätzlich statisch und dynamisch, jeweils mit dynamischer C++-Laufzeit.
+pybind11 stellt Header und CMake-Konfiguration bereit.
+Git, VS Code, 7-Zip und eine passende Visual-C++-Laufzeit waren bereits vorhanden.
 
-## Im Gespräch genannte optionale Ergänzungen
+OGRE, CEGUI, OIS, SFML und Python 3.10 orientieren sich an der vorhandenen
+[Snap-Baurezeptur](../../snap/snapcraft.yaml); die konkreten Windows-Optionen stehen
+in den Skripten. Dies dokumentiert OGRE 13.6.5 und belegt keinen Ogre-14-Port.
+Die älteren allgemeinen Angaben in README und AppVeyor ersetzen diesen lokalen Stand nicht.
 
-- CMake Tools für VS Code.
-- C/C++-Erweiterung für VS Code.
-- Codex in VS Code.
+## Wie Projekt und externe Installation zusammenfinden
 
-## Noch zu prüfen
+[Enter-OpenDungeonsPlus.ps1](../../scripts/win32/Enter-OpenDungeonsPlus.ps1)
+lädt die Visual-Studio-Entwicklungsumgebung für x64 und setzt in der aktuellen
+PowerShell-Sitzung:
 
-- Welche Werkzeuge und Abhängigkeiten auf dem Rechner bereits installiert sind.
-- Welche konkreten Versionen, Compiler und Zielarchitektur zusammen funktionieren.
-- Wie die Abhängigkeiten für diese Kombination bereitgestellt und gefunden werden.
-- Ob das Spiel damit tatsächlich gebaut und gestartet werden kann.
+- `PATH` für CMake, Bibliotheks-DLLs und Python.
+- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` und `OIS_HOME` auf `od-deps\install`.
+- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` auf die installierten Boost-Dateien.
+- `LIB` zusätzlich auf `od-deps\install\lib` für MSVCs automatische Verknüpfung.
 
-Die Bibliotheksliste wurde statisch mit dem Repository abgeglichen; im Rahmen
-dieser Dokumentation wurden keine Programme installiert und keine Builds oder
-Spieltests gestartet.
+CMake wurde bei der Installation außerdem dem Benutzer-PATH hinzugefügt;
+für einen eindeutigen Build trotzdem den Starthelfer laden.
+Die Compilerinitialisierung verwendet unter den Build Tools
+`Common7\Tools\Microsoft.VisualStudio.DevShell.dll`;
+Boost verwendet zusätzlich `VC\Auxiliary\Build\vcvarsall.bat`.
+Der Compiler liegt dort unter
+`VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\cl.exe`.
 
-Sobald ein funktionierender Ablauf feststeht, die tatsächlich verwendeten Versionen
-und Build-Schritte in einer eigenen Build-Anleitung festhalten und hier verlinken.
+[configure-windows-prereqs.ps1](../../scripts/win32/configure-windows-prereqs.ps1)
+ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
+benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
+Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
+und deaktiviert die Testtargets. Die Spielquellen und `CMakeLists.txt` wurden für
+diese Einrichtung nicht geändert.
+
+## Überprüft und noch offen
+
+| Schritt | Stand / Nachweis |
+| --- | --- |
+| Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
+| Bibliotheken bauen und installieren | Release und Debug erfolgreich; Protokolle unter `od-deps\logs` |
+| Unverändertes Spiel konfigurieren | Erfolgreich; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
+| Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
+| Spiel kompilieren | Noch nicht ausgeführt; Befehle in [BUILDING.md](BUILDING.md) |
+| Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
+| Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
+
+CMake hat Python, pybind11, OIS, OGRE, CEGUI samt OgreRenderer, SFML und die
+benötigten Boost-Linkbibliotheken gefunden. Die Meldung
+`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` betrifft die separate DLL-Suche für die
+Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
+Installationspaket ableiten.
+Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
+MSVC 19.44.35228.0; die Generierung gelingt trotzdem, die tatsächliche
+Verknüpfung des Spiels bleibt bis zum ersten Spielbuild ungeprüft.
+
+Für die Fortsetzung zuerst den Spielbuild durchführen, sobald er beauftragt ist,
+und dessen tatsächliches Ergebnis hier nachtragen; erst danach kann die Umgebung
+als für das Spiel vollständig geprüft gelten.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -3,8 +3,13 @@
 As of September 5, 2026, Mario's local computer, Windows x64.
 The prerequisites are installed; their library builds and the game's
 CMake configuration succeeded.
-The Release and Debug game builds succeeded after four targeted fixes;
-game startup and packaging remain unverified.
+The Release and Debug game builds succeeded after four targeted fixes.
+The Release runtime files are now staged for testing the executable directly
+from File Explorer. The user's startup attempts exposed incorrect handling of
+absolute Windows resource paths; both builds now include the correction.
+A subsequent Release run loaded the main-menu scene and shut down normally
+without the earlier errors; the user confirmed that direct Release startup works
+without errors. Broader gameplay tests and packaging remain unverified.
 
 ## Entry point and file responsibilities
 
@@ -110,7 +115,9 @@ from the actual compilation are recorded in the [build error log](WINDOWS-BUILD-
 | Configuration using the scripts added to the project | Successfully rerun, also from `docs\development`; the project path and adjacent environment helper are resolved correctly |
 | Compile the game | Release and Debug successful with exit code 0; commands in [BUILDING.md](BUILDING.md), evidence in the [build error log](WINDOWS-BUILD-FIXES.md) |
 | Check generated programs | Both files have the AMD64 PE signature; Release imports only `python310.dll`, Debug only `python310_d.dll` as the Python runtime |
-| Start the game, test GUI and cursor | Not yet verified; manual QA by the user |
+| Prepare direct Release startup | 22 DLLs staged beside the executable, Python module paths recorded locally and OGRE media paths corrected; static checks of 23 PE files, four plugins and 14 resource directories passed; see [BUILDING.md](BUILDING.md) and `build\windows\runtime-validation.json` |
+| Start the Release game directly | User confirmed error-free startup after the path fix; the 14:07 logs show main-menu scene loading and normal shutdown without the earlier loading errors; see [startup fixes](WINDOWS-STARTUP-FIXES.md) |
+| Test gameplay, GUI and cursor | Broader manual gameplay and visual QA remain with the user |
 | Create an installation package | Not yet verified; older packaging logic cannot find some expected Boost DLL names |
 
 CMake found Python, pybind11, OIS, OGRE, CEGUI including OgreRenderer, SFML and the
@@ -124,5 +131,10 @@ after correcting the Boost search path described in the
 [build error log](WINDOWS-BUILD-FIXES.md).
 
 The build errors are fixed; existing compiler/linker warnings are recorded in the
-build error log. Runtime verification by the user is next;
-successful builds do not replace this check.
+build error log. The configuration script now also runs
+[prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1)
+to stage the local Release runtime without requiring a prepared shell for startup.
+Debug runtime staging is still pending; its generated plugin list also mixes
+Debug plugins with Release variants of Codec_STBI and RenderSystem_GL3Plus.
+Direct Release startup is verified by the user's confirmation and runtime logs;
+broader gameplay tests remain with the user.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -9,7 +9,13 @@ from File Explorer. The user's startup attempts exposed incorrect handling of
 absolute Windows resource paths; both builds now include the correction.
 A subsequent Release run loaded the main-menu scene and shut down normally
 without the earlier errors; the user confirmed that direct Release startup works
-without errors. Broader gameplay tests and packaging remain unverified.
+without errors. Enabling dynamic shadows later exposed a separate resource-group
+failure: the resource template now also registers OGRE's Main media in its internal
+group, retaining the existing Graphics registration for shader includes.
+Reconfiguration and the headless OGRE resource test succeeded; actual startup
+verification with shadows enabled is pending; see
+[startup fixes](WINDOWS-STARTUP-FIXES.md).
+Broader gameplay tests and packaging remain unverified.
 
 ## Entry point and file responsibilities
 

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -3,7 +3,8 @@
 Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
 Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
 CMake-Konfiguration des Spiels waren erfolgreich.
-Der vollständige Spielbuild, Spielstart und die Paketierung sind noch ungeprüft.
+Die Spielbuilds für Release und Debug sind nach vier gezielten Korrekturen
+erfolgreich; Spielstart und Paketierung bleiben ungeprüft.
 
 ## Einstieg und Zuständigkeit der Dateien
 
@@ -53,7 +54,7 @@ Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Inst
 | CMake | 3.31.8, portable Installation |
 | Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
 | OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
-| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer und Expat |
+| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer, Expat und dem gespeicherten MSVC-Kompatibilitätspatch |
 | OIS | 1.5.1 |
 | SFML | 2.5.1 |
 | Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
@@ -95,18 +96,20 @@ Der Compiler liegt dort unter
 ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
 benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
 Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
-und deaktiviert die Testtargets. Die Spielquellen und `CMakeLists.txt` wurden für
-diese Einrichtung nicht geändert.
+und deaktiviert die Testtargets. Bei der ursprünglichen Einrichtung wurden die
+Spielquellen und `CMakeLists.txt` nicht geändert; die anschließenden Korrekturen
+aus der tatsächlichen Kompilierung stehen im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md).
 
 ## Überprüft und noch offen
 
 | Schritt | Stand / Nachweis |
 | --- | --- |
 | Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
-| Bibliotheken bauen und installieren | Release und Debug erfolgreich; Protokolle unter `od-deps\logs` |
-| Unverändertes Spiel konfigurieren | Erfolgreich; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
+| Bibliotheken bauen und installieren | Release und Debug erfolgreich; CEGUI anschließend mit dem gespeicherten MSVC-Patch neu gebaut und installiert; Protokolle unter `od-deps\logs` |
+| Spiel konfigurieren | Mit den Buildkorrekturen erfolgreich erneut konfiguriert; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
 | Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
-| Spiel kompilieren | Noch nicht ausgeführt; Befehle in [BUILDING.md](BUILDING.md) |
+| Spiel kompilieren | Release und Debug erfolgreich mit Exitcode 0; Befehle in [BUILDING.md](BUILDING.md), Nachweise im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) |
+| Erzeugte Programme prüfen | Beide Dateien tragen die AMD64-PE-Kennung; Release importiert nur `python310.dll`, Debug nur `python310_d.dll` als Python-Laufzeit |
 | Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
 | Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
 
@@ -116,9 +119,10 @@ benötigten Boost-Linkbibliotheken gefunden. Die Meldung
 Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
 Installationspaket ableiten.
 Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
-MSVC 19.44.35228.0; die Generierung gelingt trotzdem, die tatsächliche
-Verknüpfung des Spiels bleibt bis zum ersten Spielbuild ungeprüft.
+MSVC 19.44.35228.0; die Generierung und beide Linkschritte gelingen trotzdem,
+nachdem der im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) beschriebene
+Boost-Suchpfad korrigiert wurde.
 
-Für die Fortsetzung zuerst den Spielbuild durchführen, sobald er beauftragt ist,
-und dessen tatsächliches Ergebnis hier nachtragen; erst danach kann die Umgebung
-als für das Spiel vollständig geprüft gelten.
+Die Buildfehler sind behoben; vorhandene Compiler-/Linkerwarnungen sind im
+Buildfehlerprotokoll festgehalten. Als Nächstes steht die Laufzeitprüfung durch
+den Nutzer an; erfolgreiche Builds ersetzen diese Prüfung nicht.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,128 +1,128 @@
-# Windows-Entwicklungsumgebung
+# Windows development environment
 
-Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
-Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
-CMake-Konfiguration des Spiels waren erfolgreich.
-Die Spielbuilds für Release und Debug sind nach vier gezielten Korrekturen
-erfolgreich; Spielstart und Paketierung bleiben ungeprüft.
+As of September 5, 2026, Mario's local computer, Windows x64.
+The prerequisites are installed; their library builds and the game's
+CMake configuration succeeded.
+The Release and Debug game builds succeeded after four targeted fixes;
+game startup and packaging remain unverified.
 
-## Einstieg und Zuständigkeit der Dateien
+## Entry point and file responsibilities
 
-Diese Dokumentation und die Skripte unter [scripts/win32](../../scripts/win32)
-sind der gepflegte Projektbezug zur externen Installation.
-Für die tägliche Arbeit [BUILDING.md](BUILDING.md) verwenden;
-Quellen und Neuaufbau stehen in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
-[AGENTS.md](../../AGENTS.md) verweist neue Agentensitzungen auf diese Dateien.
+This documentation and the scripts under [scripts/win32](../../scripts/win32)
+are the maintained connection between the project and the external installation.
+Use [BUILDING.md](BUILDING.md) for daily work;
+sources and rebuilding are covered in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
+[AGENTS.md](../../AGENTS.md) directs new agent sessions to these files.
 
-Die großen Downloads, Bibliotheksquellen und kompilierten Dateien liegen außerhalb
-des Git-Repositories, damit sie unabhängig vom Arbeitsbranch wiederverwendbar sind.
-Die Skripte enthalten bewusst die konkreten Pfade dieser lokalen Installation;
-auf einem anderen Rechner müssen diese Pfade geprüft und angepasst werden.
-VS Code ist der Editor; Compiler, SDK und Bibliotheken werden zusätzlich benötigt.
+The large downloads, library sources and compiled files are stored outside
+the Git repository so they can be reused independently of the work branch.
+The scripts deliberately contain the specific paths of this local installation;
+on another computer, these paths must be checked and adjusted.
+VS Code is the editor; the compiler, SDK and libraries are also required.
 
-## Speicherorte
+## Locations
 
-| Zweck | Tatsächlicher Pfad |
+| Purpose | Actual path |
 | --- | --- |
-| Projekt | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
-| Externer Entwicklungsordner | `C:\Users\mario\od-deps` |
-| Installationspräfix der Bibliotheken | `C:\Users\mario\od-deps\install` |
-| Header / Linkbibliotheken / DLLs | Unter `install\include`, `install\lib`, `install\bin`; einige DLLs liegen auch unter `install\lib` |
-| Bibliotheksquellen | `C:\Users\mario\od-deps\src` |
-| Bibliotheksbuilds | `C:\Users\mario\od-deps\build` |
-| Archive und Prüfsummen | `C:\Users\mario\od-deps\downloads` |
-| Konfigurations- und Bibliotheksprotokolle | `C:\Users\mario\od-deps\logs` |
+| Project | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
+| External development directory | `C:\Users\mario\od-deps` |
+| Library installation prefix | `C:\Users\mario\od-deps\install` |
+| Headers / link libraries / DLLs | Under `install\include`, `install\lib`, `install\bin`; some DLLs are also under `install\lib` |
+| Library sources | `C:\Users\mario\od-deps\src` |
+| Library builds | `C:\Users\mario\od-deps\build` |
+| Archives and checksums | `C:\Users\mario\od-deps\downloads` |
+| Configuration and library logs | `C:\Users\mario\od-deps\logs` |
 | CMake | `C:\Users\mario\od-deps\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` |
 | Visual Studio Build Tools | `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools` |
 | Python | `C:\Users\mario\AppData\Local\Programs\Python\Python310` |
-| 7-Zip für die Quellarchive | `C:\Users\mario\scoop\shims\7z.exe` |
-| Generierter Spielbuild | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
-| Vorgesehener Installationsordner des Spiels | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (noch nicht installiert) |
+| 7-Zip for source archives | `C:\Users\mario\scoop\shims\7z.exe` |
+| Generated game build | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
+| Intended game installation directory | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (not yet installed) |
 
-Unter `od-deps\setup-scripts`, `od-deps\Enter-OpenDungeonsPlus.ps1`,
-`od-deps\INSTALLATION.md` und dem ignorierten Projektordner `build` liegen noch
-Kopien aus der Installation; für weitere Arbeit die gepflegten Projektdateien
-verwenden, da die alten Kopien nicht automatisch aktualisiert werden.
-Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Installation.
+Copies from the installation still exist under `od-deps\setup-scripts`,
+`od-deps\Enter-OpenDungeonsPlus.ps1`, `od-deps\INSTALLATION.md` and the ignored
+project directory `build`; use the maintained project files for further work,
+as the old copies are not updated automatically.
+A new clone contains the instructions and scripts, but not the external installation.
 
-## Installierter Stand
+## Installed state
 
-| Komponente | Version / Konfiguration |
+| Component | Version / configuration |
 | --- | --- |
-| Visual Studio 2022 Build Tools | 17.14.39, MSVC-Toolsetordner 14.44.35207, von CMake erkannter Compiler 19.44.35228.0, Ziel und Host x64 |
+| Visual Studio 2022 Build Tools | 17.14.39, MSVC toolset directory 14.44.35207, compiler detected by CMake 19.44.35228.0, target and host x64 |
 | Windows SDK | 10.0.26100.0 |
-| CMake | 3.31.8, portable Installation |
-| Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
+| CMake | 3.31.8, portable installation |
+| Python | 3.10.11 with headers, Release and Debug import libraries and debug binaries |
 | OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
-| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer, Expat und dem gespeicherten MSVC-Kompatibilitätspatch |
+| CEGUI | 0.9999.0 from `tomluchowski/cegui`, tag `scissors_test_disabled`, with OgreRenderer, Expat and the saved MSVC compatibility patch |
 | OIS | 1.5.1 |
 | SFML | 2.5.1 |
 | Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
 | pybind11 | 2.10.4 |
 | FreeType | 2.12.1 |
 | Expat | 2.8.4 |
-| PCRE | 8.45 mit UTF und Unicode-Properties |
+| PCRE | 8.45 with UTF and Unicode properties |
 
-Die kompilierten Bibliotheken liegen für x64 in Release und Debug vor;
-Boost zusätzlich statisch und dynamisch, jeweils mit dynamischer C++-Laufzeit.
-pybind11 stellt Header und CMake-Konfiguration bereit.
-Git, VS Code, 7-Zip und eine passende Visual-C++-Laufzeit waren bereits vorhanden.
+The compiled libraries are available for x64 in Release and Debug;
+Boost is also available in static and shared variants, each using the dynamic C++ runtime.
+pybind11 provides headers and CMake configuration.
+Git, VS Code, 7-Zip and a suitable Visual C++ runtime were already present.
 
-OGRE, CEGUI, OIS, SFML und Python 3.10 orientieren sich an der vorhandenen
-[Snap-Baurezeptur](../../snap/snapcraft.yaml); die konkreten Windows-Optionen stehen
-in den Skripten. Dies dokumentiert OGRE 13.6.5 und belegt keinen Ogre-14-Port.
-Die älteren allgemeinen Angaben in README und AppVeyor ersetzen diesen lokalen Stand nicht.
+OGRE, CEGUI, OIS, SFML and Python 3.10 follow the existing
+[Snap build recipe](../../snap/snapcraft.yaml); the specific Windows options are
+in the scripts. This documents OGRE 13.6.5 and does not establish an Ogre 14 port.
+The older general information in README and AppVeyor does not supersede this local state.
 
-## Wie Projekt und externe Installation zusammenfinden
+## How the project and external installation connect
 
 [Enter-OpenDungeonsPlus.ps1](../../scripts/win32/Enter-OpenDungeonsPlus.ps1)
-lädt die Visual-Studio-Entwicklungsumgebung für x64 und setzt in der aktuellen
-PowerShell-Sitzung:
+loads the Visual Studio development environment for x64 and sets the following
+in the current PowerShell session:
 
-- `PATH` für CMake, Bibliotheks-DLLs und Python.
-- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` und `OIS_HOME` auf `od-deps\install`.
-- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` auf die installierten Boost-Dateien.
-- `LIB` zusätzlich auf `od-deps\install\lib` für MSVCs automatische Verknüpfung.
+- `PATH` for CMake, library DLLs and Python.
+- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` and `OIS_HOME` to `od-deps\install`.
+- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` to the installed Boost files.
+- `LIB` additionally to `od-deps\install\lib` for MSVC's automatic linking.
 
-CMake wurde bei der Installation außerdem dem Benutzer-PATH hinzugefügt;
-für einen eindeutigen Build trotzdem den Starthelfer laden.
-Die Compilerinitialisierung verwendet unter den Build Tools
-`Common7\Tools\Microsoft.VisualStudio.DevShell.dll`;
-Boost verwendet zusätzlich `VC\Auxiliary\Build\vcvarsall.bat`.
-Der Compiler liegt dort unter
+CMake was also added to the user PATH during installation;
+still load the environment helper to ensure an unambiguous build environment.
+Compiler initialization uses
+`Common7\Tools\Microsoft.VisualStudio.DevShell.dll` under the Build Tools;
+Boost additionally uses `VC\Auxiliary\Build\vcvarsall.bat`.
+The compiler is located there under
 `VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\cl.exe`.
 
 [configure-windows-prereqs.ps1](../../scripts/win32/configure-windows-prereqs.ps1)
-ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
-benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
-Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
-und deaktiviert die Testtargets. Bei der ursprünglichen Einrichtung wurden die
-Spielquellen und `CMakeLists.txt` nicht geändert; die anschließenden Korrekturen
-aus der tatsächlichen Kompilierung stehen im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md).
+determines the project root relative to its own location, loads the
+adjacent environment helper and configures `build\windows` with Visual Studio 2022/x64.
+It explicitly passes the Python executable, headers and both import libraries
+and disables the test targets. During the original setup, the
+game sources and `CMakeLists.txt` were not changed; the subsequent fixes
+from the actual compilation are recorded in the [build error log](WINDOWS-BUILD-FIXES.md).
 
-## Überprüft und noch offen
+## Verified and still pending
 
-| Schritt | Stand / Nachweis |
+| Step | Status / evidence |
 | --- | --- |
-| Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
-| Bibliotheken bauen und installieren | Release und Debug erfolgreich; CEGUI anschließend mit dem gespeicherten MSVC-Patch neu gebaut und installiert; Protokolle unter `od-deps\logs` |
-| Spiel konfigurieren | Mit den Buildkorrekturen erfolgreich erneut konfiguriert; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
-| Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
-| Spiel kompilieren | Release und Debug erfolgreich mit Exitcode 0; Befehle in [BUILDING.md](BUILDING.md), Nachweise im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) |
-| Erzeugte Programme prüfen | Beide Dateien tragen die AMD64-PE-Kennung; Release importiert nur `python310.dll`, Debug nur `python310_d.dll` als Python-Laufzeit |
-| Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
-| Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
+| Load compiler, CMake and Python | Successfully verified using the environment helper |
+| Build and install libraries | Release and Debug successful; CEGUI subsequently rebuilt and installed with the saved MSVC patch; logs under `od-deps\logs` |
+| Configure the game | Successfully reconfigured with the build fixes; `opendungeons-configure.log` ends with successful configuration and generation |
+| Configuration using the scripts added to the project | Successfully rerun, also from `docs\development`; the project path and adjacent environment helper are resolved correctly |
+| Compile the game | Release and Debug successful with exit code 0; commands in [BUILDING.md](BUILDING.md), evidence in the [build error log](WINDOWS-BUILD-FIXES.md) |
+| Check generated programs | Both files have the AMD64 PE signature; Release imports only `python310.dll`, Debug only `python310_d.dll` as the Python runtime |
+| Start the game, test GUI and cursor | Not yet verified; manual QA by the user |
+| Create an installation package | Not yet verified; older packaging logic cannot find some expected Boost DLL names |
 
-CMake hat Python, pybind11, OIS, OGRE, CEGUI samt OgreRenderer, SFML und die
-benötigten Boost-Linkbibliotheken gefunden. Die Meldung
-`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` betrifft die separate DLL-Suche für die
-Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
-Installationspaket ableiten.
-Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
-MSVC 19.44.35228.0; die Generierung und beide Linkschritte gelingen trotzdem,
-nachdem der im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) beschriebene
-Boost-Suchpfad korrigiert wurde.
+CMake found Python, pybind11, OIS, OGRE, CEGUI including OgreRenderer, SFML and the
+required Boost link libraries. The message
+`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` concerns the separate DLL search for
+packaging; do not infer either a failed link test or a working
+installation package from it.
+The reconfiguration also reports `Boost toolset is unknown` for
+MSVC 19.44.35228.0; generation and both linking steps still succeed
+after correcting the Boost search path described in the
+[build error log](WINDOWS-BUILD-FIXES.md).
 
-Die Buildfehler sind behoben; vorhandene Compiler-/Linkerwarnungen sind im
-Buildfehlerprotokoll festgehalten. Als Nächstes steht die Laufzeitprüfung durch
-den Nutzer an; erfolgreiche Builds ersetzen diese Prüfung nicht.
+The build errors are fixed; existing compiler/linker warnings are recorded in the
+build error log. Runtime verification by the user is next;
+successful builds do not replace this check.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -12,8 +12,13 @@ without the earlier errors; the user confirmed that direct Release startup works
 without errors. Enabling dynamic shadows later exposed a separate resource-group
 failure: the resource template now also registers OGRE's Main media in its internal
 group, retaining the existing Graphics registration for shader includes.
-Reconfiguration and the headless OGRE resource test succeeded; actual startup
-verification with shadows enabled is pending; see
+Reconfiguration, the headless OGRE resource test and the user's subsequent
+main-menu startup with shadows enabled succeeded. Exception logging added for a
+subsequent Legacy test-map failure captured the cause in the user's 15:05 run:
+OGRE's automatic illumination splitting removed DirtInstanced's fragment shader.
+RenderManager now selects integrated additive texture shadows; both builds and
+the isolated OGRE pass test succeeded, with the user's map retest and visual
+acceptance still pending; see
 [startup fixes](WINDOWS-STARTUP-FIXES.md).
 Broader gameplay tests and packaging remain unverified.
 

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,5 +1,18 @@
 # Windows development environment
 
+For the current `feature/gui-scaling` work, the September 5 clean Release build
+succeeded, but CMake regeneration restored invalid runtime resource paths.
+The existing runtime preparation script corrected them at 23:23:55; the isolated
+OGRE resource probe passes, and the user confirmed startup in the 23:27 run.
+The subsequent settings report exposed stale font-dependent control geometry,
+overlapping rows and disabled renderer clipping. Those corrections passed the
+isolated settings probe; the Release game was rebuilt at 23:39:49 and the CEGUI
+clipping correction was built in Release and Debug, installed and staged for
+Release testing. The user subsequently confirmed that the reported settings
+problems are fixed; the complete GUI verification matrix has not been confirmed
+individually. See [GUI scaling](GUI-SCALING.md) and the
+[startup failure record](WINDOWS-STARTUP-FIXES.md#resource-path-regression-after-the-gui-scaling-clean-build).
+
 The current settings work is on `feature/live-settings`; see
 [LIVE-SETTINGS.md](LIVE-SETTINGS.md) for changes and verification after the
 Windows-support baseline described below.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,5 +1,9 @@
 # Windows development environment
 
+The current settings work is on `feature/live-settings`; see
+[LIVE-SETTINGS.md](LIVE-SETTINGS.md) for changes and verification after the
+Windows-support baseline described below.
+
 As of September 5, 2026, Mario's local computer, Windows x64.
 The prerequisites are installed; their library builds and the game's
 CMake configuration succeeded.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,0 +1,63 @@
+# Windows-Entwicklungsumgebung
+
+Stand: 5. September 2026. Diese Notiz hält die besprochene Vorbereitung für
+Aufgabe 3, GUI-Skalierung, fest; sie ist noch keine praktisch verifizierte
+Installations- oder Build-Anleitung.
+
+## Reicht VS Code allein?
+
+Nein. VS Code dient als Editor; um die Änderungen im Spiel zu prüfen, müssen
+zusätzlich Compiler, Build-Werkzeuge und Projektabhängigkeiten verfügbar sein,
+sodass das Spiel lokal kompiliert und startet.
+
+## Im Gespräch vorgeschlagene Werkzeuge
+
+- VS Code als Editor.
+- Git für die Versionsverwaltung.
+- CMake für die Build-Konfiguration.
+- Visual Studio 2022 Build Tools mit dem Workload "Desktop development with C++",
+  MSVC-Compiler und Windows SDK.
+- Der lokale Klon des eigenen OpenDungeonsPlus-Forks.
+
+Visual Studio 2022 wurde im Gespräch vorgeschlagen; eine funktionierende
+Kombination mit diesem Projekt und seinen Abhängigkeiten ist noch nicht bestätigt.
+Die vorhandene [Windows-Build-Konfiguration](../../appveyor.yml) enthält stattdessen
+ältere Einträge für Visual Studio 12 und MinGW, die keinen erfolgreichen Build mit
+Visual Studio 2022 belegen.
+
+## Im aktuellen Build-Code bestätigte Abhängigkeiten
+
+Die [Build-Datei](../../CMakeLists.txt) sucht folgende Bibliotheken:
+
+- OGRE, einschließlich der vom Spiel verknüpften Komponenten.
+- CEGUI einschließlich des OGRE-Renderers.
+- SFML.
+- OIS.
+- Boost.
+- Python-Entwicklungsbibliotheken und Header.
+- pybind11 für die Python-Einbettung.
+
+Die Build-Datei nennt CMake 3.5 als Mindestversion, prüft OGRE ab 1.9 und CEGUI ab
+0.8 und sucht SFML 2. Diese Angaben beschreiben die vorhandenen Build-Prüfungen;
+sie belegen keine konkret funktionierende Kombination aktueller Paketversionen
+und keinen stabilen Ogre-14-Port.
+
+## Im Gespräch genannte optionale Ergänzungen
+
+- CMake Tools für VS Code.
+- C/C++-Erweiterung für VS Code.
+- Codex in VS Code.
+
+## Noch zu prüfen
+
+- Welche Werkzeuge und Abhängigkeiten auf dem Rechner bereits installiert sind.
+- Welche konkreten Versionen, Compiler und Zielarchitektur zusammen funktionieren.
+- Wie die Abhängigkeiten für diese Kombination bereitgestellt und gefunden werden.
+- Ob das Spiel damit tatsächlich gebaut und gestartet werden kann.
+
+Die Bibliotheksliste wurde statisch mit dem Repository abgeglichen; im Rahmen
+dieser Dokumentation wurden keine Programme installiert und keine Builds oder
+Spieltests gestartet.
+
+Sobald ein funktionierender Ablauf feststeht, die tatsächlich verwendeten Versionen
+und Build-Schritte in einer eigenen Build-Anleitung festhalten und hier verlinken.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -1,116 +1,116 @@
-# Windows-Voraussetzungen wiederherstellen
+# Restoring Windows prerequisites
 
-Installationsprotokoll vom 5. September 2026; die Voraussetzungen sind auf Marios
-Rechner bereits vorhanden. Für die tägliche Arbeit genügt [BUILDING.md](BUILDING.md).
-Diese Anleitung hält die tatsächlich verwendeten Quellen und Optionen fest;
-die spätere Verfügbarkeit der Downloads ist damit nicht garantiert.
+Installation log from September 5, 2026; the prerequisites are already present on
+Mario's computer. For daily work, [BUILDING.md](BUILDING.md) is sufficient.
+This guide records the sources and options actually used;
+it does not guarantee that the downloads will remain available later.
 
-## Verzeichnisse und Werkzeuge
+## Directories and tools
 
-Externer Stamm: `C:\Users\mario\od-deps`, mit den Unterordnern `src`, `build`,
-`install`, `tools`, `downloads` und `logs`.
-Bei einer leeren Installation diese Ordner vor dem Ausführen der Skripte anlegen.
-Git, VS Code, 7-Zip und die Visual-C++-Laufzeit waren bereits installiert.
-Das verwendete 7-Zip ist `C:\Users\mario\scoop\shims\7z.exe`.
+External root: `C:\Users\mario\od-deps`, with the subdirectories `src`, `build`,
+`install`, `tools`, `downloads` and `logs`.
+For an empty installation, create these directories before running the scripts.
+Git, VS Code, 7-Zip and the Visual C++ runtime were already installed.
+The 7-Zip used is `C:\Users\mario\scoop\shims\7z.exe`.
 
-Die ursprünglichen Werkzeuginstallationen wurden mit diesen Befehlen durchgeführt:
+The original tool installations were performed with these commands:
 
 ```powershell
 winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --source winget --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
 winget install --id Python.Python.3.10 --exact --source winget --scope user --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Include_debug=1 /quiet"
 ```
 
-Dabei wurden Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 und
-Python 3.10.11 installiert. Die Befehle selbst fixieren diese Patchversionen nicht;
-bei einem späteren Neuaufbau die tatsächlich installierten Versionen abgleichen.
-Python benötigt auch `libs\python310_d.lib`; eine reine Laufzeitinstallation reicht
-für die dokumentierte Debug-Konfiguration nicht aus.
+This installed Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 and
+Python 3.10.11. The commands themselves do not pin these patch versions;
+compare the versions actually installed when rebuilding at a later date.
+Python also requires `libs\python310_d.lib`; a runtime-only installation is not
+sufficient for the documented Debug configuration.
 
-CMake wurde als [Version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
-heruntergeladen und unter `od-deps\tools` entpackt, sodass
-`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` existiert.
-Die dokumentierten Skripte verwenden diesen Stand; die ältere Buildlogik wurde
-nicht mit einer beliebigen neueren CMake-Version geprüft.
+CMake was downloaded as [version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
+and extracted under `od-deps\tools`, so that
+`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` exists.
+The documented scripts use this version; the older build logic has not been
+tested with an arbitrary newer CMake version.
 
-## Git-Quellen
+## Git sources
 
-Alle Zielpfade sind relativ zu `C:\Users\mario\od-deps`.
-Die Commits wurden an den vorhandenen lokalen Quellklonen abgeglichen.
+All target paths are relative to `C:\Users\mario\od-deps`.
+The commits were checked against the existing local source clones.
 
-| Quelle | Tag | Zielpfad | Commit |
+| Source | Tag | Target path | Commit |
 | --- | --- | --- | --- |
 | [OGRE](https://github.com/OGRECave/ogre) | `v13.6.5` | `src\ogre` | `856cf743ebcce8250d181a621ee47a70b12ed17e` |
-| [CEGUI-Projektfork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
+| [CEGUI project fork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
 | [OIS](https://github.com/wgois/OIS) | `v1.5.1` | `src\ois` | `6edb487cccb54d59e5b0fff86549d5eef475dea6` |
 | [SFML](https://github.com/SFML/SFML) | `2.5.1` | `src\sfml` | `2f11710abc5aa478503a7ff3f9e654bd2078ebab` |
 | [FreeType](https://github.com/freetype/freetype) | `VER-2-12-1` | `src\freetype` | `e8ebfe988b5f57bfb9a3ecb13c70d9791bce9ecf` |
 | [Expat](https://github.com/libexpat/libexpat) | `R_2_8_4` | `src\expat` | `12cf0b1f25f026a022fe728ad8f7e3d017285b80` |
 | [pybind11](https://github.com/pybind/pybind11) | `v2.10.4` | `src\pybind11` | `5b0a6fc2017fcc176545afe3e09c9f9885283242` |
 
-Für einen fehlenden Quellordner das betreffende Repository mit
-`git clone --depth 1 --branch <Tag> <Repository-URL>.git <Zielpfad>` klonen und
-`git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
-Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
-Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
-Zusätzlich zum aufgeführten CEGUI-Basiscommit wird beim Windows-Neuaufbau der
-[MSVC-Kompatibilitätspatch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
-angewendet; die Ursache ist im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) belegt.
+For a missing source directory, clone the relevant repository with
+`git clone --depth 1 --branch <Tag> <Repository-URL>.git <TargetPath>` and
+compare `git -C <TargetPath> rev-parse HEAD` with the table.
+Preserve existing sources when doing so. `scissors_test_disabled` is a tag.
+Expat is configured from the subdirectory `src\expat\expat`.
+In addition to the listed CEGUI base commit, the
+[MSVC compatibility patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
+is applied when rebuilding on Windows; the cause is documented in the [build error log](WINDOWS-BUILD-FIXES.md).
 
-## Archive und Prüfsummen
+## Archives and checksums
 
-Die Downloadarchive liegen unter `od-deps\downloads`; die folgenden Hashes wurden
-bei der Installation geprüft und vor der Übernahme in diese Dokumentation erneut
-mit den vorhandenen Dateien abgeglichen.
-Downloads erst nach erfolgreichem Hashvergleich entpacken.
+The download archives are stored under `od-deps\downloads`; the following hashes were
+verified during installation and checked against the existing files again before
+being added to this documentation.
+Extract downloads only after a successful hash comparison.
 
-| Archiv / Download | Entpacktes Ziel |
+| Archive / download | Extraction target |
 | --- | --- |
 | [cmake-3.31.8-windows-x86_64.zip](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-windows-x86_64.zip) | `tools\cmake-3.31.8-windows-x86_64` |
 | [boost_1_82_0.zip](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip) | `src\boost_1_82_0` |
-| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), lokal als `pcre-8.45-verified.zip` | `src\pcre-8.45` |
+| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), locally named `pcre-8.45-verified.zip` | `src\pcre-8.45` |
 
-CMake, SHA-256 aus der
-[Release-Prüfsummendatei](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
+CMake, SHA-256 from the
+[release checksum file](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
 
 ```text
 81aa9964dbabd71fe02e7ec50472fd3ad56138c49944515ece9001efbff8d719
 ```
 
-Boost, SHA-256 aus den
-[Archivmetadaten](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
+Boost, SHA-256 from the
+[archive metadata](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
 
 ```text
 f7c9e28d242abcd7a2c1b962039fcdd463ca149d1883c3a950bbcc0ce6f7c6d9
 ```
 
-PCRE, SHA-512 abgeglichen mit dem
-[vcpkg-Port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
-zum Installationszeitpunkt; vcpkg selbst wurde nicht benötigt oder installiert:
+PCRE, SHA-512 checked against the
+[vcpkg port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
+at the time of installation; vcpkg itself was neither required nor installed:
 
 ```text
 71f246c0abbf356222933ad1604cab87a1a2a3cd8054a0b9d6deb25e0735ce9f40f923d14cbd21f32fdac7283794270afcb0f221ad24662ac35934fcb73675cd
 ```
 
-Zum Prüfen und Entpacken beispielsweise:
+For example, to verify and extract:
 
 ```powershell
 Get-FileHash -Algorithm SHA512 -LiteralPath 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip'
-# Nur bei Übereinstimmung mit dem oben dokumentierten Hash:
+# Only if it matches the hash documented above:
 & 'C:\Users\mario\scoop\shims\7z.exe' x 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip' '-oC:\Users\mario\od-deps\src'
 ```
 
-Für CMake und Boost `SHA256` verwenden; CMake nach `tools`, Boost nach `src`
-entpacken. Ein früherer PCRE-Download namens `pcre-8.45.zip` enthält HTML und
-ist kein verwendbares Archiv; die geprüfte Datei trägt den Zusatz `-verified`.
+Use `SHA256` for CMake and Boost; extract CMake to `tools` and Boost to `src`.
+An earlier PCRE download named `pcre-8.45.zip` contains HTML and
+is not a usable archive; the verified file has the suffix `-verified`.
 
-## Bibliotheken neu bauen, falls erforderlich
+## Rebuild libraries if necessary
 
-Die Skripte wurden aus der erfolgreichen Einrichtung übernommen und erwarten die
-oben vorbereiteten Quellen und Werkzeuge; sie laden selbst keine Quellen herunter.
-Sie konfigurieren, bauen und installieren ins gemeinsame Präfix `od-deps\install`.
-Release und Debug werden jeweils nacheinander gebaut.
+The scripts were taken from the successful setup and expect the
+sources and tools prepared above; they do not download sources themselves.
+They configure, build and install into the shared prefix `od-deps\install`.
+Release and Debug are built sequentially for each library.
 
-Aus dem Projektstamm, bei einem notwendigen vollständigen Neuaufbau:
+From the project root, when a complete rebuild is necessary:
 
 ```powershell
 Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
@@ -123,47 +123,47 @@ $taskInstallScripts = @(
 foreach ($taskInstallScript in $taskInstallScripts) {
     $taskScriptPath = Join-Path $PWD.Path "scripts\win32\$taskInstallScript"
     & powershell.exe -NoProfile -File $taskScriptPath
-    if ($LASTEXITCODE -ne 0) { throw "Installation fehlgeschlagen: $taskInstallScript" }
+    if ($LASTEXITCODE -ne 0) { throw "Installation failed: $taskInstallScript" }
 }
 ```
 
-Die separaten PowerShell-Prozesse halten die Verzeichnis- und Umgebungsänderungen
-des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenfolge.
+The separate PowerShell processes keep the Boost script's directory and environment
+changes out of the calling session; errors stop the sequence.
 
-| Skript | Zuständigkeit / Reihenfolge |
+| Script | Responsibility / order |
 | --- | --- |
-| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
-| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
-| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
-| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Wendet den gespeicherten MSVC-Patch einmalig an und baut CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, then FreeType, pybind11, PCRE; can be filtered with `-Only` for targeted needs |
+| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost build tool and libraries; generates `od-deps\boost-user-config.jam` |
+| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE with GL3Plus and the required components |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Applies the saved MSVC patch once and builds CEGUI with OgreRenderer and Expat, after OGRE and the base libraries |
 
-Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
-konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
-Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
+Then load the environment helper and configure the game following [BUILDING.md](BUILDING.md);
+a library build alone does not establish a successful game build.
+Logs are stored under `od-deps\logs`; each new script run replaces its logs.
 
-## Behobene Installationsprobleme erhalten
+## Preserve fixes for installation problems
 
-- **SFML / FreeType:** SFML installiert eine alte mitgelieferte statische
-  `freetype.lib` über die selbst gebaute Datei im gemeinsamen Präfix; das führte
-  beim Linken von OgreOverlay zu `sprintf` / `LNK2019`.
-  Deshalb FreeType nach SFML installieren; diese Reihenfolge steht im Basisskript.
-  Die endgültige Datei wurde per Hash mit dem eigenen FreeType-Build abgeglichen.
-- **Boost / Compilerinitialisierung:** Die automatische Suche verwendete einen
-  falschen Pfad zu `vcvarsall.bat`. Das Skript erzeugt deshalb eine Jam-Konfiguration
-  mit dem tatsächlich gefundenen `cl.exe` und
-  `VC\Auxiliary\Build\vcvarsall.bat`, verwendet `--user-config`, `--reconfigure`
-  sowie `architecture=x86 address-model=64` für den x64-Build.
-- **MSVC-Optionen:** OGRE und CEGUI verwenden
-  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; `/EHsc` beim Anpassen der Parallelität
-  erhalten. OGRE verwendet vorkompilierte Header und
-  `OGRE_BUILD_MSVC_MP=OFF`, da `/MP4` bereits explizit gesetzt ist.
-- **PCRE-Download:** Den HTML-Fehldownload nicht erneut verwenden; Archiv und Hash
-  sind oben eindeutig festgehalten.
-- **Paketierung:** Die alte Windows-Paketlogik findet einige Boost-DLL-Namen nicht,
-  obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
-  ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
+- **SFML / FreeType:** SFML installs an old bundled static
+  `freetype.lib` over the locally built file in the shared prefix; this caused
+  `sprintf` / `LNK2019` when linking OgreOverlay.
+  Therefore, install FreeType after SFML; this order is recorded in the base script.
+  The final file was compared with the local FreeType build by hash.
+- **Boost / compiler initialization:** The automatic search used an
+  incorrect path to `vcvarsall.bat`. The script therefore generates a Jam configuration
+  with the actual detected `cl.exe` and
+  `VC\Auxiliary\Build\vcvarsall.bat`, uses `--user-config`, `--reconfigure`
+  and `architecture=x86 address-model=64` for the x64 build.
+- **MSVC options:** OGRE and CEGUI use
+  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; preserve `/EHsc` when adjusting
+  parallelism. OGRE uses precompiled headers and
+  `OGRE_BUILD_MSVC_MP=OFF`, since `/MP4` is already set explicitly.
+- **PCRE download:** Do not reuse the failed HTML download; the archive and hash
+  are clearly recorded above.
+- **Packaging:** The old Windows packaging logic cannot find some Boost DLL names,
+  although CMake finds the link libraries; packaging and runtime remain
+  unverified, see the [current status](WINDOWS-DEV-SETUP.md).
 
-Die ursprüngliche Einrichtung benötigte für diese Lösungen keine Quellpatches;
-bei der anschließenden Spielkompilierung wurde der oben verlinkte CEGUI-Patch
-erforderlich. Die konkreten CMake- und Boost-Optionen stehen vollständig in den
-Skripten, die Änderung am CEGUI-Header in der zugehörigen Patchdatei.
+The original setup did not require source patches for these solutions;
+the CEGUI patch linked above became necessary during the subsequent game
+compilation. The specific CMake and Boost options are fully recorded in the
+scripts, and the change to the CEGUI header is in the corresponding patch file.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -52,6 +52,9 @@ Für einen fehlenden Quellordner das betreffende Repository mit
 `git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
 Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
 Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
+Zusätzlich zum aufgeführten CEGUI-Basiscommit wird beim Windows-Neuaufbau der
+[MSVC-Kompatibilitätspatch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
+angewendet; die Ursache ist im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) belegt.
 
 ## Archive und Prüfsummen
 
@@ -132,7 +135,7 @@ des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenf
 | [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
 | [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
 | [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
-| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Wendet den gespeicherten MSVC-Patch einmalig an und baut CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
 
 Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
 konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
@@ -160,5 +163,7 @@ Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
   obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
   ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
 
-Die Dependency-Quellen wurden für diese Lösungen nicht gepatcht; die konkreten
-CMake- und Boost-Optionen stehen vollständig in den übernommenen Skripten.
+Die ursprüngliche Einrichtung benötigte für diese Lösungen keine Quellpatches;
+bei der anschließenden Spielkompilierung wurde der oben verlinkte CEGUI-Patch
+erforderlich. Die konkreten CMake- und Boost-Optionen stehen vollständig in den
+Skripten, die Änderung am CEGUI-Header in der zugehörigen Patchdatei.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -1,0 +1,164 @@
+# Windows-Voraussetzungen wiederherstellen
+
+Installationsprotokoll vom 5. September 2026; die Voraussetzungen sind auf Marios
+Rechner bereits vorhanden. Für die tägliche Arbeit genügt [BUILDING.md](BUILDING.md).
+Diese Anleitung hält die tatsächlich verwendeten Quellen und Optionen fest;
+die spätere Verfügbarkeit der Downloads ist damit nicht garantiert.
+
+## Verzeichnisse und Werkzeuge
+
+Externer Stamm: `C:\Users\mario\od-deps`, mit den Unterordnern `src`, `build`,
+`install`, `tools`, `downloads` und `logs`.
+Bei einer leeren Installation diese Ordner vor dem Ausführen der Skripte anlegen.
+Git, VS Code, 7-Zip und die Visual-C++-Laufzeit waren bereits installiert.
+Das verwendete 7-Zip ist `C:\Users\mario\scoop\shims\7z.exe`.
+
+Die ursprünglichen Werkzeuginstallationen wurden mit diesen Befehlen durchgeführt:
+
+```powershell
+winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --source winget --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
+winget install --id Python.Python.3.10 --exact --source winget --scope user --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Include_debug=1 /quiet"
+```
+
+Dabei wurden Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 und
+Python 3.10.11 installiert. Die Befehle selbst fixieren diese Patchversionen nicht;
+bei einem späteren Neuaufbau die tatsächlich installierten Versionen abgleichen.
+Python benötigt auch `libs\python310_d.lib`; eine reine Laufzeitinstallation reicht
+für die dokumentierte Debug-Konfiguration nicht aus.
+
+CMake wurde als [Version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
+heruntergeladen und unter `od-deps\tools` entpackt, sodass
+`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` existiert.
+Die dokumentierten Skripte verwenden diesen Stand; die ältere Buildlogik wurde
+nicht mit einer beliebigen neueren CMake-Version geprüft.
+
+## Git-Quellen
+
+Alle Zielpfade sind relativ zu `C:\Users\mario\od-deps`.
+Die Commits wurden an den vorhandenen lokalen Quellklonen abgeglichen.
+
+| Quelle | Tag | Zielpfad | Commit |
+| --- | --- | --- | --- |
+| [OGRE](https://github.com/OGRECave/ogre) | `v13.6.5` | `src\ogre` | `856cf743ebcce8250d181a621ee47a70b12ed17e` |
+| [CEGUI-Projektfork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
+| [OIS](https://github.com/wgois/OIS) | `v1.5.1` | `src\ois` | `6edb487cccb54d59e5b0fff86549d5eef475dea6` |
+| [SFML](https://github.com/SFML/SFML) | `2.5.1` | `src\sfml` | `2f11710abc5aa478503a7ff3f9e654bd2078ebab` |
+| [FreeType](https://github.com/freetype/freetype) | `VER-2-12-1` | `src\freetype` | `e8ebfe988b5f57bfb9a3ecb13c70d9791bce9ecf` |
+| [Expat](https://github.com/libexpat/libexpat) | `R_2_8_4` | `src\expat` | `12cf0b1f25f026a022fe728ad8f7e3d017285b80` |
+| [pybind11](https://github.com/pybind/pybind11) | `v2.10.4` | `src\pybind11` | `5b0a6fc2017fcc176545afe3e09c9f9885283242` |
+
+Für einen fehlenden Quellordner das betreffende Repository mit
+`git clone --depth 1 --branch <Tag> <Repository-URL>.git <Zielpfad>` klonen und
+`git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
+Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
+Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
+
+## Archive und Prüfsummen
+
+Die Downloadarchive liegen unter `od-deps\downloads`; die folgenden Hashes wurden
+bei der Installation geprüft und vor der Übernahme in diese Dokumentation erneut
+mit den vorhandenen Dateien abgeglichen.
+Downloads erst nach erfolgreichem Hashvergleich entpacken.
+
+| Archiv / Download | Entpacktes Ziel |
+| --- | --- |
+| [cmake-3.31.8-windows-x86_64.zip](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-windows-x86_64.zip) | `tools\cmake-3.31.8-windows-x86_64` |
+| [boost_1_82_0.zip](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip) | `src\boost_1_82_0` |
+| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), lokal als `pcre-8.45-verified.zip` | `src\pcre-8.45` |
+
+CMake, SHA-256 aus der
+[Release-Prüfsummendatei](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
+
+```text
+81aa9964dbabd71fe02e7ec50472fd3ad56138c49944515ece9001efbff8d719
+```
+
+Boost, SHA-256 aus den
+[Archivmetadaten](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
+
+```text
+f7c9e28d242abcd7a2c1b962039fcdd463ca149d1883c3a950bbcc0ce6f7c6d9
+```
+
+PCRE, SHA-512 abgeglichen mit dem
+[vcpkg-Port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
+zum Installationszeitpunkt; vcpkg selbst wurde nicht benötigt oder installiert:
+
+```text
+71f246c0abbf356222933ad1604cab87a1a2a3cd8054a0b9d6deb25e0735ce9f40f923d14cbd21f32fdac7283794270afcb0f221ad24662ac35934fcb73675cd
+```
+
+Zum Prüfen und Entpacken beispielsweise:
+
+```powershell
+Get-FileHash -Algorithm SHA512 -LiteralPath 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip'
+# Nur bei Übereinstimmung mit dem oben dokumentierten Hash:
+& 'C:\Users\mario\scoop\shims\7z.exe' x 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip' '-oC:\Users\mario\od-deps\src'
+```
+
+Für CMake und Boost `SHA256` verwenden; CMake nach `tools`, Boost nach `src`
+entpacken. Ein früherer PCRE-Download namens `pcre-8.45.zip` enthält HTML und
+ist kein verwendbares Archiv; die geprüfte Datei trägt den Zusatz `-verified`.
+
+## Bibliotheken neu bauen, falls erforderlich
+
+Die Skripte wurden aus der erfolgreichen Einrichtung übernommen und erwarten die
+oben vorbereiteten Quellen und Werkzeuge; sie laden selbst keine Quellen herunter.
+Sie konfigurieren, bauen und installieren ins gemeinsame Präfix `od-deps\install`.
+Release und Debug werden jeweils nacheinander gebaut.
+
+Aus dem Projektstamm, bei einem notwendigen vollständigen Neuaufbau:
+
+```powershell
+Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
+$taskInstallScripts = @(
+    'install-base-prereqs.ps1'
+    'install-boost-prereq.ps1'
+    'install-ogre-prereq.ps1'
+    'install-cegui-prereq.ps1'
+)
+foreach ($taskInstallScript in $taskInstallScripts) {
+    $taskScriptPath = Join-Path $PWD.Path "scripts\win32\$taskInstallScript"
+    & powershell.exe -NoProfile -File $taskScriptPath
+    if ($LASTEXITCODE -ne 0) { throw "Installation fehlgeschlagen: $taskInstallScript" }
+}
+```
+
+Die separaten PowerShell-Prozesse halten die Verzeichnis- und Umgebungsänderungen
+des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenfolge.
+
+| Skript | Zuständigkeit / Reihenfolge |
+| --- | --- |
+| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
+| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
+| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+
+Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
+konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
+Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
+
+## Behobene Installationsprobleme erhalten
+
+- **SFML / FreeType:** SFML installiert eine alte mitgelieferte statische
+  `freetype.lib` über die selbst gebaute Datei im gemeinsamen Präfix; das führte
+  beim Linken von OgreOverlay zu `sprintf` / `LNK2019`.
+  Deshalb FreeType nach SFML installieren; diese Reihenfolge steht im Basisskript.
+  Die endgültige Datei wurde per Hash mit dem eigenen FreeType-Build abgeglichen.
+- **Boost / Compilerinitialisierung:** Die automatische Suche verwendete einen
+  falschen Pfad zu `vcvarsall.bat`. Das Skript erzeugt deshalb eine Jam-Konfiguration
+  mit dem tatsächlich gefundenen `cl.exe` und
+  `VC\Auxiliary\Build\vcvarsall.bat`, verwendet `--user-config`, `--reconfigure`
+  sowie `architecture=x86 address-model=64` für den x64-Build.
+- **MSVC-Optionen:** OGRE und CEGUI verwenden
+  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; `/EHsc` beim Anpassen der Parallelität
+  erhalten. OGRE verwendet vorkompilierte Header und
+  `OGRE_BUILD_MSVC_MP=OFF`, da `/MP4` bereits explizit gesetzt ist.
+- **PCRE-Download:** Den HTML-Fehldownload nicht erneut verwenden; Archiv und Hash
+  sind oben eindeutig festgehalten.
+- **Paketierung:** Die alte Windows-Paketlogik findet einige Boost-DLL-Namen nicht,
+  obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
+  ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
+
+Die Dependency-Quellen wurden für diese Lösungen nicht gepatcht; die konkreten
+CMake- und Boost-Optionen stehen vollständig in den übernommenen Skripten.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -134,7 +134,7 @@ changes out of the calling session; errors stop the sequence.
 | --- | --- |
 | [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, then FreeType, pybind11, PCRE; can be filtered with `-Only` for targeted needs |
 | [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost build tool and libraries; generates `od-deps\boost-user-config.jam` |
-| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE with GL3Plus and the required components |
+| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | Applies the saved multi-window settings patch once, then builds OGRE with GL3Plus and the required components |
 | [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Applies the saved MSVC patch once and builds CEGUI with OgreRenderer and Expat, after OGRE and the base libraries |
 
 Then load the environment helper and configure the game following [BUILDING.md](BUILDING.md);
@@ -163,7 +163,10 @@ Logs are stored under `od-deps\logs`; each new script run replaces its logs.
   although CMake finds the link libraries; packaging and runtime remain
   unverified, see the [current status](WINDOWS-DEV-SETUP.md).
 
-The original setup did not require source patches for these solutions;
-the CEGUI patch linked above became necessary during the subsequent game
-compilation. The specific CMake and Boost options are fully recorded in the
-scripts, and the change to the CEGUI header is in the corresponding patch file.
+The original setup did not require source patches. The CEGUI patch linked above
+became necessary during the subsequent game compilation. The live-settings work
+also requires
+[the OGRE multi-window settings patch](../../scripts/win32/patches/ogre-multiwindow-settings.patch)
+for context-safe secondary windows, hardware-gamma detection and runtime GL3Plus
+options. Both installers apply their patch idempotently. The specific CMake and
+Boost options are fully recorded in the scripts.

--- a/docs/development/WINDOWS-SETTINGS-FIXES.md
+++ b/docs/development/WINDOWS-SETTINGS-FIXES.md
@@ -1,0 +1,30 @@
+# Windows settings fixes
+
+## Duplicate colour-depth choices
+
+On September 5, 2026, the user reported that the colour-depth dropdown offered
+`32`, `32`, `32` instead of distinct values.
+
+In the installed OGRE 13.6.5 source,
+`RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp`, `refreshConfig` first
+deduplicates colour depths, then appends them again while enumerating fullscreen
+refresh rates. This leaves repeated depths in the renderer's possible values.
+[SettingsWindow.cpp](../../source/modes/SettingsWindow.cpp) previously inserted
+every entry into its renderer-dependent dropdowns.
+
+The settings code now sorts and deduplicates the local copy of each option's
+possible values before sizing and filling its dropdown. If the renderer offers
+only 32-bit colour, the list contains one `32`; any genuinely different supported
+depths are retained. The dropdowns were already sorted, and selection and saving
+still use the option text. No renderer options or user settings are modified by
+building these lists.
+
+Release and Debug rebuilt successfully with exit code 0 using the maintained
+Windows environment helper. Logs are in
+`build/windows/game-Release-colour-depth.log` and
+`build/windows/game-Debug-colour-depth.log`; `git diff --check` also passed.
+The updated dropdown has not yet been verified visually in the game.
+
+The user performs the visual check: restart the updated Release executable,
+open video settings, and confirm that the colour-depth list has no duplicates
+and retains its current selection when the settings are reopened.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -1,0 +1,90 @@
+# Windows startup failures and verification
+
+As of September 5, 2026, the user confirmed that the Release executable starts
+directly without errors. This result is supported by the runtime evidence below,
+in addition to successful builds and static DLL checks.
+See [BUILDING.md](BUILDING.md) for the executable and runtime setup.
+
+## Runtime files and generated resource configuration
+
+The initial build directory contained no dependency DLLs, while `plugins.cfg`
+loads OGRE plugins from that directory. The maintained
+[runtime preparation script](../../scripts/win32/prepare-windows-runtime.ps1)
+now stages the Release DLLs, including the dynamically loaded OGRE and CEGUI
+modules, and configures the existing Python installation's module paths.
+
+The generated `resources.cfg` initially pointed at
+`build/windows/install/share/OGRE/Media`, although the installed Windows OGRE
+media is under `C:\Users\mario\od-deps\install\Media`. The script corrects those
+paths and excludes the shader subdirectories absent from this OGRE installation.
+Both standalone preparation and preparation through the configuration script
+completed successfully; the copied DLL hashes match their installed sources.
+
+The static report `build/windows/runtime-validation.json` checked the Release
+executable and 22 DLLs, four OGRE plugins and 14 resource directories. It found
+no missing imported DLLs or architecture mismatches, but did not execute the
+resource-loading code and therefore did not detect the path error below.
+
+## Absolute Windows resource paths were prefixed with the game directory
+
+The user's 14:00 startup reached OGRE and its OpenGL 3+ renderer, but reported
+that `OgreUnifiedShader.h` could not be found in the Graphics resource group.
+Cloud2, DirtInstanced, Fog and ReflMetal shader/material errors followed.
+
+The actual paths in both the game and OGRE logs were malformed, for example:
+
+```text
+./C:/Users/mario/od-deps/install/Media/Main
+```
+
+In [ResourceManager.cpp](../../source/utils/ResourceManager.cpp),
+`setupOgreResources` treated a path as absolute only if it began with `/`.
+It therefore prefixed valid drive-qualified Windows paths with `./`, even though
+the configured directories and `OgreUnifiedShader.h` existed on disk.
+The condition now uses the existing Boost filesystem path API's `is_absolute()`
+check, preserving absolute paths and continuing to prefix relative game paths.
+
+The original runtime evidence is retained locally in:
+
+- `build/windows/startup-before-path-fix-Ogre.log`.
+- `build/windows/startup-before-path-fix-game.log`.
+
+Both binaries were rebuilt successfully after this correction:
+
+- `build/windows/game-Release-startup-path-fix.log`, exit code 0.
+- `build/windows/game-Debug-startup-path-fix.log`, exit code 0.
+
+The Release executable was replaced with the corrected build. A subsequent run
+from 14:07:36 to 14:07:52 registered the absolute OGRE media paths correctly,
+initialized CEGUI and its skin, loaded the main-menu scene, rendered its materials
+and followed the normal shutdown path. The earlier missing-resource and material
+errors are absent from the new OGRE, game and CEGUI logs.
+The game reached the normal post-render-loop disconnect and shutdown statements
+in `ODApplication.cpp`; these are not reached by an exception unwinding that loop.
+
+The preserved post-fix evidence is:
+
+- `build/windows/startup-after-path-fix-Ogre.log`.
+- `build/windows/startup-after-path-fix-game.log`.
+- `build/windows/startup-after-path-fix-CEGUI.log`.
+- `build/windows/startup-path-fix-validation.json`, including the checked binary's SHA-256.
+
+These logs verify the resource-path fix during an actual startup. Existing shader
+extension, shader-version and deprecated material-syntax warnings remain; no
+warnings were disabled. The user subsequently confirmed error-free startup on
+September 5, 2026, completing the verification of the direct Release startup.
+
+## Build process note
+
+The sandboxed process environment supplied both `Path` and `PATH`, causing the
+Visual Studio environment helper and MSBuild to reject the duplicate dictionary
+key before compilation. Running the same build in the approved normal process
+environment succeeded; no system environment setting was changed.
+
+## Verified outcome and remaining scope
+
+The direct Release startup objective is complete: the user confirmed error-free
+startup and the runtime logs verify that the earlier loading failures are gone.
+Broader gameplay and visual QA remain with the user; Debug runtime staging and
+packaging remain separate, unverified work. The game version remains 0.7.1;
+no release has been published.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -3,6 +3,8 @@
 As of September 5, 2026, the user confirmed that the Release executable starts
 directly without errors. This result is supported by the runtime evidence below,
 in addition to successful builds and static DLL checks.
+That confirmation preceded enabling dynamic shadows; the resulting startup
+failure and its resource-group correction are documented below.
 See [BUILDING.md](BUILDING.md) for the executable and runtime setup.
 
 ## Runtime files and generated resource configuration
@@ -74,6 +76,59 @@ extension, shader-version and deprecated material-syntax warnings remain; no
 warnings were disabled. The user subsequently confirmed error-free startup on
 September 5, 2026, completing the verification of the direct Release startup.
 
+## Enabling dynamic shadows prevented subsequent startup
+
+At 14:24:35 on September 5, 2026, the settings handler saved `Dynamic Shadows=Yes`
+and explicitly called `exit(0)`. The preceding run reached the main menu at
+3440 x 1440 fullscreen with shadows disabled. The subsequent attempts at 14:24:38,
+14:24:41 and 14:27:21 failed before CEGUI initialization with shadows enabled.
+The abrupt exit on saving is existing behavior in
+[SettingsWindow.cpp](../../source/modes/SettingsWindow.cpp); the failure on the
+next startup is a separate resource-loading bug.
+
+[RenderManager.cpp](../../source/render/RenderManager.cpp) enables texture shadows
+during construction. OGRE 13.6.5 then looks up its four shadow-extrusion programs
+through `OgreInternal`. The installed library uses
+`OGRE_RESOURCEMANAGER_STRICT=2`, but the generated configuration registered
+`Media/Main` only in the isolated `Graphics` group. The files were parsed there,
+yet the internal lookup could not find them. The DLL and shader files exist;
+this failure does not require reinstalling dependencies.
+
+The [resource template](../../cmake/config/resources.cfg.in) now also registers
+the same `Media/Main` directory under `OgreInternal`. Its existing `Graphics`
+registration is deliberately retained: game shaders include `OgreUnifiedShader.h`
+using strict group-local file lookup. Moving the directory out of `Graphics`
+would reintroduce missing-header errors. The two resource pools remain separate;
+no dependency files, user settings or game C++ sources are changed.
+The maintained Windows configuration script regenerates the template and resolves
+both entries to the existing local OGRE installation.
+
+The preserved evidence under `build/windows` is:
+
+- `startup-shadow-setting-change-game.log`: successful startup with shadows off,
+  followed by the explicit exit after saving the shadow setting.
+- `startup-before-shadow-fix-Ogre.log` and `startup-before-shadow-fix-game.log`:
+  the failed startup with shadows enabled.
+- `shadow-resources-before.cfg`: the original resource-group assignment.
+- `shadow-resource-probe.cpp`: an isolated check using the installed OGRE DLL and
+  its own script parser, without creating a renderer or game window.
+- `shadow-probe-before.log`: all four internal shadow lookups fail, exit code 1;
+  the game shader header remains accessible.
+- `shadow-probe-after.log`: all four internal shadow lookups and their source-file
+  loads succeed, and the game shader header remains accessible, exit code 0.
+- `shadow-resource-validation.json`: configuration, probe and unchanged executable
+  evidence, with actual game startup explicitly marked as pending.
+
+The probe checks resource registration, program lookup and source-file loading;
+without a renderer, OGRE uses null shader programs, so it does not verify shader
+compilation or rendering. The maintained Windows configuration script succeeded
+and prepared the corrected configuration beside the existing Release executable.
+The user configuration still enables dynamic shadows at 3440 x 1440 fullscreen.
+The executable is unchanged, so no C++ rebuild is required for this template-only
+fix. The game version remains 0.7.1; the root README already links to this startup
+record, and no separate release changelog entry is needed for this unreleased fix.
+The user's actual game startup with shadows enabled is still pending.
+
 ## Build process note
 
 The sandboxed process environment supplied both `Path` and `PATH`, causing the
@@ -83,8 +138,9 @@ environment succeeded; no system environment setting was changed.
 
 ## Verified outcome and remaining scope
 
-The direct Release startup objective is complete: the user confirmed error-free
-startup and the runtime logs verify that the earlier loading failures are gone.
+The earlier resource-path fix was verified by the user's error-free startup.
+The later dynamic-shadow resource-group correction still requires the checks
+described above; do not treat the earlier confirmation as verification of shadows.
 Broader gameplay and visual QA remain with the user; Debug runtime staging and
 packaging remain separate, unverified work. The game version remains 0.7.1;
 no release has been published.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -220,6 +220,57 @@ The user must launch the rebuilt Release executable and enter
 stability and lighting/shadow appearance. This correction is ready for that test;
 the actual gameplay result and shadow coverage remain unverified.
 
+## Resource-path regression after the GUI-scaling clean build
+
+On September 5, 2026, the clean Release build of the corrected fork-based
+`feature/gui-scaling` branch completed at 23:18:43. During that build, CMake had
+regenerated `build/windows/resources.cfg` at 23:10:13. Both `Graphics` and
+`OgreInternal` then pointed to
+`build/windows/install/share/OGRE/Media/RTShaderLib/../Main`, which does not exist.
+The required header still exists under
+`C:\Users\mario\od-deps\install\Media\Main\OgreUnifiedShader.h`.
+
+The user's 23:21:36 start reached CEGUI initialization and logged:
+
+```text
+Cannot locate resource OgreUnifiedShader.h in resource group OgreInternal.
+```
+
+The same log records the nonexistent path being registered in `OgreInternal`.
+The resource group was present; its directory was wrong. The Windows runtime
+preparation step had been omitted after CMake regenerated the configuration.
+
+Running the existing
+[runtime preparation script](../../scripts/win32/prepare-windows-runtime.ps1)
+restored the installed media paths at 23:23:55. Its first attempt stopped because
+the failed game process still held a runtime DLL open; it succeeded after that
+process was stopped. No game source, dependency version or executable changed.
+The [build instructions](BUILDING.md#3-build-the-game) now include runtime
+preparation immediately after both normal and clean Release builds.
+
+Verification found all 15 configured resource entries accessible, including
+`Media/Main` in both groups, and the required shader header present. The existing
+`shadow-resource-probe.exe` loaded the corrected configuration with the installed
+OGRE DLL and exited with code 0: the game shader header opens in `Graphics`, and
+all four internal shadow programs resolve and load. The probe creates no renderer
+or game window and does not verify CEGUI initialization or rendering.
+
+Evidence is retained under `build/windows`:
+
+- `gui-scaling-before-runtime-refresh-game.log`: the user's failed startup.
+- `gui-scaling-after-runtime-refresh-resources.cfg`: the corrected configuration.
+- `gui-scaling-runtime-probe.log` and `gui-scaling-runtime-probe-Ogre.log`: the
+  successful isolated resource check.
+
+The user's subsequent run reached the main-menu scene at 23:27:27 and shut down
+normally at 23:28:32, and the user confirmed startup. The reported settings
+geometry and clipping defects are documented with their corrections in
+[GUI-SCALING.md](GUI-SCALING.md#settings-geometry-and-clipping-correction).
+The user subsequently confirmed that these settings corrections work, and the
+updated game's 23:47 run reached a game map and shut down normally. The complete
+manual GUI matrix has not been confirmed individually; this result alone does not
+complete roadmap step 1.
+
 ## Build process note
 
 The sandboxed process environment supplied both `Path` and `PATH`, causing the

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -117,7 +117,7 @@ The preserved evidence under `build/windows` is:
 - `shadow-probe-after.log`: all four internal shadow lookups and their source-file
   loads succeed, and the game shader header remains accessible, exit code 0.
 - `shadow-resource-validation.json`: configuration, probe and unchanged executable
-  evidence, with actual game startup explicitly marked as pending.
+  evidence from before the user's subsequent startup attempt.
 
 The probe checks resource registration, program lookup and source-file loading;
 without a renderer, OGRE uses null shader programs, so it does not verify shader
@@ -127,7 +127,98 @@ The user configuration still enables dynamic shadows at 3440 x 1440 fullscreen.
 The executable is unchanged, so no C++ rebuild is required for this template-only
 fix. The game version remains 0.7.1; the root README already links to this startup
 record, and no separate release changelog entry is needed for this unreleased fix.
-The user's actual game startup with shadows enabled is still pending.
+The user's subsequent 14:52:23 run had shadows enabled and reached CEGUI and the
+main-menu scene at 14:52:24, confirming that the blocking shadow-program lookup is
+resolved during actual startup. A later failure while entering a level is tracked
+separately below; shadow appearance and broader gameplay remain unverified.
+
+## Legacy test-map exception after successful startup
+
+The same user-launched run selected
+`levels/skirmish/TestLegacyNoScripts.level` at 14:52:53. Client/server setup
+completed, the client was accepted at 14:52:55 and the server started its first
+turn at 14:52:58. The frame listener then began destruction without reaching the
+normal post-render-loop `Disconnecting client...` message in `ODApplication.cpp`.
+CEGUI and OGRE subsequently shut down. This identifies exception unwinding after
+entering the level, but the existing logs do not contain the exception text.
+
+The logs contain rejected legacy skills, missing mesh material assignments and
+server-side attempts to rotate objects without rendering nodes. These messages
+precede further execution and do not by themselves identify the fatal exception;
+none has been changed speculatively.
+
+The diagnostic gap is in the exception path: `startGame` owns the file logger,
+which was destroyed before `main.cpp` displayed caught exceptions in a Windows
+dialog. [ODApplication.cpp](../../source/ODApplication.cpp) now logs
+`std::exception::what()` while that logger remains alive, then rethrows the same
+exception to preserve the existing dialog and exit behavior. This covers OGRE,
+CEGUI and standard C++ exceptions; it is diagnostic instrumentation, not a claim
+that the gameplay failure is fixed.
+
+Both diagnostic builds, Release and Debug, completed successfully with exit code 0:
+`build/windows/game-Release-exception-diagnostics.log` and
+`build/windows/game-Debug-exception-diagnostics.log`.
+The pre-change logs are preserved as `build/windows/legacy-crash-before-Ogre.log`,
+`legacy-crash-before-game.log` and `legacy-crash-before-CEGUI.log`.
+
+### Captured cause and correction
+
+The user's diagnostic run reached the main menu at 15:05:03 and selected the same
+map at 15:05:11. At 15:05:19, the added logging captured an
+`Ogre::InvalidStateException` before the dialog:
+
+```text
+RenderSystem does not support FixedFunction, but technique of 'DirtInstanced'
+has no Fragment Shader. Use the RTSS or write custom shaders.
+```
+
+The exception originates in OGRE 13.6.5's `SceneManager::_setPass`,
+`OgreMain/src/OgreSceneManager.cpp:935`, in the installed dependency source tree.
+The captured logs are preserved under `build/windows` as
+`legacy-crash-diagnostic-Ogre.log`, `legacy-crash-diagnostic-game.log` (line 897)
+and `legacy-crash-diagnostic-CEGUI.log`.
+
+The original [DirtInstanced material](../../materials/scripts/DirtInstanced.material)
+already defines both a vertex and a fragment program. The missing program is on
+a derived pass: the game enabled `SHADOWTYPE_TEXTURE_ADDITIVE`, causing OGRE to
+split opaque material passes into ambient, per-light and decal stages. In
+`OgreTechnique.cpp`, this automatic splitting clears fragment programs on derived
+ambient and per-light passes. GL3Plus cannot draw these fixed-function passes.
+The material is used by the instanced unrevealed ground tiles created when the
+level starts, explaining why startup could succeed before entering the map.
+
+[RenderManager.cpp](../../source/render/RenderManager.cpp) now uses
+`SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED`. This keeps texture-shadow generation
+enabled while retaining the existing custom lighting/shadow shader passes instead
+of generating incompatible illumination passes. The game's shaders already
+calculate lighting and sample shadow maps; this matches OGRE's documented
+[integrated texture-shadow mode](https://ogrecave.github.io/ogre/api/13/_shadows.html#Integrated-Texture-Shadows).
+The shadow toggle, material definitions and user configuration are unchanged.
+
+### Verification
+
+- The user's reproduction verified that exception logging records the actual
+  fatal error before the existing Windows dialog.
+- `build/windows/illumination-pass-probe.cpp` exercises the installed OGRE DLL's
+  real material-pass splitting and render queue, without a renderer or game
+  window. Its representative programmable pass has the same default lighting,
+  ambient and diffuse state as DirtInstanced; it uses null shader programs and
+  no textures. The queue flags follow `SceneManager::updateRenderQueueSplitOptions`.
+- `illumination-pass-additive.log`: two queued passes, both missing their fragment
+  programs, exit code 1.
+- `illumination-pass-integrated.log`: one unchanged original pass with its fragment
+  program, exit code 0. `illumination-pass-off.log` also passes, exit code 0.
+- Release and Debug rebuilt successfully, exit code 0, with logs in
+  `game-Release-integrated-shadows.log` and `game-Debug-integrated-shadows.log`.
+  The Release executable was rebuilt at 15:17:22 and Debug at 15:17:29.
+  Binary hashes and test scope are recorded in `integrated-shadow-validation.json`.
+
+These checks verify the identified pass-generation failure and successful builds;
+they do not compile the actual GLSL on the GPU or verify the rendered scene.
+The user must launch the rebuilt Release executable and enter
+`TestLegacyNoScripts.level` again with dynamic shadows enabled, then check both
+stability and lighting/shadow appearance. This correction is ready for that test;
+the actual gameplay result and shadow coverage remain unverified.
 
 ## Build process note
 
@@ -139,8 +230,12 @@ environment succeeded; no system environment setting was changed.
 ## Verified outcome and remaining scope
 
 The earlier resource-path fix was verified by the user's error-free startup.
-The later dynamic-shadow resource-group correction still requires the checks
-described above; do not treat the earlier confirmation as verification of shadows.
+The later dynamic-shadow resource-group correction passed the isolated resource
+check and the user's subsequent main-menu startup with shadows enabled.
+The separate Legacy test-map exception was captured and traced to automatic
+illumination-pass splitting; the integrated shadow-mode correction passed the
+isolated OGRE pass test and both builds. Verification in the user's game session
+is still pending.
 Broader gameplay and visual QA remain with the user; Debug runtime staging and
 packaging remain separate, unverified work. The game version remains 0.7.1;
 no release has been published.

--- a/gui/MenuMain.layout
+++ b/gui/MenuMain.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Root" >
-        <Property name="Area" value="{{0,40},{0,10},{1,-40},{1,-10}}" />
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Window type="OD/StaticImage" name="WelcomeBanner" >
             <Property name="Area" value="{{0.5,-320},{0,52},{0.5,320},{0,191}}" />

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -61,8 +61,7 @@
                     </Window>
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
                         <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
-                        <Property name="Text" value="VSync*" />
-                        <Property name="TooltipText" value="* Needs a restart to be potentially applied." />
+                        <Property name="Text" value="VSync" />
                     </Window>
                 </Window>
             </Window>
@@ -102,12 +101,12 @@
                     <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
                         <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
                         <Property name="Text" value="Keyboard grab" />
-                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
                         <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
                         <Property name="Text" value="Mouse grab" />
-                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="AutoscrollCheckbox" >
                         <Property name="Area" value="{{0,32},{0,120},{0,150},{0,140}}" />

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,50},{0,750},{0,550}}" />
+        <Property name="Area" value="{{0.5,-272.5},{0.5,-250},{0.5,272.5},{0.5,250}}" />
         <Property name="Text" value="Settings" />
         <Property name="SizingEnabled" value="False" />
         <Property name="AlwaysOnTop" value="True" />
@@ -62,6 +62,18 @@
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
                         <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
                         <Property name="Text" value="VSync" />
+                    </Window>
+                    <Window type="OD/StaticText" name="UIScaleText" >
+                        <Property name="Area" value="{{0,22},{0,150},{0,184},{0,170}}" />
+                        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                        <Property name="Text" value="UI Scale:" />
+                        <Property name="BackgroundEnabled" value="False" />
+                        <Property name="FrameEnabled" value="False" />
+                    </Window>
+                    <Window type="OD/Combobox" name="UIScaleCombobox" >
+                        <Property name="Area" value="{{0,202},{0,145},{0,346},{0,265}}" />
+                        <Property name="ReadOnly" value="True" />
+                        <Property name="TooltipText" value="Scales the interface immediately. Apply saves the setting." />
                     </Window>
                 </Window>
             </Window>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -17,7 +17,7 @@
             <Property name="IconImage" value="OpenDungeonsIcons/CheckIcon" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,10},{0,20},{1,-10},{1,-70}}" />
+            <Property name="Area" value="{{0,10},{0,32},{1,-10},{1,-70}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Window type="DefaultWindow" name="Video" >
@@ -28,26 +28,26 @@
                 <Window type="OD/ScrollablePane" name="VideoSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="ResolutionText" >
-                        <Property name="Area" value="{{0,22},{0,31},{0,184},{0,43}}" />
+                        <Property name="Area" value="{{0,22},{0,20},{0,184},{0,46}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Resolution:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="ResolutionCombobox" >
-                        <Property name="Area" value="{{0,22},{0,42},{0,166},{0,162}}" />
+                        <Property name="Area" value="{{0,22},{0,48},{0,166},{0,168}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/Checkbox" name="FullscreenCheckbox" >
-                        <Property name="Area" value="{{0,202},{0,42},{0,302},{0,68}}" />
+                        <Property name="Area" value="{{0,202},{0,48},{0,302},{0,74}}" />
                         <Property name="Text" value="Fullscreen" />
                     </Window>
                     <Window type="OD/Checkbox" name="DynamicShadowsCheckbox" >
-                        <Property name="Area" value="{{0,342},{0,42},{0,542},{0,68}}" />
+                        <Property name="Area" value="{{0,322},{0,48},{0,502},{0,74}}" />
                         <Property name="Text" value="Dynamic Shadows" />
                     </Window>                   
                     <Window type="OD/StaticText" name="RendererText" >
-                        <Property name="Area" value="{{0,22},{0,78},{0,184},{0,90}}" />
+                        <Property name="Area" value="{{0,22},{0,88},{0,184},{0,114}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Renderer*:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -55,23 +55,23 @@
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Combobox" name="RendererCombobox" >
-                        <Property name="Area" value="{{0,22},{0,90},{0,266},{0,210}}" />
+                        <Property name="Area" value="{{0,22},{0,116},{0,266},{0,236}}" />
                         <Property name="ReadOnly" value="True" />
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
-                        <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
+                        <Property name="Area" value="{{0,22},{0,156},{0,166},{0,182}}" />
                         <Property name="Text" value="VSync" />
                     </Window>
                     <Window type="OD/StaticText" name="UIScaleText" >
-                        <Property name="Area" value="{{0,22},{0,150},{0,184},{0,170}}" />
+                        <Property name="Area" value="{{0,22},{0,194},{0,184},{0,220}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="UI Scale:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="UIScaleCombobox" >
-                        <Property name="Area" value="{{0,202},{0,145},{0,346},{0,265}}" />
+                        <Property name="Area" value="{{0,202},{0,190},{0,346},{0,310}}" />
                         <Property name="ReadOnly" value="True" />
                         <Property name="TooltipText" value="Scales the interface immediately. Apply saves the setting." />
                     </Window>
@@ -86,7 +86,7 @@
                 <Window type="OD/ScrollablePane" name="AudioSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="MusicText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,66}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Music:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -111,29 +111,29 @@
                 <Window type="OD/ScrollablePane" name="InputSP" >
                     <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                     <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,66}}" />
                         <Property name="Text" value="Keyboard grab" />
                         <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
+                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,106}}" />
                         <Property name="Text" value="Mouse grab" />
                         <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="AutoscrollCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,140}}" />
+                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,146}}" />
                         <Property name="Text" value="Autoscroll" />
                         <Property name="TooltipText" value="When checked, if the mouse cousor is on the screen border it will make camera fly " />
                     </Window>
                     <Window type="OD/StaticText" name="PanSpeedText" >
-                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,180}}" />
+                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,186}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Camera pan speed: 100%" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="PanSpeedSlider" >
-                        <Property name="Area" value="{{0,32},{0,180},{0,327},{0,193}}" />
+                        <Property name="Area" value="{{0,32},{0,190},{0,327},{0,203}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />
@@ -152,47 +152,47 @@
                 <Window type="OD/ScrollablePane" name="GameSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="NicknameText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,46},{0,150},{0,72}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Nickname:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Editbox" name="NicknameEdit" >
-                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,60}}" />
+                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,80}}" />
                         <Property name="Text" value="" />
                     </Window>
                     <Window type="OD/StaticText" name="KeeperVoiceText" >
-                        <Property name="Area" value="{{0,32},{0,70},{0,150},{0,90}}" />
+                        <Property name="Area" value="{{0,32},{0,90},{0,150},{0,116}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Keeper Voice:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="KeeperVoice" >
-                        <Property name="Area" value="{{0,160},{0,70},{0,320},{0,150}}" />
+                        <Property name="Area" value="{{0,160},{0,90},{0,320},{0,190}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="MinimapText" >
-                        <Property name="Area" value="{{0,32},{0,100},{0,150},{0,120}}" />
+                        <Property name="Area" value="{{0,32},{0,130},{0,150},{0,156}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Minimap Type:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="MiniMapType" >
-                        <Property name="Area" value="{{0,160},{0,100},{0,320},{0,180}}" />
+                        <Property name="Area" value="{{0,160},{0,130},{0,320},{0,230}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="LightText" >
-                        <Property name="Area" value="{{0,32},{0,130},{0,220},{0,150}}" />
+                        <Property name="Area" value="{{0,32},{0,170},{0,220},{0,196}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Ambient Light: +" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="LightSlider" >
-                        <Property name="Area" value="{{0,32},{0,150},{0,327},{0,163}}" />
+                        <Property name="Area" value="{{0,32},{0,200},{0,327},{0,213}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -106,14 +106,14 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TempleButton" >
-            <Property name="Area" value="{{0,570},{0,20},{0,630},{0,80}}" />
+            <Property name="Area" value="{{0,300},{0,50},{0,340},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TempleButton" />
             <Property name="TooltipText" value="Build a Temple (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="PortalButton" >
-            <Property name="Area" value="{{0,630},{0,20},{0,690},{0,80}}" />
+            <Property name="Area" value="{{0,340},{0,50},{0,380},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PortalButton" />
             <Property name="TooltipText" value="Build a Portal (3x3)" />

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -120,7 +120,7 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WavePortalButton" >
-            <Property name="Area" value="{{0,690},{0,20},{0,750},{0,80}}" />
+            <Property name="Area" value="{{0,380},{0,50},{0,420},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WavePortalButton" />
             <Property name="TooltipText" value="Build a Wave portal (3x3), the room that sends waves of enemies" />

--- a/gui/WindowTabSpells.layout
+++ b/gui/WindowTabSpells.layout
@@ -8,14 +8,18 @@
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
+        <!-- Two rows of 40x40, the same shape the rooms tab uses: one row of 60s
+             ran to x=700 and the last buttons fell off the right edge of the tab,
+             which is only window width - 200 wide, at anything close to the
+             minimum window size. -->
         <Window type="OD/GameTabButton" name="SummonWorkerButton" >
-            <Property name="Area" value="{{0,100},{0,25},{0,160},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,10},{0,140},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SummonWorkerButton" />
             <Property name="TooltipText" value="Summon a worker" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SummonWorkerButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -27,13 +31,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CallToWarButton" >
-            <Property name="Area" value="{{0,160},{0,25},{0,220},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,10},{0,180},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CallToWarButton" />
             <Property name="TooltipText" value="Casts a spell that calls available creatures" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CallToWarButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -45,13 +49,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHealButton" >
-            <Property name="Area" value="{{0,220},{0,25},{0,280},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,10},{0,220},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHealButton" />
             <Property name="TooltipText" value="Casts a spell that heals owned creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHealButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -63,13 +67,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureExplosionButton" >
-            <Property name="Area" value="{{0,280},{0,25},{0,340},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,10},{0,260},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
             <Property name="TooltipText" value="Casts a spell that damages enemy creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureExplosionButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -81,13 +85,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHasteButton" >
-            <Property name="Area" value="{{0,340},{0,25},{0,400},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,10},{0,300},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHasteButton" />
             <Property name="TooltipText" value="Increases, target speed. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHasteButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -99,13 +103,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureDefenseButton" >
-            <Property name="Area" value="{{0,400},{0,25},{0,460},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,50},{0,140},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureDefenseButton" />
             <Property name="TooltipText" value="Increases target physical defense. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureDefenseButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -117,13 +121,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureSlowButton" >
-            <Property name="Area" value="{{0,460},{0,25},{0,520},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,50},{0,180},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureSlowButton" />
             <Property name="TooltipText" value="Decrease target speed. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureSlowButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -135,13 +139,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureStrengthButton" >
-            <Property name="Area" value="{{0,520},{0,25},{0,580},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,50},{0,220},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureStrengthButton" />
             <Property name="TooltipText" value="Increase target strength. Target: allied creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureStrengthButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -153,13 +157,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureWeakButton" >
-            <Property name="Area" value="{{0,580},{0,25},{0,640},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,50},{0,260},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureWeakButton" />
             <Property name="TooltipText" value="Decrease target strength. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureWeakButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -171,13 +175,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="SpellEyeEvilButton" >
-            <Property name="Area" value="{{0,640},{0,25},{0,700},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,50},{0,300},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SpellEyeEvilButton" />
             <Property name="TooltipText" value="Temporary gives vision on tiles without vision. Target: any tile" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SpellEyeEvilButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -14,3 +14,4 @@ $ErrorActionPreference = 'Continue'
 $ErrorActionPreference = 'Stop'
 if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
 Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,6 +1,15 @@
 $ErrorActionPreference = 'Stop'
 $taskRoot = 'C:\Users\mario\od-deps'
 $taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
     "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -9,6 +9,13 @@ if ($LASTEXITCODE -ne 0) {
     & git -C "$taskRoot\src\cegui" apply $taskPatch
     if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
 }
+$taskClippingPatch = Join-Path $PSScriptRoot 'patches/cegui-ogre-clipping.patch'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskClippingPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Restoring CEGUI Ogre rendering clip regions'
+    & git -C "$taskRoot\src\cegui" apply $taskClippingPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI clipping patch failed' }
+}
 $ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,6 +1,15 @@
 $ErrorActionPreference = 'Stop'
 $taskRoot = 'C:\Users\mario\od-deps'
 $taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/ogre-multiwindow-settings.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\ogre" apply --recount --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying OGRE multi-window settings compatibility fixes'
+    & git -C "$taskRoot\src\ogre" apply --recount $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'OGRE compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
     "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/patches/cegui-ogre-clipping.patch
+++ b/scripts/win32/patches/cegui-ogre-clipping.patch
@@ -1,0 +1,11 @@
+diff --git a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
++++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+@@ -211,6 +211,6 @@
+             d_renderSystem._setViewport(currentViewport);
+ #else
+             d_renderSystem.setScissorTest(
+-                false, d_clipRect.left(), d_clipRect.top(),
++                i->clip, d_clipRect.left(), d_clipRect.top(),
+                          d_clipRect.right(), d_clipRect.bottom());
+ #endif

--- a/scripts/win32/patches/ogre-multiwindow-settings.patch
+++ b/scripts/win32/patches/ogre-multiwindow-settings.patch
@@ -1,0 +1,362 @@
+diff --git a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+index 361ff64..f7c6444 100644
+--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
++++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+@@ -126,6 +126,8 @@ namespace Ogre {
+ 
+         void initConfigOptions() override;
+ 
++        void setConfigOption(const String &name, const String &value) override;
++
+         RenderSystemCapabilities* createRenderSystemCapabilities() const override;
+ 
+         void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+index 8b9b623..294afa8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+@@ -74,6 +74,15 @@ namespace Ogre {
+         */
+         GLSLProgram* getActiveProgram(void);
+ 
++        /// Destroy all linked programs in the current OpenGL context.
++        void destroyAllPrograms();
++
++        /// Forget program-pipeline objects owned by a context that is being destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
++        /// Return the context currently selected by the render system.
++        GL3PlusContext* getCurrentContext() const;
++
+         /** Populate a list of uniforms based on an OpenGL program object.
+         */
+         void extractUniformsFromProgram(
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+index 65fec8d..a1b50e7 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+@@ -90,9 +90,12 @@ namespace Ogre
+         */
+         void activate(void) override;
+ 
++        /// Forget the context-local pipeline before its OpenGL context is destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
+     protected:
+-        /// GL handle for pipeline object.
+-        GLuint mGLProgramPipelineHandle;
++        /// GL program-pipeline objects are context-local even when shader programs are shared.
++        std::map<GL3PlusContext*, GLuint> mGLProgramPipelineHandles;
+ 
+         /// Compiles and links the separate programs.
+         void compileAndLink(void) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+index da255e6..9c6271e 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+@@ -62,6 +62,31 @@ namespace Ogre {
+ 
+     GLSLProgramManager::~GLSLProgramManager(void) {}
+ 
++    void GLSLProgramManager::destroyAllPrograms()
++    {
++        for (auto & program : mPrograms)
++        {
++            delete program.second;
++        }
++        mPrograms.clear();
++        mActiveProgram = NULL;
++    }
++
++    void GLSLProgramManager::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        for (auto & program : mPrograms)
++        {
++            if (auto separableProgram = dynamic_cast<GLSLSeparableProgram*>(program.second))
++                separableProgram->notifyContextDestroyed(context);
++        }
++        mActiveProgram = NULL;
++    }
++
++    GL3PlusContext* GLSLProgramManager::getCurrentContext() const
++    {
++        return mRenderSystem->_getCurrentContext();
++    }
++
+     GL3PlusStateCacheManager* GLSLProgramManager::getStateCacheManager()
+     {
+         return mRenderSystem->_getStateCacheManager();
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+index f22f44f..278f7e8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+@@ -45,14 +45,32 @@ namespace Ogre
+ 
+     GLSLSeparableProgram::~GLSLSeparableProgram()
+     {
+-        OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &mGLProgramPipelineHandle));
++        notifyContextDestroyed(GLSLProgramManager::getSingleton().getCurrentContext());
++        mGLProgramPipelineHandles.clear();
+     }
+ 
+     void GLSLSeparableProgram::compileAndLink()
+     {
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        OgreAssert(context, "cannot create a program pipeline without an active OpenGL context");
++
++        if (!mLinked)
++        {
++            auto currentPipeline = mGLProgramPipelineHandles.find(context);
++            if (currentPipeline != mGLProgramPipelineHandles.end())
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &currentPipeline->second));
++            mGLProgramPipelineHandles.clear();
++        }
++
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline != mGLProgramPipelineHandles.end())
++            return;
++
+         // Ensure no monolithic programs are in use.
+         OGRE_CHECK_GL_ERROR(glUseProgram(0));
+-        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &mGLProgramPipelineHandle));
++        GLuint pipelineHandle = 0;
++        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &pipelineHandle));
+ 
+         mLinked = true;
+ 
+@@ -61,51 +79,69 @@ namespace Ogre
+             if(!s) continue;
+ 
+             if(!s->linkSeparable())
+-        {
++            {
+                 mLinked = false;
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipelineHandle));
+                 return;
+             }
+         }
+ 
+-            GLenum ogre2gltype[GPT_COUNT] = {
+-                GL_VERTEX_SHADER_BIT,
+-                GL_FRAGMENT_SHADER_BIT,
+-                GL_GEOMETRY_SHADER_BIT,
+-                GL_TESS_EVALUATION_SHADER_BIT,
+-                GL_TESS_CONTROL_SHADER_BIT,
+-                GL_COMPUTE_SHADER_BIT
+-            };
++        GLenum ogre2gltype[GPT_COUNT] = {
++            GL_VERTEX_SHADER_BIT,
++            GL_FRAGMENT_SHADER_BIT,
++            GL_GEOMETRY_SHADER_BIT,
++            GL_TESS_EVALUATION_SHADER_BIT,
++            GL_TESS_CONTROL_SHADER_BIT,
++            GL_COMPUTE_SHADER_BIT
++        };
+ 
+-            for (auto s : mShaders)
+-            {
++        for (auto s : mShaders)
++        {
+             if(!s) continue;
+ 
+-                OGRE_CHECK_GL_ERROR(glUseProgramStages(mGLProgramPipelineHandle, ogre2gltype[s->getType()],
+-                                                       s->getGLProgramHandle()));
+-            }
++            OGRE_CHECK_GL_ERROR(glUseProgramStages(pipelineHandle, ogre2gltype[s->getType()],
++                                                   s->getGLProgramHandle()));
++        }
+ 
+-            // Validate pipeline
+-            OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(mGLProgramPipelineHandle));
+-            logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), mGLProgramPipelineHandle );
++        // Validate pipeline
++        OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(pipelineHandle));
++        logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), pipelineHandle );
+ 
+-            //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
+-            //                glObjectLabel(GL_PROGRAM_PIPELINE, mGLProgramPipelineHandle, 0,
+-            //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
+-        }
++        mGLProgramPipelineHandles[context] = pipelineHandle;
++
++        //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
++        //                glObjectLabel(GL_PROGRAM_PIPELINE, pipelineHandle, 0,
++        //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
++    }
+ 
+     void GLSLSeparableProgram::activate(void)
+     {
+-        if (!mLinked)
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (!mLinked || pipeline == mGLProgramPipelineHandles.end())
+         {
+             compileAndLink();
++            pipeline = mGLProgramPipelineHandles.find(context);
+         }
+ 
+-        if (mLinked)
++        if (mLinked && pipeline != mGLProgramPipelineHandles.end())
+         {
+-            GLSLProgramManager::getSingleton().getStateCacheManager()->bindGLProgramPipeline(mGLProgramPipelineHandle);
++            programManager.getStateCacheManager()->bindGLProgramPipeline(pipeline->second);
+         }
+     }
+ 
++    void GLSLSeparableProgram::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline == mGLProgramPipelineHandles.end())
++            return;
++
++        if (GLSLProgramManager::getSingleton().getCurrentContext() == context)
++            OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipeline->second));
++        mGLProgramPipelineHandles.erase(pipeline);
++    }
++
+     void GLSLSeparableProgram::updateUniforms(GpuProgramParametersSharedPtr params,
+                                               uint16 mask, GpuProgramType fromProgType)
+     {
+diff --git a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+index 5695b7f..07e3aa1 100644
+--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
++++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+@@ -34,6 +34,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
+ #include "OgreStringConverter.h"
+ #include "OgreGL3PlusTextureManager.h"
+ #include "OgreGL3PlusHardwareBuffer.h"
++#include "OgreHighLevelGpuProgramManager.h"
+ #include "OgreGLSLShader.h"
+ #include "OgreGpuProgramManager.h"
+ #include "OgreException.h"
+@@ -214,6 +215,78 @@ namespace Ogre {
+         mOptions[opt.name] = opt;
+     }
+ 
++    void GL3PlusRenderSystem::setConfigOption(const String &name, const String &value)
++    {
++        const bool separateShadersChanged = name == "Separate Shader Objects"
++            && mGLInitialised && mSeparateShaderObjectsEnabled != StringConverter::parseBool(value);
++
++        GLRenderSystemCommon::setConfigOption(name, value);
++        if (!mGLInitialised)
++            return;
++
++        if (separateShadersChanged)
++        {
++            std::vector<ResourcePtr> loadedPrograms;
++            ResourceManager::ResourceMapIterator resources =
++                HighLevelGpuProgramManager::getSingleton().getResourceIterator();
++            while (resources.hasMoreElements())
++            {
++                ResourcePtr program = resources.getNext();
++                if (program->isLoaded())
++                    loadedPrograms.push_back(program);
++            }
++            for (int programType = 0; programType < GPT_COUNT; ++programType)
++            {
++                GpuProgramType type = static_cast<GpuProgramType>(programType);
++                if (mCurrentShader[type])
++                    unbindGpuProgram(type);
++            }
++            OGRE_CHECK_GL_ERROR(glUseProgram(0));
++            mStateCacheManager->bindGLProgramPipeline(0);
++            mProgramManager->destroyAllPrograms();
++            for (ResourcePtr & program : loadedPrograms)
++                program->unload();
++
++            mSeparateShaderObjectsEnabled = StringConverter::parseBool(value);
++            if (mSeparateShaderObjectsEnabled)
++                mCurrentCapabilities->setCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            else
++                mCurrentCapabilities->unsetCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            for (ResourcePtr & program : loadedPrograms)
++                program->load();
++        }
++        else if (name == "Reversed Z-Buffer")
++        {
++            const bool clipControlSupported = hasMinGLVersion(4, 5)
++                || checkExtension("GL_ARB_clip_control");
++            mIsReverseDepthBufferEnabled = StringConverter::parseBool(value)
++                && clipControlSupported;
++            if (clipControlSupported)
++            {
++                OGRE_CHECK_GL_ERROR(glClipControl(GL_LOWER_LEFT,
++                    mIsReverseDepthBufferEnabled ? GL_ZERO_TO_ONE : GL_NEGATIVE_ONE_TO_ONE));
++            }
++        }
++        else if (name == "Debug Layer" && getCapabilities()->hasCapability(RSC_DEBUG))
++        {
++            const bool debugEnabled = StringConverter::parseBool(value);
++            if (debugEnabled)
++            {
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT));
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(&GLDebugCallback, NULL));
++                OGRE_CHECK_GL_ERROR(glDebugMessageControlARB(GL_DEBUG_SOURCE_API, GL_DONT_CARE,
++                    GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_FALSE));
++            }
++            else
++            {
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(NULL, NULL));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT));
++            }
++        }
++    }
++
+     RenderSystemCapabilities* GL3PlusRenderSystem::createRenderSystemCapabilities() const
+     {
+         RenderSystemCapabilities* rsc = OGRE_NEW RenderSystemCapabilities();
+@@ -1398,6 +1471,7 @@ namespace Ogre {
+ 
+     void GL3PlusRenderSystem::_unregisterContext(GL3PlusContext *context)
+     {
++        mProgramManager->notifyContextDestroyed(context);
+         static_cast<GL3PlusHardwareBufferManager*>(HardwareBufferManager::getSingletonPtr())->notifyContextDestroyed(context);
+ 
+         for(auto & rt : mRenderTargets)
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+index 70e89c2..8f8178c 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+@@ -327,7 +327,8 @@ namespace Ogre {
+                         mHasPixelFormatARB = true;
+                     else if (ext == "WGL_ARB_multisample")
+                         mHasMultisample = true;
+-                    else if (ext == "WGL_EXT_framebuffer_sRGB")
++                    else if (ext == "WGL_EXT_framebuffer_sRGB"
++                             || ext == "WGL_ARB_framebuffer_sRGB")
+                         mHasHardwareGamma = true;
+                 }
+             }
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+index c4269f8..f46ddff 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+@@ -551,11 +551,8 @@ namespace Ogre {
+ 
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_TOPMOST, mLeft, mTop, width, height,
+-                    SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+-
++                    SWP_FRAMECHANGED | SWP_NOACTIVATE);
++                windowMovedOrResized();
+             }
+             else
+             {               
+@@ -584,9 +581,6 @@ namespace Ogre {
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_NOTOPMOST, left, top, winWidth, winHeight,
+                     SWP_DRAWFRAME | SWP_FRAMECHANGED | SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+                 windowMovedOrResized();
+ 
+             }

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -172,7 +172,7 @@ void ODApplication::startClient()
         std::stringstream ss(videoMode);
         // Ignore the x in the middle
         char ignore;
-        ss >> w >> ignore >> h >> h;
+        ss >> w >> ignore >> h;
 
         w = std::max(w, MIN_WIDTH);
         h = std::max(h, MIN_HEIGHT);
@@ -221,11 +221,7 @@ void ODApplication::startClient()
     
     ogreRoot.initialise(false);
 
-    Ogre::NameValuePairList misc;
-    misc["FSAA"] = "0";
-    misc["vsync"] = "true";
-
-    // You can also later load these from config or allow command-line override
+    Ogre::NameValuePairList misc = ogreRoot.getRenderSystem()->getRenderWindowDescription().miscParams;
 
     OD_LOG_INF("Creating window: with resolution " + Helper::toString(w) + " " + Helper::toString(h));
     
@@ -344,6 +340,7 @@ void ODApplication::startClient()
     Ogre::MaterialManager::getSingleton().removeListener(sgListener);
     delete sgListener;
     Ogre::RTShader::ShaderGenerator::destroy();
+    frameListener.prepareRenderWindowShutdown();
     ogreRoot.destroyRenderTarget(renderWindow);
 }
 

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,7 +235,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -65,6 +65,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <exception>
 
 void ODApplication::startGame(boost::program_options::variables_map& options)
 {
@@ -80,10 +81,20 @@ void ODApplication::startGame(boost::program_options::variables_map& options)
     logMgr.setLevel(resMgr.getLogLevel());
 
 
-    if(resMgr.isServerMode())
-        startServer();
-    else
-        startClient();
+    try
+    {
+        if(resMgr.isServerMode())
+            startServer();
+        else
+            startClient();
+    }
+    catch(const std::exception& error)
+    {
+        // Preserve the exception before the log manager is destroyed and main
+        // displays its Windows error dialog.
+        OD_LOG_ERR("Unhandled exception: " + std::string(error.what()));
+        throw;
+    }
 }
 
 void ODApplication::startServer()

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -80,6 +80,7 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mSwivelDegrees(0.0),
     mTranslateVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mTranslateVectorAccel(Ogre::Vector3(0.0, 0.0, 0.0)),
+    mTranslateMaxSpeedFactor(Ogre::Vector2(1.0, 1.0)),
     mRotateLocalVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mSceneManager(sceneManager),
     mViewport(nullptr)
@@ -309,6 +310,18 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     mTranslateVector *= static_cast<Ogre::Real>(std::max(0.0f, speed - (0.75f + (speed / mMoveSpeed))
                         * mMoveSpeedAcceleration * frameTime));
     mTranslateVector += mTranslateVectorAccel * static_cast<Ogre::Real>(frameTime * 2.0f);
+
+    const Ogre::Real maxMoveSpeedX = mMoveSpeed * mTranslateMaxSpeedFactor.x;
+    if(mTranslateVector.x > maxMoveSpeedX)
+        mTranslateVector.x = maxMoveSpeedX;
+    else if(mTranslateVector.x < -maxMoveSpeedX)
+        mTranslateVector.x = -maxMoveSpeedX;
+
+    const Ogre::Real maxMoveSpeedY = mMoveSpeed * mTranslateMaxSpeedFactor.y;
+    if(mTranslateVector.y > maxMoveSpeedY)
+        mTranslateVector.y = maxMoveSpeedY;
+    else if(mTranslateVector.y < -maxMoveSpeedY)
+        mTranslateVector.y = -maxMoveSpeedY;
 
     // If we have sped up to more than the maximum moveSpeed then rescale the
     // vector to that length. We use the squaredLength() in this calculation
@@ -639,54 +652,70 @@ void CameraManager::move(const Direction direction, double aux)
     Ogre::Real currentPitch = getActiveCameraNode()->getOrientation().getPitch().valueDegrees();
     currentPitch = std::fmod(currentPitch, 90.0f);
 
+    const bool scaledPan = aux > 0.0;
+    const Ogre::Real maxSpeedFactor = scaledPan ?
+        static_cast<Ogre::Real>(std::min(aux, 1.0)) : 1.0f;
+    const auto applyPanAcceleration = [this, scaledPan](Ogre::Real& acceleration, Ogre::Real direction)
+    {
+        const Ogre::Real newAcceleration = direction * mMoveSpeedAcceleration;
+        if(scaledPan)
+            acceleration = newAcceleration;
+        else
+            acceleration += newAcceleration;
+    };
+
     switch (direction)
     {
     case moveRight:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopRight:
         if(mTranslateVectorAccel.x >= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveLeft:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopLeft:
         if(mTranslateVectorAccel.x <= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveBackward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopBackward:
         if(mTranslateVectorAccel.y <= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveForward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopForward:
         if(mTranslateVectorAccel.y >= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveUp:

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -241,6 +241,30 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
     OD_LOG_INF("Creating viewport...");
 }
 
+void CameraManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    Ogre::Viewport* previousViewport = mViewport;
+    Ogre::RenderTarget* previousTarget = previousViewport->getTarget();
+    Ogre::Viewport* viewport = renderWindow->addViewport(mActiveCamera,
+        previousViewport->getZOrder(), previousViewport->getLeft(), previousViewport->getTop(),
+        previousViewport->getWidth(), previousViewport->getHeight());
+    viewport->setBackgroundColour(previousViewport->getBackgroundColour());
+    viewport->setClearEveryFrame(previousViewport->getClearEveryFrame(), previousViewport->getClearBuffers());
+    viewport->setMaterialScheme(previousViewport->getMaterialScheme());
+    viewport->setOverlaysEnabled(previousViewport->getOverlaysEnabled());
+    viewport->setSkiesEnabled(previousViewport->getSkiesEnabled());
+    viewport->setShadowsEnabled(previousViewport->getShadowsEnabled());
+    viewport->setVisibilityMask(previousViewport->getVisibilityMask());
+
+    mViewport = viewport;
+    previousTarget->removeViewport(previousViewport->getZOrder());
+    if(viewport->getActualHeight() > 0)
+    {
+        mActiveCamera->setAspectRatio(static_cast<Ogre::Real>(viewport->getActualWidth())
+            / static_cast<Ogre::Real>(viewport->getActualHeight()));
+    }
+}
+
 const Ogre::Vector3& CameraManager::getActiveCameraPosition() const
 {
     return getActiveCameraNode()->getPosition();

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -163,6 +163,9 @@ public:
     Ogre::Viewport* getViewport()
     { return mViewport; }
 
+    //! \brief Move the main camera viewport to another render window.
+    void setRenderWindow(Ogre::RenderWindow* renderWindow);
+
     void resetHCSNodes(int nodeValue)
     {
         mXHCS.resetNodes(nodeValue);

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -248,6 +248,9 @@ private:
     Ogre::Vector3   mTranslateVector;
     Ogre::Vector3   mTranslateVectorAccel;
 
+    //! \brief Maximum pan speed per axis, used to scale mouse-edge scrolling.
+    Ogre::Vector2   mTranslateMaxSpeedFactor;
+
     //! \brief The X-axis rotation vector, tilting the point of view (look down or up).
     Ogre::Vector3   mRotateLocalVector;
 

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -123,6 +123,7 @@ MiniMapCamera::~MiniMapCamera()
     rt->removeAllListeners();
     Ogre::SceneManager* sceneManager = RenderManager::getSingleton().getSceneManager();
     sceneManager->destroyCamera(mMiniMapCam);
+    sceneManager->destroySceneNode(mMiniMapCamNode);
     Ogre::String mm("miniMapOgreTexture");
     Ogre::TextureManager::getSingletonPtr()->remove(mm,Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     CEGUI::ImageManager::getSingletonPtr()->destroy("MiniMapImageset");
@@ -131,6 +132,8 @@ MiniMapCamera::~MiniMapCamera()
 
 Ogre::Vector2 MiniMapCamera::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     if(mCurCamPosX == -1)
         return Ogre::Vector2::ZERO;
 

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -96,6 +96,8 @@ MiniMapDrawn::~MiniMapDrawn()
 
 Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Real mm, nn, oo, pp;
     // Compute move and normalise
     mm = (xx - mTopLeftCornerX) / static_cast<double>(mWidth) - 0.5;

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -451,6 +451,8 @@ MiniMapDrawnFull::~MiniMapDrawnFull()
 
 Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Vector2 v(0, 0);
     Ogre::Real gainX = static_cast<Ogre::Real>(mGameMap.getMapSizeX())
         / static_cast<Ogre::Real>(mWidth);

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -122,7 +122,7 @@ EditorMode::EditorMode(ModeManager* modeManager):
     mPortalWaveRefreshing(false),
     mMouseX(0),
     mMouseY(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mModifiedMapBit(false)
 {
 

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -29,6 +29,7 @@
 #include "rooms/RoomType.h"
 #include "traps/TrapType.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/MakeUnique.h"
 
 #include <Ogre.h>
@@ -94,6 +95,7 @@ GameEditorModeBase::GameEditorModeBase(ModeManager* modeManager, ModeManager::Mo
     mChatMessageDisplayTime(0),
     mChatMessageBoxDisplay(ChatMessageBoxDisplay::hide),
     mMiniMap(MiniMap::createMiniMap(rootWindow->getChild(Gui::MINIMAP))),
+    mMiniMapType(ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false)),
     mMainCullingManager( new CullingManager(mGameMap, CullingType::SHOW_MAIN_WINDOW)),
     mKeepReplayAtDisconnect(false),
     mCameraTilesIntersections(std::vector<Ogre::Vector3>(4, Ogre::Vector3::ZERO)),
@@ -192,6 +194,14 @@ bool GameEditorModeBase::onMinimapClick(const CEGUI::EventArgs& arg)
 
 void GameEditorModeBase::onFrameStarted(const Ogre::FrameEvent& evt)
 {
+    const std::string miniMapType = ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false);
+    if(miniMapType != mMiniMapType)
+    {
+        delete mMiniMap;
+        mMiniMap = nullptr;
+        mMiniMap = MiniMap::createMiniMap(mRootWindow->getChild(Gui::MINIMAP));
+        mMiniMapType = miniMapType;
+    }
     updateMessages(evt.timeSinceLastFrame);
     if(mMainCullingManager != nullptr)
     {
@@ -336,4 +346,3 @@ void GameEditorModeBase::leaveConsole()
     mCurrentInputMode = InputModeNormal;
     activate();
 }
-

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -156,6 +156,7 @@ protected:
 
     //! \brief The minimap used in this mode
     MiniMap* mMiniMap;
+    std::string mMiniMapType;
 
     //! \brief Culling manager for the main map
     CullingManager* mMainCullingManager;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -387,10 +387,11 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        const double leftIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
-        const double rightIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
-        const double topIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
-        const double bottomIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
+        const bool mouseOverGui = isMouseWheelOnCEGUIWindow();
+        const double leftIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
+        const double rightIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
+        const double topIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
+        const double bottomIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
 
         if (leftIntensity > 0.0)
             ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -87,7 +87,7 @@ GameMode::GameMode(ModeManager *modeManager):
     mDigSetBool(false),
     mIsSpellCooldownDisplayed(false),
     mIndexEvent(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mIsSkillWindowOpen(false),
     mCurrentSkillType(SkillType::nullSkillType),
     mCurrentSkillProgress(0.0),
@@ -2010,7 +2010,7 @@ void GameMode::buildPlayerSettingsWindow()
         mSeatIds.push_back(seat->getId());
         offset += 15;
     }
+
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
 }
-
-
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -70,6 +70,18 @@ const std::string TEXT_SEAT_ID_PREFIX = "TextSeat";
 const std::string TEXT_SEAT_PLAYER_NICKNAME_PREFIX = "TextSeatPlayerNick";
 const std::string TEXT_SEAT_TEAM_ID_PREFIX = "TextSeatTeam";
 
+const double AUTOSCROLL_EDGE_RATIO = 0.02;
+
+static double getAutoscrollIntensity(int mousePosition, int screenSize, bool minimumEdge)
+{
+    if(screenSize <= 1)
+        return 0.0;
+
+    const double edgeSize = AUTOSCROLL_EDGE_RATIO * screenSize;
+    const int distanceFromEdge = minimumEdge ? mousePosition : screenSize - 1 - mousePosition;
+    return std::max(0.0, std::min(1.0, (edgeSize - distanceFromEdge) / edgeSize));
+}
+
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
@@ -375,23 +387,28 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        if (arg.state.X.abs <= 0.02 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft);
+        const double leftIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
+        const double rightIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
+        const double topIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
+        const double bottomIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
+
+        if (leftIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopLeft);
 
-        if (arg.state.X.abs >= 0.98 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight);
+        if (rightIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight, rightIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopRight);
 
-        if (arg.state.Y.abs <= 0.02 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward);
+        if (topIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward, topIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopForward);
 
-        if (arg.state.Y.abs >= 0.98 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward);
+        if (bottomIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward, bottomIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopBackward);            
     }

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -29,6 +29,7 @@
 
 #include <OISInputManager.h>
 #include <OgreRenderWindow.h>
+#include <exception>
 
 InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager(nullptr),
@@ -52,7 +53,10 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mMouse(nullptr),
     mCurrentAMode(nullptr),
     mHighlightedCreature(nullptr),
-    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied)
+    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied),
+    mRenderWindow(renderWindow),
+    mMouseGrab(false),
+    mKeyboardGrab(false)
 #ifdef OD_USE_SFML_WINDOW
     ,
     mListener(Utils::make_unique<SFMLToOISListener>(mCurrentAMode, renderWindow->getWidth(), renderWindow->getHeight()))
@@ -67,17 +71,20 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
         mHotkeyLocation[i].qq = Ogre::Quaternion::IDENTITY;
     }
 
+    ConfigManager& config = ConfigManager::getSingleton();
+    createInputDevices(config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes",
+                       config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes");
+}
+
+void InputManager::createInputDevices(bool mouseGrab, bool keyboardGrab)
+{
 #ifndef OD_USE_SFML_WINDOW
 
     // Get the Window attribute for OIS.
     size_t windowHnd = 0;
-    renderWindow->getCustomAttribute("WINDOW", &windowHnd);
+    mRenderWindow->getCustomAttribute("WINDOW", &windowHnd);
     std::ostringstream windowHndStr;
     windowHndStr << windowHnd;
-
-    ConfigManager& config = ConfigManager::getSingleton();
-    bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
-    bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
 
     //setup parameter list for OIS
     OIS::ParamList paramList;
@@ -101,7 +108,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager = OIS::InputManager::createInputSystem(paramList);
 
     //setup Keyboard
-    auto oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
+    OIS::Keyboard* oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
 
     oisKeyboard->setTextTranslation(OIS::Keyboard::Unicode);
 
@@ -112,6 +119,11 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
 #else
     mKeyboard.reset(new Keyboard());
 #endif
+    mMouseGrab = mouseGrab;
+    mKeyboardGrab = keyboardGrab;
+    setWidthAndHeight(mRenderWindow->getWidth(), mRenderWindow->getHeight());
+    if(mCurrentAMode != nullptr)
+        setCurrentAMode(*mCurrentAMode);
 }
 
 template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
@@ -120,12 +132,79 @@ template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
 InputManager::~InputManager()
 {
     OD_LOG_INF("*** Destroying Input Manager ***");
-#ifndef OD_USE_SFML_WINDOW
-    mInputManager->destroyInputObject(mMouse);
-    mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+    destroyInputDevices();
+}
 
-    OIS::InputManager::destroyInputSystem(mInputManager);
+void InputManager::destroyInputDevices()
+{
+#ifndef OD_USE_SFML_WINDOW
+    if(mInputManager != nullptr)
+    {
+        if(mMouse != nullptr)
+            mInputManager->destroyInputObject(mMouse);
+        if(mKeyboard != nullptr)
+            mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+        OIS::InputManager::destroyInputSystem(mInputManager);
+    }
     mInputManager = nullptr;
+    mMouse = nullptr;
+#endif
+    mKeyboard.reset();
+}
+
+void InputManager::refreshSettings()
+{
+    // Called before capturing input, never from inside an OIS callback.
+    ConfigManager& config = ConfigManager::getSingleton();
+    const bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
+    const bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
+    if(mouseGrab == mMouseGrab && keyboardGrab == mKeyboardGrab)
+        return;
+
+    const bool previousMouseGrab = mMouseGrab;
+    const bool previousKeyboardGrab = mKeyboardGrab;
+    destroyInputDevices();
+    try
+    {
+        createInputDevices(mouseGrab, keyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply input capture settings: " + std::string(error.what()));
+        destroyInputDevices();
+        config.setInputValue(Config::MOUSE_GRAB, previousMouseGrab ? "Yes" : "No");
+        config.setInputValue(Config::KEYBOARD_GRAB, previousKeyboardGrab ? "Yes" : "No");
+        config.saveUserConfig();
+        createInputDevices(previousMouseGrab, previousKeyboardGrab);
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+}
+
+bool InputManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    if(renderWindow == mRenderWindow)
+        return true;
+
+#ifdef OD_USE_SFML_WINDOW
+    return false;
+#else
+    Ogre::RenderWindow* previousWindow = mRenderWindow;
+    destroyInputDevices();
+    mRenderWindow = renderWindow;
+    try
+    {
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not move input to the new render window: " + std::string(error.what()));
+        destroyInputDevices();
+        mRenderWindow = previousWindow;
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+        return false;
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+    return true;
 #endif
 }
 

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -75,6 +75,8 @@ public:
     void setWidthAndHeight(int width, int height);
     void setCurrentAMode(AbstractApplicationMode& mode);
     void handleSFMLEvent(const sf::Event& evt);
+    void refreshSettings();
+    bool setRenderWindow(Ogre::RenderWindow* renderWindow);
 
     OIS::InputManager*  mInputManager;
 
@@ -104,6 +106,11 @@ public:
     
     private:
     AbstractApplicationMode* mCurrentAMode;
+    Ogre::RenderWindow* mRenderWindow;
+    bool mMouseGrab;
+    bool mKeyboardGrab;
+    void createInputDevices(bool mouseGrab, bool keyboardGrab);
+    void destroyInputDevices();
 #ifdef OD_USE_SFML_WINDOW
     std::unique_ptr<SFMLToOISListener> mListener;
 #endif

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -259,6 +259,8 @@ void MenuModeConfigureSeats::activate()
         offset += 30;
     }
 
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
+
     tmpWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers/LaunchGameButton");
     tmpWin->setEnabled(enabled);
 

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -71,7 +71,7 @@ public:
 
 MenuModeMain::MenuModeMain(ModeManager *modeManager):
     AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN),
-    mSettings(SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
+    mSettings(getModeManager().getGui().getGuiSheet(Gui::mainMenu), modeManager->getGui())
 {
     CEGUI::Window* rootWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);
     OD_ASSERT_TRUE(rootWin != nullptr);

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -154,6 +154,7 @@ void ModeManager::checkModeChange()
 void ModeManager::update(const Ogre::FrameEvent& evt)
 {
     checkModeChange();
+    mInputManager.refreshSettings();
 
     // We update the current mode
     AbstractApplicationMode* currentMode = getCurrentMode();

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -18,6 +18,7 @@
 #include "modes/SettingsWindow.h"
 
 #include "gamemap/MiniMap.h"
+#include "network/ODClient.h"
 #include "camera/CameraManager.h"
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
@@ -33,17 +34,20 @@
 #include <CEGUI/WindowManager.h>
 
 #include <OgreRoot.h>
+#include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreSceneManager.h>
 
 #include <SFML/Audio/Listener.hpp>
 
 #include <algorithm>
+#include <exception>
+#include <map>
 
 SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
-    mRootWindow(rootWindow),
-    dynamicShadowsChanged(false)
+    mRootWindow(rootWindow)
 {
     if (rootWindow == nullptr)
     {
@@ -140,14 +144,6 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
             CEGUI::Event::Subscriber(&SettingsWindow::onPopupApplySettings, this)
         )
     );
-
-    addEventConnection(
-        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/DynamicShadowsCheckbox")->subscribeEvent(
-            CEGUI::ToggleButton::EventSelectStateChanged,
-            CEGUI::Event::Subscriber(&SettingsWindow::onTriggerDynamicShadows, this)
-        )
-    );
-    
 
     initConfig();
 }
@@ -292,7 +288,6 @@ void SettingsWindow::initConfig()
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
     dynamicShadowsCheckBox->setSelected( config.getUserValue(Config::Ctg::AUDIO,Config::SHADOWS,"",false) == "Yes");
-    dynamicShadowsChanged = false;
     Ogre::ConfigOptionMap::const_iterator it = options.find(Config::VIDEO_MODE);
     if (it != options.end())
     {
@@ -409,7 +404,7 @@ void SettingsWindow::initConfig()
     }
 }
 
-void SettingsWindow::saveConfig()
+bool SettingsWindow::saveConfig()
 {
     Ogre::Root* ogreRoot = Ogre::Root::getSingletonPtr();
     ConfigManager& config = ConfigManager::getSingleton();
@@ -419,6 +414,7 @@ void SettingsWindow::saveConfig()
     CEGUI::Editbox* usernameEb = static_cast<CEGUI::Editbox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/NicknameEdit"));
     config.setGameValue(Config::NICKNAME, usernameEb->getText().c_str());
+    ODClient::getSingleton().requestNicknameChange(usernameEb->getText().c_str());
 
     CEGUI::Combobox* keeperVoiceCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/KeeperVoice"));
@@ -470,98 +466,136 @@ void SettingsWindow::saveConfig()
     // Video
     Ogre::RenderSystem* renderer = ogreRoot->getRenderSystem();
 
-    // Changing Ogre renderer needs a restart to allow to load shaders and requested stuff
     CEGUI::Combobox* rdrCb = static_cast<CEGUI::Combobox*>(
     mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/RendererCombobox"));
     std::string rendererName = rdrCb->getSelectedItem()->getText().c_str();
-    if (rendererName != renderer->getName() || dynamicShadowsChanged)
+    if (rendererName != renderer->getName())
     {
-        renderer = ogreRoot->getRenderSystemByName(rendererName);
-        if (renderer == nullptr)
-        {
-            const Ogre::RenderSystemList& renderers = ogreRoot->getAvailableRenderers();
-            if (renderers.empty())
-            {
-                OD_LOG_ERR("No valid renderer found while searching for " + std::string(rdrCb->getSelectedItem()->getText().c_str()));
-                return;
-            }
-            renderer = *renderers.begin();
-            OD_LOG_WRN("Wanted renderer : " + std::string(rdrCb->getSelectedItem()->getText().c_str()) + " not found. Using the first available: " + renderer->getName());
-        }
-
-        config.setVideoValue(Config::RENDERER, renderer->getName());
-        config.saveUserConfig();
-
-        // If render changed, we need to restart game.
-        // Note that we do not change values according to the others inputs. The reason
-        // is that we don't know if the given values are acceptable for the selected renderer
-        if(rendererName != renderer->getName())
-            OD_LOG_INF("Changed Ogre renderer to " + rendererName + ". We need to restart");
-        else
-            OD_LOG_INF("Changed Ogre dynamic shadows. We need to restart.");
-        exit(0);
+        OD_LOG_ERR("Cannot replace the active renderer while the game is running: " + rendererName);
+        return false;
     }
 
-    
     config.setVideoValue(Config::RENDERER, renderer->getName());
 
-    // Set renderer-dependent options now we know it didn't change.
     CEGUI::ToggleButton* fsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/FullscreenCheckbox"));
-    renderer->setConfigOption(Config::FULL_SCREEN, (fsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::FULL_SCREEN, fsCheckBox->isSelected() ? "Yes" : "No");
-
     CEGUI::Combobox* resCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/ResolutionCombobox"));
-    renderer->setConfigOption(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-    config.setVideoValue(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-
-    // Stores the renderer dependent options
     CEGUI::ToggleButton* vsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/VSyncCheckbox"));
-    renderer->setConfigOption(Config::VSYNC, (vsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::VSYNC, fsCheckBox->isSelected() ? "Yes" : "No");
 
-    // Save renderer dependent settings and apply them.
+    std::map<std::string, std::string> selectedVideoOptions;
+    selectedVideoOptions[Config::FULL_SCREEN] = fsCheckBox->isSelected() ? "Yes" : "No";
+    selectedVideoOptions[Config::VIDEO_MODE] = resCb->getSelectedItem()->getText().c_str();
+    selectedVideoOptions[Config::VSYNC] = vsCheckBox->isSelected() ? "Yes" : "No";
     for (CEGUI::Window* combo : mCustomVideoComboBoxes)
-    {
-        std::string optionName = combo->getName().c_str();
-        std::string optionValue = combo->getText().c_str();
-        renderer->setConfigOption(optionName, optionValue);
-        config.setVideoValue(optionName, optionValue);
-    }
+        selectedVideoOptions[combo->getName().c_str()] = combo->getText().c_str();
 
-    config.saveUserConfig();
-
-    // Apply config
-
-    // Video
-    Ogre::RenderWindow* win = ogreRoot->getAutoCreatedWindow();
-    if(win == nullptr)
+    const Ogre::ConfigOptionMap initialRendererOptions = renderer->getConfigOptions();
+    std::map<std::string, std::string> previousRendererOptions;
+    std::map<std::string, std::string> previousVideoConfig;
+    bool resizeRenderWindow = false;
+    bool recreateRenderWindow = false;
+    for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
     {
-        OD_LOG_WRN("Changing window options when using sfml is not implemented yet! Please restart for the changes to have an effect.");
-    }
-    else
-    {
-        std::vector<std::string> resVtr = Helper::split(resCb->getSelectedItem()->getText().c_str(), 'x');
-        if (resVtr.size() == 2)
+        Ogre::ConfigOptionMap::const_iterator previous = initialRendererOptions.find(selected.first);
+        if(previous == initialRendererOptions.end())
+            continue;
+        previousRendererOptions[selected.first] = previous->second.currentValue;
+        previousVideoConfig[selected.first] = config.getVideoValue(
+            selected.first, previous->second.currentValue, false);
+        if(previous->second.currentValue == selected.second)
+            continue;
+        if(selected.first == Config::FULL_SCREEN || selected.first == Config::VIDEO_MODE)
         {
-            uint32_t width = static_cast<uint32_t>(Helper::toInt(resVtr[0]));
-            uint32_t height = static_cast<uint32_t>(Helper::toInt(resVtr[1]));
-            win->setFullscreen(fsCheckBox->isSelected(), width, height);
-
-            // In windowed mode, the window needs resizing through other means
-            // NOTE: Doesn't work when the window is maximized on certain Composers.
-            if (!fsCheckBox->isSelected())
-              win->resize(width, height);
+            resizeRenderWindow = true;
+            continue;
+        }
+        if(selected.first != Config::VSYNC && selected.first != "VSync Interval"
+            && selected.first != "Reversed Z-Buffer"
+            && selected.first != "Separate Shader Objects" && selected.first != "Debug Layer")
+        {
+            recreateRenderWindow = true;
         }
     }
+
+    ODFrameListener& frameListener = ODFrameListener::getSingleton();
+    try
+    {
+        renderer->setConfigOption(Config::FULL_SCREEN, selectedVideoOptions[Config::FULL_SCREEN]);
+        renderer->setConfigOption(Config::VIDEO_MODE, selectedVideoOptions[Config::VIDEO_MODE]);
+        renderer->setConfigOption(Config::VSYNC, selectedVideoOptions[Config::VSYNC]);
+        for (CEGUI::Window* combo : mCustomVideoComboBoxes)
+            renderer->setConfigOption(combo->getName().c_str(), combo->getText().c_str());
+
+        for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
+            config.setVideoValue(selected.first, selected.second);
+        config.saveUserConfig();
+
+        const Ogre::SceneManager::CameraList& cameras = RenderManager::getSingleton().getSceneManager()->getCameras();
+        for(const std::pair<const Ogre::String, Ogre::Camera*>& camera : cameras)
+            camera.second->setAspectRatio(camera.second->getAspectRatio());
+
+        if(recreateRenderWindow)
+        {
+            frameListener.requestRenderWindowRecreation(previousRendererOptions, previousVideoConfig);
+        }
+        else
+        {
+            Ogre::RenderWindow* window = frameListener.getRenderWindow();
+            if(resizeRenderWindow)
+            {
+                const std::vector<std::string> resolution = Helper::split(
+                    selectedVideoOptions[Config::VIDEO_MODE], 'x');
+                if(resolution.size() != 2)
+                    throw std::runtime_error("invalid video mode: " + selectedVideoOptions[Config::VIDEO_MODE]);
+
+                const uint32_t width = static_cast<uint32_t>(Helper::toInt(resolution[0]));
+                const uint32_t height = static_cast<uint32_t>(Helper::toInt(resolution[1]));
+                const bool fullscreen = fsCheckBox->isSelected();
+                window->setFullscreen(fullscreen, width, height);
+                if(!fullscreen)
+                    window->resize(width, height);
+                window->windowMovedOrResized();
+                frameListener.windowResized(window);
+            }
+            window->setVSyncInterval(static_cast<unsigned int>(Helper::toInt(
+                config.getVideoValue("VSync Interval", "1", false))));
+            window->setVSyncEnabled(vsCheckBox->isSelected());
+        }
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        std::map<std::string, std::string>::const_iterator fullscreen =
+            previousRendererOptions.find(Config::FULL_SCREEN);
+        if(fullscreen != previousRendererOptions.end())
+            renderer->setConfigOption(fullscreen->first, fullscreen->second);
+        std::map<std::string, std::string>::const_iterator videoMode =
+            previousRendererOptions.find(Config::VIDEO_MODE);
+        if(videoMode != previousRendererOptions.end())
+            renderer->setConfigOption(videoMode->first, videoMode->second);
+        for(const std::pair<const std::string, std::string>& option : previousRendererOptions)
+        {
+            if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+                continue;
+            renderer->setConfigOption(option.first, option.second);
+        }
+        for(const std::pair<const std::string, std::string>& option : previousVideoConfig)
+            config.setVideoValue(option.first, option.second);
+        config.saveUserConfig();
+        initConfig();
+        return false;
+    }
+    RenderManager::getSingleton().setDynamicShadowsEnabled(dynamicShadowsCheckBox->isSelected());
+    return true;
 }
 
 void SettingsWindow::show()
 {
     if (mSettingsWindow)
     {
+        initConfig();
         // Input only allowed on this window when visible.
         mSettingsWindow->setModalState(true);
         mSettingsWindow->show();
@@ -630,8 +664,8 @@ bool SettingsWindow::onApplySettings(const CEGUI::EventArgs&)
         return true;
     }
 
-    saveConfig();
-    hide();
+    if(saveConfig())
+        hide();
     return true;
 }
 
@@ -709,11 +743,6 @@ bool SettingsWindow::onLightFactorChanged(const CEGUI::EventArgs&)
     return true;
 }
 
-
-void SettingsWindow::onTriggerDynamicShadows(const CEGUI::EventArgs&)
-{
-    dynamicShadowsChanged = !dynamicShadowsChanged;
-}
 
 void SettingsWindow::setLightFactorValue(float lightFactor)
 {

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -20,6 +20,7 @@
 #include "gamemap/MiniMap.h"
 #include "network/ODClient.h"
 #include "camera/CameraManager.h"
+#include "render/Gui.h"
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
 #include "utils/ConfigManager.h"
@@ -43,11 +44,13 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <sstream>
 
-SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
+SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow, Gui& gui):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
-    mRootWindow(rootWindow)
+    mRootWindow(rootWindow),
+    mGui(gui)
 {
     if (rootWindow == nullptr)
     {
@@ -145,7 +148,15 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
         )
     );
 
+    addEventConnection(
+        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/UIScaleCombobox")->subscribeEvent(
+            CEGUI::Combobox::EventListSelectionAccepted,
+            CEGUI::Event::Subscriber(&SettingsWindow::onUiScaleChanged, this)
+        )
+    );
+
     initConfig();
+    mGui.registerWindowHierarchy(mApplyWindow);
 }
 
 SettingsWindow::~SettingsWindow()
@@ -331,6 +342,32 @@ void SettingsWindow::initConfig()
         vsCheckBox->setSelected((vsync.currentValue == "Yes"));
     }
 
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    uiScaleCb->setReadOnly(true);
+    uiScaleCb->resetList();
+    int configuredUiScale = 100;
+    std::istringstream uiScaleParser(config.getGameValue(Config::UI_SCALE, "100", false));
+    if(!(uiScaleParser >> configuredUiScale))
+        configuredUiScale = 100;
+    configuredUiScale = std::max(static_cast<int>(Gui::MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<int>(Gui::MAX_UI_SCALE_PERCENT), configuredUiScale));
+    configuredUiScale = (configuredUiScale + 5) / 10 * 10;
+    for(uint32_t uiScale = Gui::MIN_UI_SCALE_PERCENT;
+        uiScale <= Gui::MAX_UI_SCALE_PERCENT; uiScale += 10)
+    {
+        CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(
+            Helper::toString(uiScale) + "%", uiScale);
+        item->setSelectionBrushImage(selImg);
+        uiScaleCb->addItem(item);
+        if(static_cast<int>(uiScale) == configuredUiScale)
+        {
+            uiScaleCb->setItemSelectState(item, true);
+            uiScaleCb->setText(item->getText());
+        }
+    }
+    mGui.setUserScalePercent(static_cast<float>(configuredUiScale));
+
     //! First of all, clear up the previously created windows.
     CEGUI::WindowManager& winMgr = CEGUI::WindowManager::getSingleton();
     CEGUI::Window* parentWindow = mSettingsWindow->getChild("MainTabControl/Video/VideoSP/");
@@ -370,13 +407,13 @@ void SettingsWindow::initConfig()
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));
-        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 155 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
+        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 190 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
         videoCbText->setText(optionName + ": ");
         videoCbText->setProperty("FrameEnabled", "False");
         videoCbText->setProperty("BackgroundEnabled", "False");
 
         CEGUI::Combobox* videoCb = static_cast<CEGUI::Combobox*>(videoTab->createChild("OD/Combobox", optionName));
-        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 160 + offset), CEGUI::UDim(0.5, -20),
+        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 195 + offset), CEGUI::UDim(0.5, -20),
                          CEGUI::UDim(0, config.possibleValues.size() * 17 + 30));
         videoCb->setReadOnly(true);
         videoCb->setSortingEnabled(true);
@@ -402,6 +439,8 @@ void SettingsWindow::initConfig()
         }
         offset += 30;
     }
+
+    mGui.registerWindowHierarchy(mSettingsWindow);
 }
 
 bool SettingsWindow::saveConfig()
@@ -458,6 +497,12 @@ bool SettingsWindow::saveConfig()
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     config.setAudioValue(Config::MUSIC_VOLUME, Helper::toString(volumeSlider->getCurrentValue()));
+
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* uiScaleItem = uiScaleCb->getSelectedItem();
+    if(uiScaleItem != nullptr)
+        config.setGameValue(Config::UI_SCALE, Helper::toString(uiScaleItem->getID()));
 
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
@@ -691,6 +736,16 @@ bool SettingsWindow::onMusicVolumeChanged(const CEGUI::EventArgs&)
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     setMusicVolumeValue(volumeSlider->getCurrentValue());
+    return true;
+}
+
+bool SettingsWindow::onUiScaleChanged(const CEGUI::EventArgs&)
+{
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* selectedItem = uiScaleCb->getSelectedItem();
+    if(selectedItem != nullptr)
+        mGui.setUserScalePercent(static_cast<float>(selectedItem->getID()));
     return true;
 }
 

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -407,13 +407,13 @@ void SettingsWindow::initConfig()
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));
-        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 190 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
+        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 34));
         videoCbText->setText(optionName + ": ");
         videoCbText->setProperty("FrameEnabled", "False");
         videoCbText->setProperty("BackgroundEnabled", "False");
 
         CEGUI::Combobox* videoCb = static_cast<CEGUI::Combobox*>(videoTab->createChild("OD/Combobox", optionName));
-        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 195 + offset), CEGUI::UDim(0.5, -20),
+        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.5, -20),
                          CEGUI::UDim(0, config.possibleValues.size() * 17 + 30));
         videoCb->setReadOnly(true);
         videoCb->setSortingEnabled(true);
@@ -437,7 +437,7 @@ void SettingsWindow::initConfig()
             }
             ++cbIndex;
         }
-        offset += 30;
+        offset += 40;
     }
 
     mGui.registerWindowHierarchy(mSettingsWindow);

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -37,6 +37,8 @@
 
 #include <SFML/Audio/Listener.hpp>
 
+#include <algorithm>
+
 SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
@@ -365,6 +367,11 @@ void SettingsWindow::initConfig()
         // If the option is immutable, we can't change it and shouldn't see it. (at least for now)
         if (config.immutable || config.possibleValues.empty())
             continue;
+
+        // OGRE may repeat colour depths for different fullscreen refresh rates.
+        std::sort(config.possibleValues.begin(), config.possibleValues.end());
+        config.possibleValues.erase(std::unique(config.possibleValues.begin(), config.possibleValues.end()),
+                                   config.possibleValues.end());
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -25,6 +25,8 @@
 
 #include <vector>
 
+class Gui;
+
 //! \brief This class is creating a setting window gui child to the current gui context
 //! and populates its widgets with the current game, video, audio values.
 //! It also permits to change them.
@@ -34,7 +36,7 @@ public:
     //! \brief Settings window constructor
     //! \param rootWindow The main CEGUI window used as background to the current mode.
     //! Used to load and later show the settings window.
-    SettingsWindow(CEGUI::Window* rootWindow);
+    SettingsWindow(CEGUI::Window* rootWindow, Gui& gui);
 
     ~SettingsWindow();
 
@@ -64,6 +66,8 @@ private:
 
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
+
+    Gui& mGui;
 
     //! \brief The temporary video comboboxes and texts created depending on the video settings.
     std::vector<CEGUI::Window*> mCustomVideoComboBoxes;
@@ -99,6 +103,9 @@ private:
     //! \brief Called when changing the ambient light factor value.
     bool onLightFactorChanged(const CEGUI::EventArgs&);
     bool onPanSpeedChanged(const CEGUI::EventArgs&);
+
+    //! \brief Applies the selected UI scale immediately.
+    bool onUiScaleChanged(const CEGUI::EventArgs&);
 
     //! \brief Set the volume value in the ambient light factor setting text and slider.
     void setLightFactorValue(float lightFactor);

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -52,7 +52,6 @@ public:
     //! \brief Called when pushing the cancel button on the settings window.
     bool onCancelSettings(const CEGUI::EventArgs& e = {});
 
-    void onTriggerDynamicShadows(const CEGUI::EventArgs& );
 private:
     //! \brief Vector of cegui event bindings to be cleared on exiting the mode
     std::vector<CEGUI::Event::Connection> mEventConnections;
@@ -73,8 +72,8 @@ private:
     //! \brief Set the different widget values according to current config.
     void initConfig();
 
-    //! \brief Save the config, potentially stopping the application if it needs to.
-    void saveConfig();
+    //! \brief Save and apply the config. Returns false if a selected value could not be applied.
+    bool saveConfig();
 
     //! \brief Adds an event binding to be cleared on exiting the mode.
     inline void addEventConnection(CEGUI::Event::Connection conn)
@@ -105,7 +104,6 @@ private:
     void setLightFactorValue(float lightFactor);
     void setPanSpeedValue(float panSpeedPercent);
 
-    bool dynamicShadowsChanged;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -127,6 +127,8 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "editorAskPortalWaveData";
         case ClientNotificationType::editorSetPortalWaveData:
             return "editorSetPortalWaveData";
+        case ClientNotificationType::changeNick:
+            return "changeNick";
         default:
             OD_LOG_ERR("Unknown enum for ClientNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -79,7 +79,10 @@ enum class ClientNotificationType
     editorAskCreateMapLight,
     editorSetCreatureLevel,
     editorAskPortalWaveData,
-    editorSetPortalWaveData
+    editorSetPortalWaveData,
+
+    // Append new messages to preserve existing network and replay identifiers.
+    changeNick
 };
 
 ODPacket& operator<<(ODPacket& os, const ClientNotificationType& nt);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -224,9 +224,17 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             ServerMode serverMode;
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
+            // Older servers and replays end this packet after the server mode.
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            setSupportsLiveNickname(liveNickname);
+
             ODPacket packSend;
             const std::string& nick = gameMap->getLocalPlayerNick();
             packSend << ClientNotificationType::setNick << nick;
+            if(liveNickname)
+                packSend << true;
             send(packSend);
 
             // We can proceed to configure seat level
@@ -289,6 +297,23 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
                 OD_ASSERT_TRUE(packetReceived >> nick >> id);
                 mode->addPlayer(nick, id);
                 addEventMessage(new EventMessage(nick + " is now connected."));
+            }
+            break;
+        }
+
+        case ServerNotificationType::playerNickChanged:
+        {
+            int32_t playerId;
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> playerId >> nickname);
+            for(Player* player : gameMap->getPlayers())
+            {
+                if(player->getId() != playerId)
+                    continue;
+                player->setNick(nickname);
+                if(player == getPlayer())
+                    gameMap->setLocalPlayerNick(nickname);
+                break;
             }
             break;
         }
@@ -1465,6 +1490,18 @@ bool ODClient::replay(const std::string& filename)
 void ODClient::queueClientNotification(ClientNotification* n)
 {
     mClientNotificationQueue.push_back(n);
+}
+
+void ODClient::requestNicknameChange(const std::string& nickname)
+{
+    if(getSource() != ODSource::network || getPlayer() == nullptr || getPlayer()->getNick() == nickname)
+        return;
+    if(!supportsLiveNickname())
+    {
+        OD_LOG_WRN("The connected server does not support changing the current player's nickname.");
+        return;
+    }
+    queueClientNotification(ClientNotificationType::changeNick, nickname);
 }
 
 void ODClient::disconnect(bool keepReplay)

--- a/source/network/ODClient.h
+++ b/source/network/ODClient.h
@@ -58,6 +58,8 @@ class ODClient: public Ogre::Singleton<ODClient>,
     //! \brief Adds a client notification to the client notification queue.
     void queueClientNotification(ClientNotification* n);
 
+    void requestNicknameChange(const std::string& nickname);
+
     /*! \brief Adds a client notification to the client notification queue.
      *  \param type The type of the notification
      *  \param args The arguments that are to be piped into the notification.

--- a/source/network/ODPacket.h
+++ b/source/network/ODPacket.h
@@ -122,6 +122,9 @@ class ODPacket
          */
         operator bool() const;
 
+        bool endOfPacket() const
+        { return mPacket.endOfPacket(); }
+
         /*! \brief Clears the packet. After calling Clear, the packet should
          * be empty.
          */
@@ -158,4 +161,3 @@ class ODPacket
 };
 
 #endif // ODPACKET_H
-

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -896,7 +896,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             clientSocket->setState("nick");
             // Tell the client to give us their nickname
             ODPacket packetSend;
-            packetSend << ServerNotificationType::pickNick << mServerMode;
+            packetSend << ServerNotificationType::pickNick << mServerMode << true;
             clientSocket->send(packetSend);
             break;
         }
@@ -909,6 +909,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // Pick nick
             std::string clientNick;
             OD_ASSERT_TRUE(packetReceived >> clientNick);
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            clientSocket->setSupportsLiveNickname(liveNickname);
 
             // NOTE : playerId 0 is reserved for inactive players and 1 is reserved for AI
             int32_t playerId = mUniqueNumberPlayer + Seat::PLAYER_ID_HUMAN_MIN;
@@ -962,6 +966,27 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             packetSend << ServerNotificationType::startGameMode << seatId << mServerMode;
             clientSocket->send(packetSend);
             mSeatsConfigured = true;
+            break;
+        }
+
+        case ClientNotificationType::changeNick:
+        {
+            if(mServerState != ServerState::StateGame || !clientSocket->supportsLiveNickname()
+                || clientSocket->getPlayer() == nullptr)
+                break;
+
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> nickname);
+            Player* player = clientSocket->getPlayer();
+            player->setNick(nickname);
+            const int32_t playerId = player->getId();
+            ODPacket packetSend;
+            packetSend << ServerNotificationType::playerNickChanged << playerId << nickname;
+            for(ODSocketClient* client : mSockClients)
+            {
+                if(client->supportsLiveNickname())
+                    client->send(packetSend);
+            }
             break;
         }
 

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -60,6 +60,7 @@ bool ODSocketClient::replay(const std::string& filename)
 
 void ODSocketClient::disconnect(bool keepReplay)
 {
+    mSupportsLiveNickname = false;
     mPendingTimestamp = -1;
     ODSource src = mSource;
     mSource = ODSource::none;

--- a/source/network/ODSocketClient.h
+++ b/source/network/ODSocketClient.h
@@ -50,7 +50,8 @@ class ODSocketClient
             mSource(ODSource::none),
             mPlayer(nullptr),
             mLastTurnAck(-1),
-            mPendingTimestamp(-1)
+            mPendingTimestamp(-1),
+            mSupportsLiveNickname(false)
         {}
 
         virtual ~ODSocketClient()
@@ -68,6 +69,8 @@ class ODSocketClient
 
         Player* getPlayer() { return mPlayer; }
         void setPlayer(Player* player) { mPlayer = player; }
+        bool supportsLiveNickname() const { return mSupportsLiveNickname; }
+        void setSupportsLiveNickname(bool supported) { mSupportsLiveNickname = supported; }
         int64_t getLastTurnAck() { return mLastTurnAck; }
         void setLastTurnAck(int64_t lastTurnAck) { mLastTurnAck = lastTurnAck; }
         const std::string& getState() {return mState;}
@@ -130,6 +133,7 @@ class ODSocketClient
         std::ofstream mReplayOutputStream;
         ODPacket mPendingPacket;
         int32_t mPendingTimestamp;
+        bool mSupportsLiveNickname;
 
         //! \brief the replay filename being written. Used to later optionally delete it
         //! if asked to.
@@ -137,4 +141,3 @@ class ODSocketClient
 };
 
 #endif // ODSOCKETCLIENT_H
-

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -140,6 +140,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "displayText";
         case ServerNotificationType::editorPortalWaveData:
             return "editorPortalWaveData";
+        case ServerNotificationType::playerNickChanged:
+            return "playerNickChanged";
         default:
             OD_LOG_ERR("Unknown enum for ServerNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -102,7 +102,10 @@ enum class ServerNotificationType
     //! \brief Answer to the editor asking what the waves of a wave portal are
     editorPortalWaveData,
 
-    exit
+    exit,
+
+    // Sent only to clients that negotiated live nickname changes.
+    playerNickChanged
 };
 
 ODPacket& operator<<(ODPacket& os, const ServerNotificationType& nt);

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -129,7 +129,14 @@ CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)
     {
         return it->second;
     }
+
     return nullptr;
+}
+
+void Gui::setRenderTarget(Ogre::RenderTarget& renderTarget)
+{
+    static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingleton().getRenderer())
+        ->setDefaultRootRenderTarget(renderTarget);
 }
 
 bool Gui::playButtonClickSound(const CEGUI::EventArgs&)

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -24,9 +24,11 @@
 
 #include "ODApplication.h"
 #include "sound/SoundEffectsManager.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 
 #include <CEGUI/CEGUI.h>
+#include <CEGUI/BasicImage.h>
 #include <CEGUI/RendererModules/Ogre/Renderer.h>
 #include <CEGUI/RendererModules/Ogre/ResourceProvider.h>
 #include <CEGUI/RendererModules/Ogre/ImageCodec.h>
@@ -34,10 +36,93 @@
 #include <CEGUI/System.h>
 #include <CEGUI/WindowManager.h>
 #include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/widgets/TabControl.h>
 #include <CEGUI/Event.h>
 
+#include <algorithm>
+#include <sstream>
+
+namespace
+{
+const float LAYOUT_DESIGN_WIDTH = 1024.0f;
+const float LAYOUT_DESIGN_HEIGHT = 768.0f;
+const float FONT_DESIGN_WIDTH = 800.0f;
+const float FONT_DESIGN_HEIGHT = 600.0f;
+
+void scaleDimension(CEGUI::UDim& dimension, float scale)
+{
+    dimension.d_offset *= scale;
+}
+
+CEGUI::URect scaleRect(const CEGUI::URect& rect, float scale)
+{
+    CEGUI::URect scaled(rect);
+    scaleDimension(scaled.d_min.d_x, scale);
+    scaleDimension(scaled.d_min.d_y, scale);
+    scaleDimension(scaled.d_max.d_x, scale);
+    scaleDimension(scaled.d_max.d_y, scale);
+    return scaled;
+}
+
+CEGUI::USize scaleSize(const CEGUI::USize& size, float scale)
+{
+    CEGUI::USize scaled(size);
+    scaleDimension(scaled.d_width, scale);
+    scaleDimension(scaled.d_height, scale);
+    return scaled;
+}
+
+bool shouldScaleImage(const CEGUI::String& ceguiName)
+{
+    const std::string name(ceguiName.c_str());
+    return name.compare(0, 17, "OpenDungeonsSkin/") == 0
+        || name.compare(0, 18, "OpenDungeonsIcons/") == 0
+        || name.compare(0, 17, "ODMainMenuButton/") == 0
+        || name.compare(0, 7, "ODLogo/") == 0;
+}
+
+std::string scaleFormattedImageSizes(const CEGUI::String& ceguiText, float scale)
+{
+    std::string text(ceguiText.c_str());
+    size_t tagStart = 0;
+    while((tagStart = text.find("[image-size='", tagStart)) != std::string::npos)
+    {
+        size_t tagEnd = text.find("']", tagStart);
+        if(tagEnd == std::string::npos)
+            break;
+
+        const char* dimensions[] = {"w:", "h:"};
+        for(const char* dimension : dimensions)
+        {
+            const size_t marker = text.find(dimension, tagStart);
+            if(marker == std::string::npos || marker >= tagEnd)
+                continue;
+
+            const size_t valueStart = marker + 2;
+            size_t valueEnd = valueStart;
+            while(valueEnd < tagEnd && ((text[valueEnd] >= '0' && text[valueEnd] <= '9') || text[valueEnd] == '.'))
+                ++valueEnd;
+
+            float value = 0.0f;
+            std::istringstream valueParser(text.substr(valueStart, valueEnd - valueStart));
+            if(!(valueParser >> value))
+                continue;
+
+            std::ostringstream scaledValue;
+            scaledValue << std::max(1, static_cast<int>(value * scale + 0.5f));
+            text.replace(valueStart, valueEnd - valueStart, scaledValue.str());
+            tagEnd = text.find("']", tagStart);
+        }
+
+        tagStart = tagEnd + 2;
+    }
+    return text;
+}
+}
+
 Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFileName, Ogre::RenderTarget &renderTarget)
-  : mSoundEffectsManager(soundEffectsManager)
+  : mUserScale(1.0f),
+    mSoundEffectsManager(soundEffectsManager)
 {
     OD_LOG_INF("*** Initializing CEGUI ***");
     CEGUI::OgreRenderer& renderer = CEGUI::OgreRenderer::create(renderTarget);
@@ -52,6 +137,15 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
     CEGUI::SchemeManager::getSingleton().createFromFile("ODSkin.scheme");
     OD_LOG_INF("CEGUI::SchemeManager created");
+
+    float configuredScalePercent = 100.0f;
+    std::istringstream scaleParser(ConfigManager::getSingleton().getGameValue(Config::UI_SCALE, "100", false));
+    if(!(scaleParser >> configuredScalePercent))
+        configuredScalePercent = 100.0f;
+    configuredScalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), configuredScalePercent));
+    mUserScale = configuredScalePercent / 100.0f;
+    updateResourceScaling(renderer.getDisplaySize());
 
     // We want Ogre overlays to be displayed in front of CEGUI. According to
     // http://cegui.org.uk/forum/viewtopic.php?f=10&t=5694
@@ -83,6 +177,17 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
     mSheets[loadSavedGameMenu] =  wmgr->loadLayoutFromFile("MenuLoad.layout");
     mSheets[console] = wmgr->loadLayoutFromFile("WindowConsole.layout");
 
+    mDisplaySizeChangedConnection = CEGUI::System::getSingleton().subscribeEvent(
+        CEGUI::System::EventDisplaySizeChanged,
+        CEGUI::Event::Subscriber(&Gui::onDisplaySizeChanged, this));
+    mWindowDestroyedConnection = wmgr->subscribeEvent(
+        CEGUI::WindowManager::EventWindowDestroyed,
+        CEGUI::Event::Subscriber(&Gui::onWindowDestroyed, this));
+
+    for(const auto& sheet : mSheets)
+        registerWindow(sheet.second);
+    applyScale(renderer.getDisplaySize());
+
     // Set the game version
     mSheets[mainMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
     mSheets[skirmishMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
@@ -103,6 +208,8 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
 Gui::~Gui()
 {
+    mDisplaySizeChangedConnection.disconnect();
+    mWindowDestroyedConnection.disconnect();
     //This also calls CEGUI::System::destroy();
     CEGUI::OgreRenderer::destroySystem();
 }
@@ -117,9 +224,133 @@ CEGUI::MouseButton Gui::convertButton(OIS::MouseButtonID buttonID)
 
 void Gui::loadGuiSheet(guiSheet newSheet)
 {
+    registerWindowHierarchy(mSheets[newSheet]);
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().setRootWindow(mSheets[newSheet]);
     // This shouldn't be needed, but the gui seems to not allways change when using hideGui without it.
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::registerWindowHierarchy(CEGUI::Window* window)
+{
+    if(window == nullptr)
+        return;
+
+    registerWindow(window);
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+void Gui::registerWindow(CEGUI::Window* window)
+{
+    if(!window->isAutoWindow() && mScaledWindows.find(window) == mScaledWindows.end())
+    {
+        WindowScaleData data;
+        data.area = window->getArea();
+        data.minSize = window->getMinSize();
+        data.maxSize = window->getMaxSize();
+        data.text = window->getText();
+        data.hasFormattedImageSize = std::string(data.text.c_str()).find("[image-size='") != std::string::npos;
+        data.hasTabHeight = false;
+
+        CEGUI::TabControl* tabControl = dynamic_cast<CEGUI::TabControl*>(window);
+        if(tabControl != nullptr)
+        {
+            data.tabHeight = tabControl->getTabHeight();
+            data.hasTabHeight = true;
+        }
+
+        mScaledWindows.insert(std::make_pair(window, data));
+    }
+
+    for(size_t i = 0; i < window->getChildCount(); ++i)
+        registerWindow(window->getChildAtIdx(i));
+}
+
+void Gui::setUserScalePercent(float scalePercent)
+{
+    if(scalePercent != scalePercent)
+        scalePercent = 100.0f;
+
+    scalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), scalePercent));
+    mUserScale = scalePercent / 100.0f;
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+bool Gui::onDisplaySizeChanged(const CEGUI::EventArgs& e)
+{
+    const CEGUI::DisplayEventArgs& displayEvent = static_cast<const CEGUI::DisplayEventArgs&>(e);
+    applyScale(displayEvent.size);
+    return true;
+}
+
+bool Gui::onWindowDestroyed(const CEGUI::EventArgs& e)
+{
+    const CEGUI::WindowEventArgs& windowEvent = static_cast<const CEGUI::WindowEventArgs&>(e);
+    mScaledWindows.erase(windowEvent.window);
+    return true;
+}
+
+void Gui::applyScale(const CEGUI::Sizef& displaySize)
+{
+    const float resolutionScale = std::min(displaySize.d_width / LAYOUT_DESIGN_WIDTH,
+        displaySize.d_height / LAYOUT_DESIGN_HEIGHT);
+    const float scale = resolutionScale * mUserScale;
+
+    for(const auto& scaledWindow : mScaledWindows)
+        applyScale(scaledWindow.first, scaledWindow.second, scale);
+
+    updateResourceScaling(displaySize);
+    CEGUI::System::getSingleton().getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale)
+{
+    window->setMinSize(scaleSize(data.minSize, scale));
+    window->setMaxSize(scaleSize(data.maxSize, scale));
+    window->setArea(scaleRect(data.area, scale));
+
+    if(data.hasFormattedImageSize)
+        window->setText(scaleFormattedImageSizes(data.text, scale));
+
+    if(data.hasTabHeight)
+    {
+        CEGUI::UDim tabHeight(data.tabHeight);
+        scaleDimension(tabHeight, scale);
+        static_cast<CEGUI::TabControl*>(window)->setTabHeight(tabHeight);
+    }
+}
+
+void Gui::updateResourceScaling(const CEGUI::Sizef& displaySize)
+{
+    const CEGUI::Sizef fontNativeResolution(FONT_DESIGN_WIDTH / mUserScale,
+        FONT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::FontManager::FontIterator font = CEGUI::FontManager::getSingleton().getIterator();
+    while(!font.isAtEnd())
+    {
+        font.getCurrentValue()->setNativeResolution(fontNativeResolution);
+        font.getCurrentValue()->setAutoScaled(CEGUI::ASM_Min);
+        ++font;
+    }
+
+    const CEGUI::Sizef imageNativeResolution(LAYOUT_DESIGN_WIDTH / mUserScale,
+        LAYOUT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::ImageManager::ImageIterator image = CEGUI::ImageManager::getSingleton().getIterator();
+    while(!image.isAtEnd())
+    {
+        if(shouldScaleImage(image.getCurrentKey()))
+        {
+            CEGUI::BasicImage* basicImage = dynamic_cast<CEGUI::BasicImage*>(image.getCurrentValue().first);
+            if(basicImage != nullptr)
+            {
+                basicImage->setNativeResolution(imageNativeResolution);
+                basicImage->setAutoScaled(CEGUI::ASM_Min);
+            }
+        }
+        ++image;
+    }
+
+    CEGUI::FontManager::getSingleton().notifyDisplaySizeChanged(displaySize);
+    CEGUI::ImageManager::getSingleton().notifyDisplaySizeChanged(displaySize);
 }
 
 CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -296,10 +296,11 @@ void Gui::applyScale(const CEGUI::Sizef& displaySize)
         displaySize.d_height / LAYOUT_DESIGN_HEIGHT);
     const float scale = resolutionScale * mUserScale;
 
+    updateResourceScaling(displaySize);
+
     for(const auto& scaledWindow : mScaledWindows)
         applyScale(scaledWindow.first, scaledWindow.second, scale);
 
-    updateResourceScaling(displaySize);
     CEGUI::System::getSingleton().getDefaultGUIContext().markAsDirty();
 }
 

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -85,6 +85,9 @@ public:
 
     CEGUI::Window* getGuiSheet(guiSheet sheet);
 
+    //! \brief Move CEGUI rendering to another Ogre render target.
+    void setRenderTarget(Ogre::RenderTarget& renderTarget);
+
     // Access names of the GUI elements
     static const std::string ROOT;
     static const std::string DISPLAY_GOLD;

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -24,7 +24,9 @@
 #ifndef GUI_H_
 #define GUI_H_
 
+#include <CEGUI/Event.h>
 #include <CEGUI/InputEvent.h>
+#include <CEGUI/Window.h>
 
 #include <OISMouse.h>
 
@@ -87,6 +89,18 @@ public:
 
     //! \brief Move CEGUI rendering to another Ogre render target.
     void setRenderTarget(Ogre::RenderTarget& renderTarget);
+
+    enum
+    {
+        MIN_UI_SCALE_PERCENT = 80,
+        MAX_UI_SCALE_PERCENT = 120
+    };
+
+    //! \brief Registers a window tree for resolution-independent scaling.
+    void registerWindowHierarchy(CEGUI::Window* window);
+
+    //! \brief Sets the user-selected UI scale and applies it immediately.
+    void setUserScalePercent(float scalePercent);
 
     // Access names of the GUI elements
     static const std::string ROOT;
@@ -155,9 +169,33 @@ public:
     bool playButtonClickSound(const CEGUI::EventArgs& e = {});
 
 private:
+    struct WindowScaleData
+    {
+        CEGUI::URect area;
+        CEGUI::USize minSize;
+        CEGUI::USize maxSize;
+        CEGUI::String text;
+        CEGUI::UDim tabHeight;
+        bool hasFormattedImageSize;
+        bool hasTabHeight;
+    };
+
     std::map<guiSheet, CEGUI::Window*> mSheets;
+    std::map<CEGUI::Window*, WindowScaleData> mScaledWindows;
+
+    float mUserScale;
+
+    CEGUI::Event::ScopedConnection mDisplaySizeChangedConnection;
+    CEGUI::Event::ScopedConnection mWindowDestroyedConnection;
 
     SoundEffectsManager* mSoundEffectsManager;
+
+    bool onDisplaySizeChanged(const CEGUI::EventArgs& e);
+    bool onWindowDestroyed(const CEGUI::EventArgs& e);
+    void registerWindow(CEGUI::Window* window);
+    void applyScale(const CEGUI::Sizef& displaySize);
+    void applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale);
+    void updateResourceScaling(const CEGUI::Sizef& displaySize);
 };
 
 #endif // GUI_H_

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -43,11 +43,13 @@
 #include "sound/MusicPlayer.h"
 #include "sound/SoundEffectsManager.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 #include "utils/MakeUnique.h"
 
 #include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreRenderSystem.h>
 #include <OgreRoot.h>
 #include <OgreSceneManager.h>
 #include <Overlay/OgreOverlaySystem.h>
@@ -59,6 +61,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <stdexcept>
 #include <iostream>
 
 #include <signal.h>
@@ -81,6 +84,9 @@ ODFrameListener::ODFrameListener(const std::string& mainSceneFileName, Ogre::Ren
     lastSecondFrameRenderingQueued(0),
     mInitialized(false),
     mWindow(renderWindow),
+    mPrimaryWindow(renderWindow),
+    mRenderWindowRecreationPending(false),
+    mRenderWindowSequence(0),
     mGui(gui),
     mRenderManager(RenderManager::getSingletonPtr()),
     mGameMap(Utils::make_unique<GameMap>(false)),
@@ -119,6 +125,12 @@ void ODFrameListener::windowResized(Ogre::RenderWindow* rw)
     int left, top;
     rw->getMetrics(width, height, left, top);
 
+    if(width == 0 || height == 0)
+        return;
+
+    Ogre::Camera* camera = mCameraManager.getActiveCamera();
+    camera->setAspectRatio(static_cast<Ogre::Real>(width) / static_cast<Ogre::Real>(height));
+
     mModeManager->getInputManager().setWidthAndHeight(width, height);
     //Notify CEGUI that the display size has changed.
     CEGUI::System::getSingleton().notifyDisplaySizeChanged(CEGUI::Size<float>(
@@ -148,6 +160,177 @@ ODFrameListener::~ODFrameListener()
 void ODFrameListener::requestExit()
 {
     mExitRequested = true;
+}
+
+void ODFrameListener::requestRenderWindowRecreation(
+    const std::map<std::string, std::string>& previousRendererOptions,
+    const std::map<std::string, std::string>& previousVideoConfig)
+{
+    mPreviousRendererOptions = previousRendererOptions;
+    mPreviousVideoConfig = previousVideoConfig;
+    mRenderWindowRecreationPending = true;
+}
+
+void ODFrameListener::restorePreviousVideoSettings()
+{
+    Ogre::RenderSystem* renderer = Ogre::Root::getSingleton().getRenderSystem();
+    std::map<std::string, std::string>::const_iterator fullscreen =
+        mPreviousRendererOptions.find(Config::FULL_SCREEN);
+    if(fullscreen != mPreviousRendererOptions.end())
+        renderer->setConfigOption(fullscreen->first, fullscreen->second);
+    std::map<std::string, std::string>::const_iterator videoMode =
+        mPreviousRendererOptions.find(Config::VIDEO_MODE);
+    if(videoMode != mPreviousRendererOptions.end())
+        renderer->setConfigOption(videoMode->first, videoMode->second);
+    for(const std::pair<const std::string, std::string>& option : mPreviousRendererOptions)
+    {
+        if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+            continue;
+        renderer->setConfigOption(option.first, option.second);
+    }
+
+    ConfigManager& config = ConfigManager::getSingleton();
+    for(const std::pair<const std::string, std::string>& option : mPreviousVideoConfig)
+        config.setVideoValue(option.first, option.second);
+    config.saveUserConfig();
+    mPreviousRendererOptions.clear();
+    mPreviousVideoConfig.clear();
+}
+
+void ODFrameListener::applyPendingRenderWindowRecreation()
+{
+    if(!mRenderWindowRecreationPending)
+        return;
+    mRenderWindowRecreationPending = false;
+
+    Ogre::Root& root = Ogre::Root::getSingleton();
+    Ogre::RenderSystem* renderer = root.getRenderSystem();
+    Ogre::RenderWindow* previousWindow = mWindow;
+    Ogre::RenderWindow* replacementWindow = nullptr;
+    unsigned int previousWidth = 0;
+    unsigned int previousHeight = 0;
+    int previousLeft = 0;
+    int previousTop = 0;
+    previousWindow->getMetrics(previousWidth, previousHeight, previousLeft, previousTop);
+    const bool previousWasFullScreen = previousWindow->isFullScreen();
+    bool guiMoved = false;
+    bool cameraMoved = false;
+    bool inputMoved = false;
+    bool listenerMoved = false;
+    bool windowRegistered = false;
+
+    try
+    {
+        Ogre::RenderWindowDescription description = renderer->getRenderWindowDescription();
+        description.name = "OpenDungeonsLiveSettings" + Helper::toString(++mRenderWindowSequence);
+        description.miscParams["title"] = mPrimaryWindow->getName();
+        description.miscParams["hidden"] = "true";
+        if(!description.useFullScreen && !previousWasFullScreen)
+        {
+            description.miscParams["left"] = Helper::toString(previousLeft);
+            description.miscParams["top"] = Helper::toString(previousTop);
+        }
+
+        replacementWindow = root.createRenderWindow(description);
+        replacementWindow->setAutoUpdated(false);
+        replacementWindow->setActive(false);
+        Ogre::WindowEventUtilities::_addRenderWindow(replacementWindow);
+        windowRegistered = true;
+
+        renderer->_setRenderTarget(replacementWindow);
+        mCameraManager.setRenderWindow(replacementWindow);
+        cameraMoved = true;
+        mRenderManager->setViewport(mCameraManager.getViewport());
+        mGui->setRenderTarget(*replacementWindow);
+        guiMoved = true;
+        if(!mModeManager->getInputManager().setRenderWindow(replacementWindow))
+            throw std::runtime_error("input initialization failed for the replacement window");
+        mModeManager->getInputManager().refreshSettings();
+        inputMoved = true;
+
+        Ogre::WindowEventUtilities::removeWindowEventListener(previousWindow, this);
+        Ogre::WindowEventUtilities::addWindowEventListener(replacementWindow, this);
+        listenerMoved = true;
+        mWindow = replacementWindow;
+
+        previousWindow->setAutoUpdated(false);
+        previousWindow->setActive(false);
+        previousWindow->setVisible(false);
+        if(previousWasFullScreen)
+        {
+            previousWindow->setFullscreen(false, previousWidth, previousHeight);
+            if(description.useFullScreen)
+            {
+                replacementWindow->setFullscreen(false, description.width, description.height);
+                replacementWindow->setFullscreen(true, description.width, description.height);
+            }
+        }
+        replacementWindow->setVisible(true);
+        replacementWindow->setActive(true);
+        replacementWindow->setAutoUpdated(true);
+        replacementWindow->windowMovedOrResized();
+        windowResized(replacementWindow);
+
+        if(previousWindow != mPrimaryWindow)
+        {
+            Ogre::WindowEventUtilities::_removeRenderWindow(previousWindow);
+            root.destroyRenderTarget(previousWindow);
+        }
+        mPreviousRendererOptions.clear();
+        mPreviousVideoConfig.clear();
+        OD_LOG_INF("Applied video settings without restarting the game");
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        renderer->_setRenderTarget(previousWindow);
+        if(listenerMoved)
+        {
+            Ogre::WindowEventUtilities::removeWindowEventListener(replacementWindow, this);
+            Ogre::WindowEventUtilities::addWindowEventListener(previousWindow, this);
+            mWindow = previousWindow;
+        }
+        if(inputMoved)
+            mModeManager->getInputManager().setRenderWindow(previousWindow);
+        if(guiMoved)
+            mGui->setRenderTarget(*previousWindow);
+        if(cameraMoved)
+        {
+            mCameraManager.setRenderWindow(previousWindow);
+            mRenderManager->setViewport(mCameraManager.getViewport());
+        }
+        if(replacementWindow != nullptr)
+        {
+            if(windowRegistered)
+                Ogre::WindowEventUtilities::_removeRenderWindow(replacementWindow);
+            root.destroyRenderTarget(replacementWindow);
+        }
+        if(previousWasFullScreen && !previousWindow->isFullScreen())
+            previousWindow->setFullscreen(true, previousWidth, previousHeight);
+        restorePreviousVideoSettings();
+        previousWindow->setVisible(true);
+        previousWindow->setActive(true);
+        previousWindow->setAutoUpdated(true);
+        windowResized(previousWindow);
+    }
+}
+
+void ODFrameListener::prepareRenderWindowShutdown()
+{
+    if(mInitialized)
+        exitApplication();
+    mModeManager.reset();
+
+    if(mWindow != mPrimaryWindow)
+    {
+        Ogre::WindowEventUtilities::_removeRenderWindow(mWindow);
+        Ogre::Root& root = Ogre::Root::getSingleton();
+        root.getRenderSystem()->_setRenderTarget(mPrimaryWindow);
+        mGui->setRenderTarget(*mPrimaryWindow);
+        root.destroyRenderTarget(mWindow);
+        mWindow = mPrimaryWindow;
+    }
+    Ogre::WindowEventUtilities::_removeRenderWindow(mPrimaryWindow);
 }
 
 void ODFrameListener::exitApplication()
@@ -193,6 +376,7 @@ bool ODFrameListener::frameRenderingQueued(const Ogre::FrameEvent& evt)
     CEGUI::System::getSingleton().getDefaultGUIContext().injectTimePulse(evt.timeSinceLastFrame);
 
     mModeManager->update(evt);
+    applyPendingRenderWindowRecreation();
 
     int64_t currentTurn = mGameMap->getTurnNumber();
 
@@ -466,4 +650,3 @@ void ODFrameListener::readMainScene(const std::string& fileName)
     OD_LOG_INF("Load main scene file: " + fileName);
     mMainScene->readSceneMenu(fileName);
 }
-

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -36,6 +36,7 @@
 #include <OgreWindowEventUtilities.h>
 
 #include <memory>
+#include <map>
 #include <vector>
 
 
@@ -152,6 +153,13 @@ public:
     inline Ogre::RenderWindow* getRenderWindow()
     { return mWindow; }
 
+    void requestRenderWindowRecreation(
+        const std::map<std::string, std::string>& previousRendererOptions,
+        const std::map<std::string, std::string>& previousVideoConfig);
+
+    //! \brief Release window-dependent objects before ODApplication destroys the primary window.
+    void prepareRenderWindowShutdown();
+
     inline bool getIsMainMenuCreated()
     { return mIsMainMenuCreated; }
 
@@ -215,6 +223,14 @@ private:
     //! \brief The Ogre render window reference. Don't delete it.
     Ogre::RenderWindow* mWindow;
 
+    //! \brief The first window owns the main OpenGL context and remains alive as an anchor.
+    Ogre::RenderWindow* mPrimaryWindow;
+
+    bool mRenderWindowRecreationPending;
+    uint32_t mRenderWindowSequence;
+    std::map<std::string, std::string> mPreviousRendererOptions;
+    std::map<std::string, std::string> mPreviousVideoConfig;
+
     //! \brief Foreign reference to gui.
     Gui*                 mGui;
 
@@ -240,6 +256,9 @@ private:
 
     //! \brief Actually exit application
     void exitApplication();
+
+    void applyPendingRenderWindowRecreation();
+    void restorePreviousVideoSettings();
 
     //! \brief Updates server-turn independent creature animation, audio, and overall rendering.
     void updateAnimations(Ogre::Real timeSinceLastFrame);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -106,6 +106,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mHandLightNode(nullptr),
     mShadowCam(nullptr),
     mCurrentFOVy(0.0f),
+    mCurrentAspectRatio(0.0f),
     mFactorWidth(0.0f),
     mFactorHeight(0.0f),
     mCreatureTextOverlayDisplayed(false),
@@ -120,44 +121,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     // mShaderGenerator->setShaderCacheEnabled(true);
     
     mShaderGenerator->addSceneManager(mSceneManager); 
-    if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
-    {
-        // Custom shaders apply lighting and shadows in one pass; automatic
-        // illumination splitting removes their fragment programs on GL3Plus.
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
-        // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
-        // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
-        // mSceneManager->setShadowFarDistance(100.0);
-        // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
-        // mSceneManager->setShadowTextureSelfShadow(true);
-        // donno if the below should be here -- paul424 :
-        auto myIter = Ogre::MaterialManager::getSingleton().getResourceIterator();
-        while(myIter.hasMoreElements())
-        {
-            auto myPointer = myIter.peekNextValue();
-            Ogre::SharedPtr<Ogre::Material> myCastPointer = std::dynamic_pointer_cast<Ogre::Material> (myPointer);
-            Ogre::Technique* technique;
-            technique = myCastPointer->getTechnique(0);
-
-            if( technique->getPass(technique->getNumPasses() - 1)->hasFragmentProgram())
-            {
-                if(technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->hasNamedParameters())
-                {
-                    const Ogre::GpuNamedConstants& gnc = technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->getConstantDefinitions();
-                    auto it = gnc.map.find("shadowingEnabled");
-                    if(it!=  gnc.map.end())
-                        technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->setNamedConstant("shadowingEnabled",true);
-                }
-            }
-            myIter.getNext();
-        }  
-        
-    }
-    else
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_NONE);
-
-    }
+    setDynamicShadowsEnabled(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS) == "Yes");
     ddd.setStatic(true);
     mSceneManager->addListener(&ddd);
     mSceneManager->addRenderQueueListener(overlaySystem);
@@ -212,6 +176,42 @@ void RenderManager::saveTexture(Ogre::TexturePtr texture, const std::string& fil
     pixelBuffer->unlock();
 }
 
+
+void RenderManager::setDynamicShadowsEnabled(bool enabled)
+{
+    // Custom shaders apply lighting and shadows in one pass; automatic
+    // illumination splitting removes their fragment programs on GL3Plus.
+    mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
+    // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
+    // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
+    // mSceneManager->setShadowFarDistance(100.0);
+    // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
+    // mSceneManager->setShadowTextureSelfShadow(true);
+
+    // Include material clones and techniques created since the game started.
+    Ogre::ResourceManager::ResourceMapIterator materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while(materials.hasMoreElements())
+    {
+        Ogre::MaterialPtr material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+        for(unsigned short techniqueIndex = 0; techniqueIndex < material->getNumTechniques(); ++techniqueIndex)
+        {
+            Ogre::Technique* technique = material->getTechnique(techniqueIndex);
+            for(unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex)
+            {
+                Ogre::Pass* pass = technique->getPass(passIndex);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters())
+                {
+                    const Ogre::GpuNamedConstants& constants = parameters->getConstantDefinitions();
+                    if(constants.map.find("shadowingEnabled") != constants.map.end())
+                        parameters->setNamedConstant("shadowingEnabled", enabled);
+                }
+            }
+        }
+    }
+}
 
 RenderManager::~RenderManager()
 {
@@ -2427,24 +2427,15 @@ std::string RenderManager::setMaterialOpacity(const std::string& materialName, f
 void RenderManager::moveCursor(float relX, float relY)
 {
     Ogre::Camera* cam = mViewport->getCamera();
-    if(cam->getFOVy() != mCurrentFOVy)
+    if(cam->getFOVy() != mCurrentFOVy || cam->getAspectRatio() != mCurrentAspectRatio)
     {
         mCurrentFOVy = cam->getFOVy();
+        mCurrentAspectRatio = cam->getAspectRatio();
         Ogre::Radian angle = cam->getFOVy() * 0.5f;
         Ogre::Real tan = Ogre::Math::Tan(angle);
-        Ogre::Real shortestSize = KEEPER_HAND_POS_Z * tan * 2.0f;
-        Ogre::Real width = mViewport->getActualWidth();
-        Ogre::Real height = mViewport->getActualHeight();
-        if(width > height)
-        {
-            mFactorHeight = shortestSize;
-            mFactorWidth = shortestSize * width / height;
-        }
-        else
-        {
-            mFactorWidth = shortestSize;
-            mFactorHeight = shortestSize * height / width;
-        }
+        // FOVy defines the vertical extent; keep the hand aligned after resizing.
+        mFactorHeight = KEEPER_HAND_POS_Z * tan * 2.0f;
+        mFactorWidth = mFactorHeight * mCurrentAspectRatio;
     }
 
     mHandKeeperNode->setPosition(mFactorWidth * (relX - 0.5f), mFactorHeight * (0.5f - relY), -KEEPER_HAND_POS_Z);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -122,7 +122,9 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mShaderGenerator->addSceneManager(mSceneManager); 
     if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
     {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE);
+        // Custom shaders apply lighting and shadows in one pass; automatic
+        // illumination splitting removes their fragment programs on GL3Plus.
+        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
         // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
         // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
         // mSceneManager->setShadowFarDistance(100.0);

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -96,8 +96,12 @@ public:
     //! \brief setup the scene
     void createScene(Ogre::Viewport*);
 
+    void setViewport(Ogre::Viewport* viewport)
+    { mViewport = viewport; }
+
     //! \brief Sets/Updates the overall world lighting value with given factor.
     void setWorldAmbientLightingFactor(float lightFactor);
+    void setDynamicShadowsEnabled(bool enabled);
 
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);
@@ -274,6 +278,7 @@ private:
     Ogre::SceneNode* mHandLightNode2;
     Ogre::Camera* mShadowCam;
     Ogre::Radian mCurrentFOVy;
+    Ogre::Real mCurrentAspectRatio;
     Ogre::Real mFactorWidth;
     Ogre::Real mFactorHeight;
 

--- a/source/tests/test_ODPacket.cpp
+++ b/source/tests/test_ODPacket.cpp
@@ -54,3 +54,32 @@ BOOST_AUTO_TEST_CASE(test_ODPacket)
 
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_optional_nickname_capability)
+{
+    // The original handshake must remain readable without an extension byte.
+    ODPacket legacy;
+    legacy << std::string("Keeper");
+    std::string nickname;
+    legacy >> nickname;
+    BOOST_REQUIRE(legacy);
+    BOOST_CHECK(legacy.endOfPacket());
+
+    // Updated peers append their capability after the unchanged nickname field.
+    ODPacket extended;
+    extended << std::string("Keeper") << true;
+    extended >> nickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK_EQUAL(nickname, "Keeper");
+    BOOST_REQUIRE(!extended.endOfPacket());
+    bool liveNickname = false;
+    extended >> liveNickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK(liveNickname);
+    BOOST_CHECK(extended.endOfPacket());
+
+    extended.clear();
+    BOOST_CHECK(extended.endOfPacket());
+    extended << false;
+    BOOST_CHECK(!extended.endOfPacket());
+}

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1963,4 +1963,5 @@ void ConfigManager::loadDefaultValuesForUserConfig(void)
     setGameValue("LightFactor",	"100");
     setGameValue("MinimapType",	"MiniMapDrawn");
     setGameValue("Nickname", "Player");
+    setGameValue("UI Scale", "100");
 }

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -68,6 +68,7 @@ const std::string NICKNAME = "Nickname";
 const std::string KEEPERVOICE = "KeeperVoice";
 const std::string MINIMAP_TYPE = "MinimapType";
 const std::string LIGHT_FACTOR = "LightFactor";
+const std::string UI_SCALE = "UI Scale";
 }
 
 typedef std::map<TileVisual,std::map<int,float>> HighMap;

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);


### PR DESCRIPTION
Withdrawn at the contributor's request and replaced by separate work-branch pull requests:

- Windows support: #47
- Dynamic-shadow fixes: #48
- Renderer-choice deduplication: #49
- Live settings: #50
- Progressive edge scrolling: #51
- Improvement roadmap: #52
- GUI scaling: #53

Dependent PRs are drafts with predecessor links and focused comparisons; their cumulative GitHub diffs must not be merged as an umbrella contribution.

---

Original submission description:

This combines the existing fork work on Windows support, shadow fixes, live settings, mouse-edge scrolling and GUI scaling into one contribution against `shaders-improvement`.

Changing resolution/fullscreen now updates the running game and its input dimensions, while the interface scales with resolution and a selectable 80–120% UI scale; Windows build/startup failures and the reported settings regressions are corrected as part of the same branch stack.

## Included work

| Existing work branch | Changes |
| --- | --- |
| `feature/windows-support` | MSVC x64 compiler/linker corrections, prerequisite scripts, absolute resource paths and direct Release runtime preparation. |
| `fix/dynamic-shadows` | Make internal shadow programs available and preserve custom fragment shaders through integrated additive texture shadows; record exception details. |
| `fix/settings-option-duplicates` | Remove repeated renderer choices, including duplicate colour-depth entries. |
| `feature/live-settings` | Apply resolution/fullscreen and other supported settings without restarting; correct VSync persistence, DPI/pointer alignment and viewport updates; safely transfer creation-time display options to a replacement window; support negotiated live nickname updates. |
| `feature/progressive-edge-scrolling` | Increase mouse-edge scrolling progressively within the existing activation zone and stop it while interacting with the game GUI. |
| `docs/improvement-roadmap` | Document the improvement roadmap, upstream issue/PR coordination and verification evidence. |
| `feature/gui-scaling` | Scale fonts, skin metrics, windows and hit targets; provide 80–120% presets; correct settings geometry, generated-control sizing and clipping. |

The head is the existing accepted fork snapshot `e21d08ea`; all listed work branches are ancestors of it. Backup branches are recovery snapshots rather than additional contributions. No new game implementation or setup-script changes were introduced to prepare this PR.

## Issue coverage

- **Partially addresses [#6](https://github.com/tomluchowski/OpenDungeonsPlus/issues/6):** the small-widget/high-resolution problem and Windows pointer/display alignment after live resolution/fullscreen changes. Its remaining discoverability and Linux/Flatpak capture or duplicate-cursor reports are not claimed resolved.
- **Related to [#11](https://github.com/tomluchowski/OpenDungeonsPlus/issues/11):** improves mouse-edge panning precision and prevents camera movement while using the HUD. Click/drag-to-pan, configurable mouse buttons and character framing remain outside this change; adjustable pan speed and centred zoom already landed in #40.
- No separate matching open issue was found for the diagnosed Windows compiler/linker failures, dynamic-shadow crashes, repeated colour-depth choices or live-settings regressions.

The current open issues and the comments on #6 and #11 were reviewed. None is claimed completely resolved, so this PR has no automatic issue-closing directive.

## Existing and pending pull requests

- **#29:** the two-row spell/room layout is included as a dependency in its own existing commit, with original authorship preserved; its patch is equivalent to the open PR. GUI scaling adds the wave-portal placement adjustment on top.
- **#21:** independently overlaps the Windows icon-handle and absolute-resource-path corrections; its other macOS, CRLF, editor and URL changes are not included here.
- **#16:** contains the same split layout/portability work alongside other changes; this PR does not import the whole aggregate.
- **#15:** the OGRE 14 port overlaps settings/rendering files, but this contribution retains the tested OGRE 13.6.5 GL3Plus baseline.
- **#41 / #45:** fog and room-ownership visuals remain separate, with file-level overlap in the render manager.
- Already merged #17, #38 and #40 are part of the base and are not claimed as newly implemented here.

## Verification and dependencies

- Windows x64 Release/Debug builds passed during development; the final GUI corrections were rebuilt in Release.
- The user accepted direct Release startup, live settings, corrected mouse alignment, removal of fullscreen bottom-edge flicker, progressive edge scrolling and the completed GUI-scaling step in the running game.
- The packet regression passed two cases with 15 assertions, covering legacy and extended packet boundaries; mixed-version multiplayer sessions were not exercised.
- Focused OGRE checks covered shadow resources/passes, GL3Plus replacement windows, in-place resize/VSync and fullscreen dimensions.
- All 39 CEGUI layouts parse as XML; focused CEGUI settings checks covered small, Full HD, ultrawide and 4K dimensions through scale changes, including nested geometry, dragging and hit targets.

The required OGRE and CEGUI patches are included under `scripts/win32/patches` and applied by the prerequisite scripts; the game changes alone do not patch a prebuilt dependency installation. The existing Windows scripts and development documentation describe the tested local installation and still contain its specific paths. The fork's documentation is included in this combined contribution.

Linux/macOS/MinGW runtime behavior, multiple-monitor transitions, mixed-version multiplayer, the optional SFML-owned window path and standalone packaging are not certified by the Windows checks. Debug direct-start runtime staging remains separate from Release. The version stays at 0.7.1 because this contribution does not declare a release.
