### PR TITLE
Deduplicate renderer setting choices

### DIFF
--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -37,6 +37,8 @@
 
 #include <SFML/Audio/Listener.hpp>
 
+#include <algorithm>
+
 SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
@@ -365,6 +367,11 @@ void SettingsWindow::initConfig()
         // If the option is immutable, we can't change it and shouldn't see it. (at least for now)
         if (config.immutable || config.possibleValues.empty())
             continue;
+
+        // OGRE may repeat colour depths for different fullscreen refresh rates.
+        std::sort(config.possibleValues.begin(), config.possibleValues.end());
+        config.possibleValues.erase(std::unique(config.possibleValues.begin(), config.possibleValues.end()),
+                                   config.possibleValues.end());
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));


### PR DESCRIPTION
Renderer settings could list the same colour depth repeatedly, such as three identical 32-bit entries.

## Change

Deduplicate the renderer-provided values before populating each settings list while preserving every distinct supported choice and the current text selection.

## Coordination

No matching open issue was found. Issue #6 covers broader interface and mouse problems and is not closed by this focused correction; PR #15 also changes renderer settings and may require reconciliation.

## Verification

The focused one-file change is included in the clean Windows x64 Release build of #53, and the user confirmed that the duplicate values are gone.
