### PR TITLE
Close the open Options window with Escape

### DIFF
--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -934,8 +934,14 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         break;
     }
 
-    // Quit the game
+    // Close Options before considering a new exit confirmation.
     case OIS::KC_ESCAPE:
+        if(mRootWindow->getChild("GameOptionsWindow")->isVisible() &&
+           !mRootWindow->getChild(Gui::EXIT_CONFIRMATION_POPUP)->isVisible())
+        {
+            hideOptionsWindow();
+            break;
+        }
         mExitToDesktop = false;
         popupExit(!mGameMap->getGamePaused());
         break;


### PR DESCRIPTION
Pressing Escape while Options is open currently opens an exit confirmation. Close Options through its existing handler first; preserve cancellation of an exit confirmation already in front of Options and the normal world Escape behavior.

Related to #6 (dialog navigation); this narrow correction does not resolve the whole interface issue.

Validation: The installed-layout and production-handler probe improved from 16 failures to zero across 32 checks; Windows Release and runtime preparation passed in the complete fork, and the user subsequently confirmed this interaction.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
