### PR TITLE
Keep the exit confirmation title and replay label visible

### DIFF
--- a/gui/WindowQuit.layout
+++ b/gui/WindowQuit.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="ConfirmExit" >
-        <Property name="Area" value="{{0.5,-200},{0.5,-100},{0.5,200},{0.5,39}}" />
+        <Property name="Area" value="{{0.5,-270},{0.5,-100},{0.5,270},{0.5,39}}" />
         <Property name="Text" value="Do you really want to leave the underworld?" />
         <Property name="Alpha" value="0.8" />
         <Property name="AlwaysOnTop" value="True" />
@@ -19,7 +19,7 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/Checkbox" name="SaveReplayCheckbox" >
-            <Property name="Area" value="{{0.5,-91},{0,96},{0.5,91},{0,123}}" />
+            <Property name="Area" value="{{0.5,-120},{0,96},{0.5,120},{0,123}}" />
             <Property name="Text" value="Save the game replay?" />
         </Window>
     </Window>


### PR DESCRIPTION
The exit confirmation clips its title and replay label at supported interface scales. Widen only the dialog and replay-checkbox areas; preserve the text, buttons, callbacks and vertical layout.

Related to #6 (exit-screen clarity); it preserves the exit behavior introduced by merged PR #38 and does not claim to close the broader issue.

Validation: Actual CEGUI font and skin measurements improved from 60 failures to zero across 260 checks at five viewport sizes and multiple scales; an isolated rendered preview showed both complete strings. This is a layout-only change.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
