### PR TITLE
Preserve literal paths and brackets in event messages

### DIFF
--- a/source/network/ChatEventMessage.cpp
+++ b/source/network/ChatEventMessage.cpp
@@ -72,5 +72,14 @@ std::string EventMessage::getMessageAsString()
             eventType = "[image-size='w:16 h:16'][image='OpenDungeonsIcons/ObjectivesIcon'] [colour='FF3333FF']";
             break;
     }
-    return eventType + mMessage + formatWhiteColor + "\n";
+    // The payload is plain text; only the surrounding event decoration is markup.
+    std::string escapedMessage;
+    escapedMessage.reserve(mMessage.size());
+    for(char character : mMessage)
+    {
+        if(character == '\\' || character == '[')
+            escapedMessage += '\\';
+        escapedMessage += character;
+    }
+    return eventType + escapedMessage + formatWhiteColor + "\n";
 }


### PR DESCRIPTION
Backslashes and opening brackets in save paths and other event payloads are interpreted as GUI markup. Escape the displayed copy before applying the existing event decoration, preserving the original stored text and avoiding repeated escaping when the window is rebuilt.

No matching reported issue was found for this parser failure; no issue-closing keyword is used.

Validation: The production formatter and installed CEGUI parser improved from 156 failures to zero across 504 checks, including Windows/UNC/POSIX paths, UTF-8, literal markup and repeated rebuilds; Windows Release and runtime preparation passed in the fork.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
