### PR TITLE
Disable obsolete MSVC minimal rebuild state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,8 +183,8 @@ endif()
 if(WIN32 AND MSVC)
     #Set some extra compiler flags
     #TODO - investigate if these are what they should be
-    set(PLATFORM_C_FLAGS "/W3 /MD /Od /DWIN32 /D_WINDOWS /Gm /Gy /fp:fast /ZI /EHsc")
-    set(PLATFORM_C_FLAGS_DEBUG "/W3 /MDd /Od /Gm /Gy /fp:fast /ZI /DOD_DEBUG" )
+    set(PLATFORM_C_FLAGS "/W3 /MD /Od /DWIN32 /D_WINDOWS /Gm- /Gy /fp:fast /ZI /EHsc")
+    set(PLATFORM_C_FLAGS_DEBUG "/W3 /MDd /Od /Gm- /Gy /fp:fast /ZI /DOD_DEBUG" )
 
     # Set the application version
     add_definitions(/DOD_VERSION="${OD_MAJOR_VERSION}.${OD_MINOR_VERSION}.${OD_PATCH_LEVEL}")


### PR DESCRIPTION
The existing MSVC minimal-rebuild setting can retain incompatible virtual-call layouts after incremental builds. Disable that obsolete setting so rebuilt callers and implementations agree without stale dependency state.

Follow-up to #47; no matching issue was found for this incremental-build failure, and it does not resolve the renderer-port work in #15.

Validation: The complete fork rebuilt all 248 translation units; linked game/editor dispatch checks passed and the preserved earlier executable failed the affected check. Runtime preparation and headless resource checks passed. The patch changes the build configuration only.

This contribution contains only this functional patch and applies independently to the current upstream default branch. The recorded runtime checks were performed on the complete fork; this extracted contribution has not been separately built or run. Internal planning, reference documents and local setup notes are excluded. Version remains 0.7.1 because this is not a release.
