### PR TITLE
Include the required fields in default save requests

### DIFF
--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -1962,6 +1962,7 @@ bool EditorMode::onSaveButtonClickFromOptions(const CEGUI::EventArgs& /*arg*/)
         // Send a message to the server telling it we want to drop the creature
         ClientNotification *clientNotification = new ClientNotification(
             ClientNotificationType::askSaveMap);
+        clientNotification->mPacket << std::string() << std::string();
         ODClient::getSingleton().queueClientNotification(clientNotification);
     }
     mModifiedMapBit = false;
@@ -2068,7 +2069,8 @@ bool EditorMode::quickSavePopUpMenu(const CEGUI::EventArgs& /*arg*/)
     if(ODClient::getSingleton().isConnected())
     {
         // Send a message to the server telling it we want to drop the creature
-        ODClient::getSingleton().queueClientNotification(ClientNotificationType::askSaveMap);
+        ODClient::getSingleton().queueClientNotification(ClientNotificationType::askSaveMap,
+            std::string(), std::string());
     }
     mModifiedMapBit = false;
     return true;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1420,6 +1420,7 @@ bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
         // Send a message to the server telling it we want to drop the creature
         ClientNotification *clientNotification = new ClientNotification(
             ClientNotificationType::askSaveMap);
+        clientNotification->mPacket << std::string() << std::string();
         ODClient::getSingleton().queueClientNotification(clientNotification);
     }
     return true;


### PR DESCRIPTION
The game Save command and two default editor save commands send a notification without the two strings the server reads. Send empty directory and filename fields, preserving the existing server defaults and explicit editor filenames; this prevents failed packet extraction and its critical log messages.

No matching reported issue was found; this does not claim to resolve the broader interface or save/load reports.

Validation: The production-caller/packet probe went from six failures to zero across 58 checks; the complete fork passed Windows Release compilation, runtime preparation and headless resource checks. No live saved-map write or crash reproduction is claimed.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
