### PR TITLE
Keep hand rotation and drop selection consistent

### DIFF
--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -274,6 +274,8 @@ void GameEntity::fireDropEntity(Player* playerPicking, Tile* tile)
     // possible. If it is an AI, we queue the message because it might have been created
     // during this turn (and, thus, not exist on client side)
     int seatId = playerPicking->getSeat()->getId();
+    const GameEntityType entityType = getObjectType();
+    const std::string& entityName = getName();
     for(Seat* seat : getGameMap()->getSeats())
     {
         if(seat->getPlayer() == nullptr)
@@ -300,6 +302,7 @@ void GameEntity::fireDropEntity(Player* playerPicking, Tile* tile)
                 ServerNotificationType::entityDropped, seat->getPlayer());
             serverNotification.mPacket << seatId;
             getGameMap()->tileToPacket(serverNotification.mPacket, tile);
+            serverNotification.mPacket << entityType << entityName;
             ODServer::getSingleton().sendAsyncMsg(serverNotification);
         }
         else
@@ -308,6 +311,7 @@ void GameEntity::fireDropEntity(Player* playerPicking, Tile* tile)
                 ServerNotificationType::entityDropped, seat->getPlayer());
             serverNotification->mPacket << seatId;
             getGameMap()->tileToPacket(serverNotification->mPacket, tile);
+            serverNotification->mPacket << entityType << entityName;
             ODServer::getSingleton().queueServerNotification(serverNotification);
         }
     }

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -295,6 +295,17 @@ void Player::pickUpEntity(GameEntity *entity)
 }
 
 
+unsigned int Player::getHandIndex(GameEntityType type, const std::string& name) const
+{
+    for(unsigned int index = 0; index < mObjectsInHand.size(); ++index)
+    {
+        GameEntity* entity = mObjectsInHand[index];
+        if(entity->getObjectType() == type && entity->getName() == name)
+            return index;
+    }
+    return static_cast<unsigned int>(mObjectsInHand.size());
+}
+
 bool Player::isDropHandPossible(Tile *t, unsigned int index)
 {
     // if we have a creature to drop

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -33,6 +33,7 @@ class Seat;
 class Tile;
 
 enum class CreatureActionType;
+enum class GameEntityType;
 enum class SpellType;
 
 enum class PlayerEventType
@@ -152,6 +153,9 @@ public:
 
     //! \brief Check to see the first object in hand can be dropped on Tile t and do so if possible.
     bool isDropHandPossible(Tile *t, unsigned int index = 0);
+
+    //! Returns the held object's index, or the hand size if it is not held.
+    unsigned int getHandIndex(GameEntityType type, const std::string& name) const;
 
     //! \brief Drops the creature on tile t. Returns the dropped creature
     void dropHand(Tile *t, unsigned int index = 0);

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -829,6 +829,8 @@ bool EditorMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
                     ClientNotification *clientNotification = new ClientNotification(
                         ClientNotificationType::askHandDrop);
                     mGameMap->tileToPacket(clientNotification->mPacket, curTile);
+                    GameEntity* entity = mGameMap->getLocalPlayer()->getObjectsInHand().front();
+                    clientNotification->mPacket << entity->getObjectType() << entity->getName();
                     ODClient::getSingleton().queueClientNotification(clientNotification);
                     mModifiedMapBit = true;
                 }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -643,6 +643,8 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
                     ClientNotification *clientNotification = new ClientNotification(
                         ClientNotificationType::askHandDrop);
                     mGameMap->tileToPacket(clientNotification->mPacket, curTile);
+                    GameEntity* entity = mGameMap->getLocalPlayer()->getObjectsInHand().front();
+                    clientNotification->mPacket << entity->getObjectType() << entity->getName();
                     ODClient::getSingleton().queueClientNotification(clientNotification);
                 }
 

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -605,7 +605,21 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             if(tile == nullptr)
                 break;
 
-            gameMap->getLocalPlayer()->dropHand(tile);
+            unsigned int index = 0;
+            // A reply may arrive after another local rotation or pickup.
+            if(!packetReceived.endOfPacket())
+            {
+                int32_t entityType;
+                std::string entityName;
+                if(!(packetReceived >> entityType >> entityName))
+                {
+                    OD_LOG_ERR("Incomplete dropped entity identity");
+                    break;
+                }
+                index = gameMap->getLocalPlayer()->getHandIndex(
+                    static_cast<GameEntityType>(entityType), entityName);
+            }
+            gameMap->getLocalPlayer()->dropHand(tile, index);
             break;
         }
         case ServerNotificationType::entityTeleported:

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1305,14 +1305,27 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                     + " send wrong tile");
                 break;
             }
-            if(!player->isDropHandPossible(tile, 0))
+            unsigned int index = 0;
+            // Old clients identify only the tile. New clients identify the held object too.
+            if(!packetReceived.endOfPacket())
+            {
+                int32_t entityType;
+                std::string entityName;
+                if(!(packetReceived >> entityType >> entityName))
+                {
+                    OD_LOG_ERR("Incomplete hand drop identity");
+                    break;
+                }
+                index = player->getHandIndex(static_cast<GameEntityType>(entityType), entityName);
+            }
+            if(!player->isDropHandPossible(tile, index))
             {
                 OD_LOG_ERR("player seatId=" + Helper::toString(player->getSeat()->getId())
                     + " could not drop entity in hand on tile "
                     + Tile::displayAsString(tile));
                 break;
             }
-            player->dropHand(tile, 0);
+            player->dropHand(tile, index);
             break;
         }
 

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -1701,15 +1701,7 @@ void RenderManager::rrOrderHand(Player* localPlayer)
 
 void RenderManager::rrRotateHand(Player* localPlayer)
 {
-    // Loop over the creatures in our hand and redraw each of them in their new location.
-    int i = 0;
-    const std::vector<GameEntity*>& objectsInHand = localPlayer->getObjectsInHand();
-    for (GameEntity* tmpEntity : objectsInHand)
-    {
-        Ogre::SceneNode* tmpEntityNode = mSceneManager->getSceneNode(tmpEntity->getOgreNamePrefix() + tmpEntity->getName() + "_node");
-        tmpEntityNode->setPosition(static_cast<Ogre::Real>(i % 6 + 1), static_cast<Ogre::Real>(i / 6), static_cast<Ogre::Real>(0.0));
-        ++i;
-    }
+    rrOrderHand(localPlayer);
 }
 
 void RenderManager::rrPitchAroundAxis(RenderedMovableEntity* renderedmovableGameEntity, Ogre::Degree dd)


### PR DESCRIPTION
Reapply the existing hand layout after rotating held objects, and identify drop requests and replies by entity identity so later pickup or rotation cannot redirect a pending drop. Preserve legacy handling when optional identity fields are absent.

Related to #6 (pointer interaction); this addresses held-object consistency only and does not close the broad interface report.

Validation: All 227 focused production renderer and packet checks passed in the complete fork, covering rotation, delayed replies, pickup while a reply is pending, permissions and legacy packet fallback; Windows Release and runtime preparation passed. Live multiplayer acceptance is not claimed.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
