### PR TITLE
Preserve shadows for small creatures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,19 @@ The maintained instructions and scripts live in this repository under
 Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
 
 At the verified state on 2026-09-05, dependency builds, game CMake configuration
-and both Windows x64 game builds (Release and Debug) succeeded; game startup,
-manual gameplay tests and packaging remain unverified.
+and both Windows x64 game builds (Release and Debug) succeeded.
+User startup attempts exposed a Windows resource-path bug; both binaries now
+include its correction. A subsequent Release run loaded the main-menu scene and
+shut down normally without the earlier loading errors; the user subsequently
+confirmed that the Release executable starts without errors.
+Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
+before investigating further startup issues; broader gameplay tests and packaging
+remain unverified.
+The Release executable now has its runtime DLLs staged beside it for direct
+File Explorer startup; the configuration script maintains this through
+`scripts/win32/prepare-windows-runtime.ps1`. Python's standard library and OGRE
+media still use the external installation. Read BUILDING.md for the static
+verification results and the remaining Debug runtime/plugin limitations.
 Read the [Windows build fixes](docs/development/WINDOWS-BUILD-FIXES.md) for the four
 diagnosed failures and verification logs; the CEGUI source now includes a
 repository-managed compatibility patch applied by its installation script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,15 @@ That confirmation predates enabling dynamic shadows: a later startup failure was
 traced to OGRE's internal shadow programs being registered only in Graphics.
 The resource template now also exposes Media/Main through OgreInternal while
 retaining Graphics access for shader includes; the headless OGRE resource test
-fails before and passes after this correction, while actual startup verification
-with shadows enabled is pending. Check the latest evidence in the startup notes.
+fails before and passes after this correction, and the user's 14:52 run reached
+the main menu with shadows enabled. That run later failed while entering
+TestLegacyNoScripts.level. Added exception logging captured the cause during the
+user's 15:05 reproduction: automatic additive illumination splitting removed
+DirtInstanced's fragment shader, which GL3Plus requires. RenderManager now uses
+integrated additive texture shadows to retain the custom shader passes. Release
+and Debug rebuilt successfully; the isolated OGRE pass test fails with splitting
+and passes without it. The user must still retest the map and shadow appearance
+with the rebuilt executable; check the latest evidence in the startup notes.
 Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
 before investigating further startup issues; broader gameplay tests and packaging
 remain unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Project context for future sessions
 
+## Language
+
+Communicate with the user in German.
+Write and maintain all project documentation in English.
+Use English for Git-related text, including commit messages, pull request titles,
+descriptions and review comments.
+
+## Project setup
+
 Before working on this project, read:
 
 1. [Windows environment and current status](docs/development/WINDOWS-DEV-SETUP.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Project context for future sessions
+
+Before working on this project, read:
+
+1. [Windows environment and current status](docs/development/WINDOWS-DEV-SETUP.md).
+2. [Configure and build commands](docs/development/BUILDING.md).
+3. [Development documentation index](docs/development/README.md); follow the
+   workflow and task notes when relevant to the request.
+
+Windows development is organized on `feature/windows-support` in this fork.
+Read the current setup in [the contribution workflow](docs/development/CONTRIBUTING-WORKFLOW.md)
+before Git operations: `origin` is the fork and `upstream` is the original project.
+Preserve the existing default branch; continue this Windows task on its work branch.
+The work branch includes local notes and is not the final upstream PR branch;
+prepare that later from upstream using only the reviewed, reusable changes.
+Do not push without explicit user authorization.
+
+The Windows prerequisites are already installed in `C:\Users\mario\od-deps`;
+their sources, binaries and logs deliberately live outside the repository.
+The maintained instructions and scripts live in this repository under
+`docs/development/` and `scripts/win32/`.
+Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
+
+At the documented handover on 2026-09-05, dependency builds and game CMake
+configuration succeeded; compiling and starting the game were still unverified.
+Read the current status document and check the actual files before making claims.
+Do not reinstall dependencies or switch versions just because a new session starts.
+Use the repository's environment helper and configuration script; the scripts
+currently target Mario's Windows installation, with paths recorded in the docs.
+
+Keep changes within the user's request and preserve existing work.
+Do not read `.env` or other secret files.
+Manual game tests, QA and visual acceptance are performed by the user.
+When changing setup paths, versions, commands or verified build status, update the
+linked documentation in the same task so the next session has the current state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ User startup attempts exposed a Windows resource-path bug; both binaries now
 include its correction. A subsequent Release run loaded the main-menu scene and
 shut down normally without the earlier loading errors; the user subsequently
 confirmed that the Release executable starts without errors.
+That confirmation predates enabling dynamic shadows: a later startup failure was
+traced to OGRE's internal shadow programs being registered only in Graphics.
+The resource template now also exposes Media/Main through OgreInternal while
+retaining Graphics access for shader includes; the headless OGRE resource test
+fails before and passes after this correction, while actual startup verification
+with shadows enabled is pending. Check the latest evidence in the startup notes.
 Read [startup failures and verification](docs/development/WINDOWS-STARTUP-FIXES.md)
 before investigating further startup issues; broader gameplay tests and packaging
 remain unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,12 @@ The maintained instructions and scripts live in this repository under
 `docs/development/` and `scripts/win32/`.
 Do not rely on the old copies in `build/` or `od-deps/setup-scripts/`.
 
-At the documented handover on 2026-09-05, dependency builds and game CMake
-configuration succeeded; compiling and starting the game were still unverified.
+At the verified state on 2026-09-05, dependency builds, game CMake configuration
+and both Windows x64 game builds (Release and Debug) succeeded; game startup,
+manual gameplay tests and packaging remain unverified.
+Read the [Windows build fixes](docs/development/WINDOWS-BUILD-FIXES.md) for the four
+diagnosed failures and verification logs; the CEGUI source now includes a
+repository-managed compatibility patch applied by its installation script.
 Read the current status document and check the actual files before making claims.
 Do not reinstall dependencies or switch versions just because a new session starts.
 Use the repository's environment helper and configuration script; the scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +660,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You will find us on the following channels:
 For this fork's local Windows setup, see the maintained
 [development environment](docs/development/WINDOWS-DEV-SETUP.md) and
 [configure/build commands](docs/development/BUILDING.md), including verified status.
+Diagnosed Windows compiler and linker failures are recorded in the
+[build fixes and validation notes](docs/development/WINDOWS-BUILD-FIXES.md).
 
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You will find us on the following channels:
 
 ### Build instructions
 
+For this fork's local Windows setup, see the maintained
+[development environment](docs/development/WINDOWS-DEV-SETUP.md) and
+[configure/build commands](docs/development/BUILDING.md), including verified status.
+
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions
 on our wiki: https://github.com/OpenDungeons/OpenDungeons/wiki/Compile

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For this fork's local Windows setup, see the maintained
 [configure/build commands](docs/development/BUILDING.md), including verified status.
 Diagnosed Windows compiler and linker failures are recorded in the
 [build fixes and validation notes](docs/development/WINDOWS-BUILD-FIXES.md).
+Direct Windows startup and its verification are covered in the
+[startup fixes](docs/development/WINDOWS-STARTUP-FIXES.md).
 
 If you retrieve the source code of OpenDungeonsPlus and want to have a go at
 building it yourself, have a look at platform-specific build instructions

--- a/cmake/config/resources.cfg.in
+++ b/cmake/config/resources.cfg.in
@@ -12,6 +12,11 @@ FileSystem=models
 FileSystem=particles
 FileSystem=shaders
 
+# Internal shadow programs must also be visible to OGRE's global resource pool.
+# Keep Main in Graphics above for game shader includes with strict group lookup.
+[OgreInternal]
+FileSystem=@CMAKE_INSTALL_PREFIX@/share/OGRE/Media/RTShaderLib/../Main
+
 [GUI]
 FileSystem=gui
 FileSystem=gui/fonts

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,24 +1,24 @@
-# Unter Windows konfigurieren und kompilieren
+# Configuring and compiling on Windows
 
-Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
-und CMake sowie die Spielbuilds für Windows x64 in Release und Debug wurden
-erfolgreich ausgeführt; der Spielstart ist noch nicht praktisch geprüft.
-Die vier behobenen Buildfehler und ihre Nachweise stehen in
+As of September 5, 2026. The [prerequisites](WINDOWS-DEV-SETUP.md) are installed
+and CMake and the Windows x64 game builds in Release and Debug have
+completed successfully; game startup has not yet been tested in practice.
+The four resolved build errors and their evidence are recorded in
 [WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
 
-## 1. PowerShell-Sitzung vorbereiten
+## 1. Prepare the PowerShell session
 
-In einer neuen PowerShell-Konsole:
+In a new PowerShell console:
 
 ```powershell
 Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
 . .\scripts\win32\Enter-OpenDungeonsPlus.ps1
 ```
 
-Der Punkt am Anfang lädt Compiler und Suchpfade in dieselbe Sitzung; in dieser
-Konsole anschließend konfigurieren und bauen. Erwartet sind CMake 3.31.8,
-Python 3.10.11 und der x64-Compiler der Visual Studio 2022 Build Tools.
-Bei Bedarf ohne Build prüfen:
+The dot at the start loads the compiler and search paths into the same session;
+then configure and build in this console. CMake 3.31.8,
+Python 3.10.11 and the x64 compiler from Visual Studio 2022 Build Tools are expected.
+If needed, check without building:
 
 ```powershell
 Get-Command cl.exe, cmake.exe, python.exe | Select-Object Name, Source
@@ -26,57 +26,57 @@ cmake --version
 python --version
 ```
 
-## 2. CMake konfigurieren
+## 2. Configure CMake
 
 ```powershell
 & .\scripts\win32\configure-windows-prereqs.ps1
 ```
 
-Das Skript lädt auch selbst den Starthelfer und verwendet:
+The script also loads the environment helper itself and uses:
 
-- Quelle: Projektstamm, aus dem Skriptpfad abgeleitet.
-- Buildordner: `build\windows`.
-- Generator: `Visual Studio 17 2022`, Architektur `x64`.
-- `OD_BUILD_TESTING=OFF` und `BUILD_TESTING=OFF`.
-- Installationsziel: `build\windows\install`.
-- Python unter `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
+- Source: project root, derived from the script path.
+- Build directory: `build\windows`.
+- Generator: `Visual Studio 17 2022`, architecture `x64`.
+- `OD_BUILD_TESTING=OFF` and `BUILD_TESTING=OFF`.
+- Installation target: `build\windows\install`.
+- Python under `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
   `python.exe`, `include`, `libs\python310.lib`, `libs\python310_d.lib`.
 
-Das Konfigurationsprotokoll wird bei jedem Aufruf ersetzt:
+The configuration log is replaced on every invocation:
 `C:\Users\mario\od-deps\logs\opendungeons-configure.log`.
-Bei Fehlern gibt das Skript die letzten Zeilen aus und bricht ab.
-Nach Änderungen an CMake-Dateien oder Quelllisten erneut konfigurieren;
-für gewöhnliche Änderungen bestehender C++-Dateien den vorhandenen Build verwenden.
+On errors, the script prints the last lines and aborts.
+Reconfigure after changes to CMake files or source lists;
+for ordinary changes to existing C++ files, use the existing build.
 
-## 3. Spiel bauen
+## 3. Build the game
 
-Release aus derselben vorbereiteten Konsole:
+Release from the same prepared console:
 
 ```powershell
 cmake --build .\build\windows --config Release --parallel 4
-if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Release fehlgeschlagen' }
+if ($LASTEXITCODE -ne 0) { throw 'Release game build failed' }
 ```
 
-Für Debug stattdessen:
+For Debug instead:
 
 ```powershell
 cmake --build .\build\windows --config Debug --parallel 4
-if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
+if ($LASTEXITCODE -ne 0) { throw 'Debug game build failed' }
 ```
 
-Die erfolgreich erzeugten Ausgabedateien sind
-`build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
-direkt im Buildordner. Beide Dateien wurden auf ihre AMD64-PE-Kennung und die
-jeweils passende Python-DLL geprüft, ohne das Spiel zu starten.
-Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
-Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
-Die protokollierten erfolgreichen Verifikationsläufe dieser Einrichtung liegen
-unter `build\windows\game-Release-pass3.log` und `game-Debug-pass3.log`.
+The successfully generated output files are
+`build\windows\opendungeons-plus.exe` and `build\windows\opendungeons-plus_d.exe`,
+directly in the build directory. Both files were checked for their AMD64 PE signature and
+the corresponding Python DLL without starting the game.
+The build output appears in the console; if an error occurs, record the first specific
+compiler/linker message and the configuration used.
+The logged successful verification runs for this setup are located
+under `build\windows\game-Release-pass3.log` and `game-Debug-pass3.log`.
 
-## 4. Spielstart und manuelle Prüfung
+## 4. Game startup and manual verification
 
-Erst nach erfolgreichem Build durch den Nutzer prüfen; der folgende Startbefehl
-ist noch nicht praktisch verifiziert und setzt dieselbe geladene Umgebung voraus:
+The user should only test after a successful build; the following startup command
+has not yet been verified in practice and requires the same loaded environment:
 
 ```powershell
 Push-Location -LiteralPath .\build\windows
@@ -87,23 +87,23 @@ try {
 }
 ```
 
-Für Debug die Datei `opendungeons-plus_d.exe` verwenden.
-CMake erzeugt hier `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` und Verbindungen
-zu den Spieldaten. Bei fehlenden DLLs oder Plugins den tatsächlichen Startfehler
-prüfen; DLL-Verteilung, Plugin-Laden und Spielstart sind noch offen.
-Manuelle Spieltests und die visuelle Abnahme führt der Nutzer durch.
+For Debug, use the file `opendungeons-plus_d.exe`.
+CMake generates `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` and links
+to the game data here. If DLLs or plugins are missing, examine the actual startup error;
+DLL distribution, plugin loading and game startup are still pending.
+The user performs manual game tests and visual acceptance.
 
-## Protokolle und Wiederaufnahme
+## Logs and resuming work
 
-- Aktueller Installations- und Prüfstand: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
-- Bibliotheksprotokolle: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
-  `<name>-Release.log`, `<name>-Debug.log`; Boost verwendet
-  `boost-bootstrap.log` und `boost-build.log`.
-- Abhängigkeiten nur bei tatsächlichem Bedarf nach
-  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md) neu bauen.
+- Current installation and verification status: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
+- Library logs: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
+  `<name>-Release.log`, `<name>-Debug.log`; Boost uses
+  `boost-bootstrap.log` and `boost-build.log`.
+- Rebuild dependencies only when actually needed, following
+  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
 
-`build` ist von Git ausgeschlossen und enthält generierte Dateien;
-`build\windows` enthält außerdem Verzeichnisverbindungen zu Projektressourcen.
-Diese Verbindungen beim Aufräumen beachten und keine Quellverzeichnisse über sie löschen.
-Nach einem neuen Ergebnis Datum, verwendete Konfiguration, Fehler bzw. Erfolg
-und verbleibende Prüfungen im Windows-Status nachtragen.
+`build` is excluded from Git and contains generated files;
+`build\windows` also contains directory junctions to project resources.
+Take these junctions into account when cleaning up and do not delete source directories through them.
+After a new result, add the date, configuration used, error or success
+and remaining checks to the Windows status document.

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,8 +1,10 @@
 # Unter Windows konfigurieren und kompilieren
 
 Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
-und CMake wurde erfolgreich ausgeführt; die folgenden Spielbuilds und der
-Spielstart sind noch nicht praktisch geprüft.
+und CMake sowie die Spielbuilds für Windows x64 in Release und Debug wurden
+erfolgreich ausgeführt; der Spielstart ist noch nicht praktisch geprüft.
+Die vier behobenen Buildfehler und ihre Nachweise stehen in
+[WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
 
 ## 1. PowerShell-Sitzung vorbereiten
 
@@ -62,12 +64,14 @@ cmake --build .\build\windows --config Debug --parallel 4
 if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
 ```
 
-Laut generiertem Visual-Studio-Projekt sind die erwarteten Ausgabedateien
+Die erfolgreich erzeugten Ausgabedateien sind
 `build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
-direkt im Buildordner. Diese Pfade wurden aus der Konfiguration geprüft;
-ein erfolgreicher Spielbuild ist damit noch nicht belegt.
+direkt im Buildordner. Beide Dateien wurden auf ihre AMD64-PE-Kennung und die
+jeweils passende Python-DLL geprüft, ohne das Spiel zu starten.
 Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
 Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
+Die protokollierten erfolgreichen Verifikationsläufe dieser Einrichtung liegen
+unter `build\windows\game-Release-pass3.log` und `game-Debug-pass3.log`.
 
 ## 4. Spielstart und manuelle Prüfung
 

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -1,0 +1,105 @@
+# Unter Windows konfigurieren und kompilieren
+
+Stand: 5. September 2026. Die [Voraussetzungen](WINDOWS-DEV-SETUP.md) sind installiert
+und CMake wurde erfolgreich ausgeführt; die folgenden Spielbuilds und der
+Spielstart sind noch nicht praktisch geprüft.
+
+## 1. PowerShell-Sitzung vorbereiten
+
+In einer neuen PowerShell-Konsole:
+
+```powershell
+Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
+. .\scripts\win32\Enter-OpenDungeonsPlus.ps1
+```
+
+Der Punkt am Anfang lädt Compiler und Suchpfade in dieselbe Sitzung; in dieser
+Konsole anschließend konfigurieren und bauen. Erwartet sind CMake 3.31.8,
+Python 3.10.11 und der x64-Compiler der Visual Studio 2022 Build Tools.
+Bei Bedarf ohne Build prüfen:
+
+```powershell
+Get-Command cl.exe, cmake.exe, python.exe | Select-Object Name, Source
+cmake --version
+python --version
+```
+
+## 2. CMake konfigurieren
+
+```powershell
+& .\scripts\win32\configure-windows-prereqs.ps1
+```
+
+Das Skript lädt auch selbst den Starthelfer und verwendet:
+
+- Quelle: Projektstamm, aus dem Skriptpfad abgeleitet.
+- Buildordner: `build\windows`.
+- Generator: `Visual Studio 17 2022`, Architektur `x64`.
+- `OD_BUILD_TESTING=OFF` und `BUILD_TESTING=OFF`.
+- Installationsziel: `build\windows\install`.
+- Python unter `C:\Users\mario\AppData\Local\Programs\Python\Python310`:
+  `python.exe`, `include`, `libs\python310.lib`, `libs\python310_d.lib`.
+
+Das Konfigurationsprotokoll wird bei jedem Aufruf ersetzt:
+`C:\Users\mario\od-deps\logs\opendungeons-configure.log`.
+Bei Fehlern gibt das Skript die letzten Zeilen aus und bricht ab.
+Nach Änderungen an CMake-Dateien oder Quelllisten erneut konfigurieren;
+für gewöhnliche Änderungen bestehender C++-Dateien den vorhandenen Build verwenden.
+
+## 3. Spiel bauen
+
+Release aus derselben vorbereiteten Konsole:
+
+```powershell
+cmake --build .\build\windows --config Release --parallel 4
+if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Release fehlgeschlagen' }
+```
+
+Für Debug stattdessen:
+
+```powershell
+cmake --build .\build\windows --config Debug --parallel 4
+if ($LASTEXITCODE -ne 0) { throw 'Spielbuild Debug fehlgeschlagen' }
+```
+
+Laut generiertem Visual-Studio-Projekt sind die erwarteten Ausgabedateien
+`build\windows\opendungeons-plus.exe` und `build\windows\opendungeons-plus_d.exe`,
+direkt im Buildordner. Diese Pfade wurden aus der Konfiguration geprüft;
+ein erfolgreicher Spielbuild ist damit noch nicht belegt.
+Die Buildausgabe erscheint in der Konsole; bei einem Fehler die erste konkrete
+Compiler-/Linkermeldung und die verwendete Konfiguration festhalten.
+
+## 4. Spielstart und manuelle Prüfung
+
+Erst nach erfolgreichem Build durch den Nutzer prüfen; der folgende Startbefehl
+ist noch nicht praktisch verifiziert und setzt dieselbe geladene Umgebung voraus:
+
+```powershell
+Push-Location -LiteralPath .\build\windows
+try {
+    & .\opendungeons-plus.exe
+} finally {
+    Pop-Location
+}
+```
+
+Für Debug die Datei `opendungeons-plus_d.exe` verwenden.
+CMake erzeugt hier `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` und Verbindungen
+zu den Spieldaten. Bei fehlenden DLLs oder Plugins den tatsächlichen Startfehler
+prüfen; DLL-Verteilung, Plugin-Laden und Spielstart sind noch offen.
+Manuelle Spieltests und die visuelle Abnahme führt der Nutzer durch.
+
+## Protokolle und Wiederaufnahme
+
+- Aktueller Installations- und Prüfstand: [WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
+- Bibliotheksprotokolle: `C:\Users\mario\od-deps\logs\<name>-configure.log`,
+  `<name>-Release.log`, `<name>-Debug.log`; Boost verwendet
+  `boost-bootstrap.log` und `boost-build.log`.
+- Abhängigkeiten nur bei tatsächlichem Bedarf nach
+  [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md) neu bauen.
+
+`build` ist von Git ausgeschlossen und enthält generierte Dateien;
+`build\windows` enthält außerdem Verzeichnisverbindungen zu Projektressourcen.
+Diese Verbindungen beim Aufräumen beachten und keine Quellverzeichnisse über sie löschen.
+Nach einem neuen Ergebnis Datum, verwendete Konfiguration, Fehler bzw. Erfolg
+und verbleibende Prüfungen im Windows-Status nachtragen.

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -89,10 +89,20 @@ loading and normal shutdown without the earlier loading errors; the user then
 confirmed an error-free direct startup on September 5, 2026.
 That confirmation predates the dynamic-shadow startup failure. The resource
 template now also registers OGRE's `Media/Main` in `OgreInternal`, while retaining
-its `Graphics` entry for game shader includes; startup verification with shadows
-enabled is pending as described in [startup fixes](WINDOWS-STARTUP-FIXES.md).
+its `Graphics` entry for game shader includes; the user's subsequent run reached
+the main menu with shadows enabled, as recorded in
+[startup fixes](WINDOWS-STARTUP-FIXES.md).
 The corrected configuration has been generated beside the executable and passed
 the isolated OGRE resource test; no C++ rebuild is needed for this template change.
+The user's later Legacy test-map reproduction identified a fragment shader removed
+by OGRE's automatic illumination splitting. RenderManager now selects integrated
+additive texture shadows, preserving the existing custom shader passes. Release
+and Debug rebuilt successfully; the isolated OGRE pass test reproduces the missing
+fragment programs with splitting and retains the original pass without it.
+The Release executable is ready for the user to retest the same map with shadows
+enabled; gameplay and shadow appearance have not yet been verified after this fix.
+Build logs: `game-Release-integrated-shadows.log` and
+`game-Debug-integrated-shadows.log` under `build/windows`.
 
 The configuration script now calls
 [prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -87,6 +87,12 @@ The files have been prepared and checked, and the executable includes the fix fo
 absolute Windows resource paths. The 14:07 startup logs confirm main-menu scene
 loading and normal shutdown without the earlier loading errors; the user then
 confirmed an error-free direct startup on September 5, 2026.
+That confirmation predates the dynamic-shadow startup failure. The resource
+template now also registers OGRE's `Media/Main` in `OgreInternal`, while retaining
+its `Graphics` entry for game shader includes; startup verification with shadows
+enabled is pending as described in [startup fixes](WINDOWS-STARTUP-FIXES.md).
+The corrected configuration has been generated beside the executable and passed
+the isolated OGRE resource test; no C++ rebuild is needed for this template change.
 
 The configuration script now calls
 [prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).

--- a/docs/development/BUILDING.md
+++ b/docs/development/BUILDING.md
@@ -2,9 +2,13 @@
 
 As of September 5, 2026. The [prerequisites](WINDOWS-DEV-SETUP.md) are installed
 and CMake and the Windows x64 game builds in Release and Debug have
-completed successfully; game startup has not yet been tested in practice.
+completed successfully; the user's startup attempts exposed a resource-path error,
+which has been corrected and rebuilt; a subsequent run reached the main-menu scene
+and shut down normally, and the user confirmed that Release starts without errors.
 The four resolved build errors and their evidence are recorded in
 [WINDOWS-BUILD-FIXES.md](WINDOWS-BUILD-FIXES.md).
+The startup evidence and subsequent correction are recorded in
+[WINDOWS-STARTUP-FIXES.md](WINDOWS-STARTUP-FIXES.md).
 
 ## 1. Prepare the PowerShell session
 
@@ -73,24 +77,66 @@ compiler/linker message and the configuration used.
 The logged successful verification runs for this setup are located
 under `build\windows\game-Release-pass3.log` and `game-Debug-pass3.log`.
 
-## 4. Game startup and manual verification
+## 4. Direct Release startup and manual verification
 
-The user should only test after a successful build; the following startup command
-has not yet been verified in practice and requires the same loaded environment:
+For the current local setup, double-click
+`C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\opendungeons-plus.exe`
+in File Explorer; no PowerShell session is needed to test the Release build.
+Keep the executable in that directory with its DLLs, configuration and resource links.
+The files have been prepared and checked, and the executable includes the fix for
+absolute Windows resource paths. The 14:07 startup logs confirm main-menu scene
+loading and normal shutdown without the earlier loading errors; the user then
+confirmed an error-free direct startup on September 5, 2026.
+
+The configuration script now calls
+[prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1).
+It copies 20 installed Release library/plugin DLLs and the two Python runtime DLLs
+next to the executable, and replaces the generated Unix-style OGRE media paths
+with the existing Windows installation's `Media/RTShaderLib`,
+`Media/RTShaderLib/GLSL` and `Media/Main` directories.
+The missing HLSL, HLSL_Cg and materials subdirectories are not registered.
+The other game resource entries and their existing junctions are preserved.
+
+The generated `python310._pth` points to the existing Python installation, its
+`Lib` and `DLLs` directories and the executable directory, with `import site` enabled;
+Python documents this application-local module path mechanism in
+[Finding modules on Windows](https://docs.python.org/3.10/using/windows.html#finding-modules).
+This is a local development setup: OGRE media and the Python standard library
+still reside outside the repository, and the installed Visual C++ runtime is used.
+It is not a standalone distribution package.
+
+If dependencies change or CMake regenerates the resource configuration outside
+the configuration script, refresh the prepared files with:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\win32\prepare-windows-runtime.ps1
+```
+
+The execution-policy option applies only to that process; it does not change the
+system's policy. The setup has already been performed for the current Release executable.
+
+As of September 5, 2026, static checks covered the executable and 22 DLLs,
+all four configured OGRE plugins and all 14 resource directories, with no missing
+DLL dependencies or incorrect CPU architectures; evidence is stored in
+`build\windows\runtime-validation.json`. These checks do not start the game.
+
+Debug still requires the prepared development environment; its direct-start
+runtime files have not been staged. An optional console startup from the loaded
+environment is:
 
 ```powershell
 Push-Location -LiteralPath .\build\windows
 try {
-    & .\opendungeons-plus.exe
+    & .\opendungeons-plus_d.exe
 } finally {
     Pop-Location
 }
 ```
 
-For Debug, use the file `opendungeons-plus_d.exe`.
-CMake generates `plugins.cfg`, `plugins_d.cfg`, `resources.cfg` and links
-to the game data here. If DLLs or plugins are missing, examine the actual startup error;
-DLL distribution, plugin loading and game startup are still pending.
+The Debug startup command has not been verified in practice; its generated
+`plugins_d.cfg` still names the Release variants of Codec_STBI and RenderSystem_GL3Plus,
+so Debug plugin selection needs correction before its startup can be considered ready.
+If a startup error occurs, record the actual message for diagnosis.
 The user performs manual game tests and visual acceptance.
 
 ## Logs and resuming work

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -1,110 +1,110 @@
-# Am Originalprojekt mitarbeiten
+# Contributing to the original project
 
-## Eigenständig im Fork arbeiten
+## Working independently in the fork
 
-Im eigenen Fork kann das Projekt unabhängig weiterentwickelt werden; eine Aufnahme
-ins Team des Originalprojekts oder dessen Schreibrechte sind dafür nicht nötig.
-Die tatsächlichen persönlichen Schreibrechte am Originalrepository wurden nicht
-geprüft.
+The project can be developed independently in your own fork; joining
+the original project's team or having write permissions there is not necessary.
+The actual personal write permissions to the original repository have not
+been checked.
 
-Das Originalprojekt wird als Upstream benötigt, wenn dessen neue Änderungen
-übernommen oder eigene Änderungen per Pull Request zurückgegeben werden sollen;
-beides ist für die reine Weiterentwicklung im eigenen Fork optional.
+The original project is needed as upstream when you want to incorporate its new
+changes or contribute your own changes back through a pull request;
+both are optional if you only want to continue development in your own fork.
 
-Auch im Fork einen eigenen Arbeitsbranch pro Aufgabe verwenden. Für reine
-Fork-Arbeiten diesen vom aktuellen eigenen Entwicklungsstand erstellen, damit
-bereits vorhandene eigene Änderungen erhalten bleiben. Die nachfolgenden Schritte
-beschreiben dagegen einen Beitrag ans Originalprojekt und starten dessen
-Arbeitsbranch direkt vom Upstream-Stand.
+Use a separate work branch for each task even in the fork. For work solely
+in the fork, create it from your own current development state so that
+existing changes of your own are preserved. The following steps,
+in contrast, describe a contribution to the original project and start its
+work branch directly from the upstream state.
 
-## Repositories und Zielbranch
+## Repositories and target branch
 
-- Eigener Fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
-  lokal als `origin` eingerichtet.
-- Originalprojekt für unsere Beiträge:
+- Own fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
+  configured locally as `origin`.
+- Original project for our contributions:
   [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
-  lokal als `upstream` eingerichtet.
-- Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
-  Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+  configured locally as `upstream`.
+- Target branch in the original project: `shaders-improvement` (as of September 5, 2026).
+  Check the intended target branch on GitHub before a pull request.
 
-## Aktuell eingerichtet: Windows-Unterstützung
+## Currently configured: Windows support
 
-Stand: 5. September 2026. Unser Arbeitsbranch im Fork ist
-`feature/windows-support`; hier setzen wir die Windows-Arbeit fort.
-Auch Dokumentation und die Vorbereitung einer Build-Umgebung gehören auf einen
-Arbeitsbranch; ein Branch ist nicht auf neue Spielfunktionen beschränkt.
+As of September 5, 2026. Our work branch in the fork is
+`feature/windows-support`; we continue the Windows work here.
+Documentation and the preparation of a build environment also belong on a
+work branch; a branch is not limited to new game features.
 
-Der Branch wurde vom vorhandenen Fork-Stand `a8ffa583` erstellt und übernimmt
-die bis dahin uncommittierten Setup-Skripte und Entwicklungsnotizen.
-Der Standardbranch `shaders-improvement` bleibt auf diesem Stand;
-seinen bereits vorhandenen Dokumentationscommit schreiben wir nicht um.
-Beim Abruf zeigte der bestätigte Standardbranch des Originals,
-`upstream/shaders-improvement`, auf den Commit `be44649f`.
-Der Fork-Standardbranch liegt damit zum Einrichtungszeitpunkt einen
-Dokumentationscommit vor dem Original.
+The branch was created from the existing fork state `a8ffa583` and includes
+the setup scripts and development notes that had not yet been committed.
+The default branch `shaders-improvement` remains at that state;
+we do not rewrite its existing documentation commit.
+When fetched, the confirmed default branch of the original project,
+`upstream/shaders-improvement`, pointed to commit `be44649f`.
+The fork's default branch was therefore one documentation commit ahead of
+the original at the time of setup.
 
-Die Einrichtung wird in zwei Commits festgehalten: zuerst die bisherigen lokalen
-Windows-Setup-Skripte, danach die Dokumentation einschließlich dieser Arbeitsweise.
-Es gibt dabei noch keine Änderung am Spielcode oder an der Spielversion;
-README und Entwicklungsdokumentation beschreiben den tatsächlichen Stand,
-ein zusätzlicher Spiele-Changelog-Eintrag ist für diese Einrichtung nicht nötig.
+The setup is recorded in two commits: first the existing local
+Windows setup scripts, then the documentation including this workflow.
+There is no change to the game code or game version at this point;
+README and the development documentation describe the actual state,
+and an additional game changelog entry is not needed for this setup.
 
-### Tägliche Arbeit
+### Daily work
 
-Beim Wiederaufnehmen `git status` prüfen und auf `feature/windows-support`
-weiterarbeiten; Umgebung und Buildbefehle stehen in [BUILDING.md](BUILDING.md).
-Für diese laufende Windows-Aufgabe nicht bei jeder Sitzung einen neuen Branch
-erstellen. Fachlich abgeschlossene Änderungen separat committen und gemeinsam
-mit ihrer zugehörigen allgemeinen Build-Dokumentation prüfen; persönliche
-Rechnernotizen in einem eigenen Dokumentationscommit halten.
+When resuming, check `git status` and continue working on `feature/windows-support`;
+the environment and build commands are in [BUILDING.md](BUILDING.md).
+Do not create a new branch for each session of this ongoing Windows task.
+Commit completed, coherent changes separately and review them together
+with their associated general build documentation; keep personal
+computer notes in a separate documentation commit.
 
-Der Standardbranch wird für diese Arbeit nicht verändert. Neue Originaländerungen
-zunächst mit `git fetch upstream` abrufen und vor einer Übernahme vergleichen;
-ein Abruf allein verändert weder Arbeitsdateien noch lokale Arbeitsbranches.
+The default branch is not changed for this work. First fetch new changes from
+the original with `git fetch upstream` and compare them before incorporating them;
+a fetch alone changes neither working files nor local work branches.
 
-`origin` ist lokal als Standardziel für spätere Pushes gesetzt, für den
-Windows-Arbeitsbranch ebenfalls ausdrücklich als Push-Remote.
-Der neue Branch ist bisher nur lokal vorhanden und hat noch keinen Remote-Tracking-Branch;
-das Hauptprojekt ist als Quelle zum Abrufen und als späteres PR-Ziel eingerichtet.
-Ein Push wird weiterhin nur nach ausdrücklicher Freigabe ausgeführt.
+`origin` is configured locally as the default target for future pushes and is
+also explicitly set as the push remote for the Windows work branch.
+The new branch currently exists only locally and has no remote-tracking branch yet;
+the main project is configured as the source for fetching and as the future PR target.
+A push is still only performed after explicit authorization.
 
-### Weg zum späteren Windows-PR
+### Path to the future Windows PR
 
-Der Arbeitsbranch enthält unseren Fork-Kontext einschließlich persönlicher Pfade
-und Notizen; diese werden durch den Ordnernamen oder einen separaten Commit
-nicht automatisch aus einem Pull Request ausgeschlossen.
-Deshalb wird der fertige Beitrag später auf einem separaten PR-Branch direkt
-vom dann aktuellen `upstream/shaders-improvement` zusammengestellt.
-Dieser PR-Branch ist jetzt noch nicht angelegt.
+The work branch contains our fork context, including personal paths
+and notes; the directory name or a separate commit does not
+automatically exclude them from a pull request.
+The finished contribution will therefore later be assembled on a separate PR branch
+directly from the then-current `upstream/shaders-improvement`.
+This PR branch has not yet been created.
 
-Vorher den Windows-Build tatsächlich zum Laufen bringen, die Setup-Skripte für
-andere Rechner nutzbar machen und die Ergebnisse der Spieltests durch den Nutzer
-dokumentieren. Für den PR nur die geprüften, allgemein nutzbaren Änderungen und
-ihre Anleitung übernehmen; lokale Installationsprotokolle und Agentenvorgaben
-aus diesem Fork bleiben außerhalb des Beitrags.
-Die Auswahl und alle betroffenen Dateiunterschiede vor dem PR ausdrücklich prüfen
-und den zusammengestellten Stand erneut bauen, da er den privaten Fork-Kontext
-nicht voraussetzen darf. Erst nach ausdrücklicher Push-Freigabe den PR-Branch in
-den eigenen Fork veröffentlichen und gegen den Standardbranch des Originals anbieten.
+First get the Windows build actually working, make the setup scripts usable
+on other computers and document the results of the user's game tests.
+Include only the verified, generally reusable changes and their instructions
+in the PR; local installation logs and agent instructions
+from this fork stay outside the contribution.
+Explicitly review the selection and all affected file differences before the PR
+and rebuild the assembled state, since it must not depend on the private
+fork context. Only after explicit push authorization, publish the PR branch
+in your own fork and propose it against the original project's default branch.
 
-## 1. Originalprojekt einmalig als Remote eintragen
+## 1. Add the original project as a remote once
 
-Vorhandene Remotes anzeigen:
+Show existing remotes:
 
 ```powershell
 git remote -v
 ```
 
-Falls `upstream` noch fehlt:
+If `upstream` is still missing:
 
 ```powershell
 git remote add upstream https://github.com/tomluchowski/OpenDungeonsPlus.git
 ```
 
-## 2. Basis aktuell halten
+## 2. Keep the base up to date
 
-Vor einem Branchwechsel mit `git status` prüfen, dass keine ungesicherten Änderungen
-vorliegen; laufende Arbeit zuerst auf ihrem eigenen Branch sichern.
+Before switching branches, use `git status` to check that there are no unsaved changes;
+save ongoing work on its own branch first.
 
 ```powershell
 git fetch upstream
@@ -112,77 +112,76 @@ git switch shaders-improvement
 git merge --ff-only upstream/shaders-improvement
 ```
 
-Damit wird der lokale Basisbranch aktualisiert; auf diesem Branch keine Features
-entwickeln. Falls Git den Fast-Forward ablehnt, die abweichenden Commits prüfen,
-bevor weitere Schritte erfolgen.
+This updates the local base branch; do not develop features on this
+branch. If Git rejects the fast-forward, inspect the divergent commits
+before taking further steps.
 
-Um auch den Basisbranch auf GitHub im eigenen Fork zu aktualisieren:
+To also update the base branch on GitHub in your own fork:
 
 ```powershell
 git push origin shaders-improvement
 ```
 
-## 3. Für jede Änderung einen eigenen Branch erstellen
+## 3. Create a separate branch for each change
 
-Beispiel für eine Arbeit an der GUI-Skalierung:
+Example for work on GUI scaling:
 
 ```powershell
 git switch -c feature/gui-scaling upstream/shaders-improvement
 ```
 
-Den Namen an die konkrete Aufgabe anpassen. Der Branch startet direkt vom zuvor
-abgerufenen Originalstand, damit bestehende Änderungen nur im Fork nicht automatisch
-Teil des Beitrags werden.
+Adapt the name to the specific task. The branch starts directly from the
+previously fetched original state so that existing fork-only changes do not
+automatically become part of the contribution.
 
-## 4. Entwickeln, prüfen und committen
+## 4. Develop, verify and commit
 
-Die Änderung umsetzen und die betroffene Funktion prüfen; im Commit nur Dateien
-aufnehmen, die zu dieser Aufgabe gehören. Vor jedem Commit prüfen, ob Version,
-README, Änderungsprotokoll oder weitere Dokumentation angepasst werden müssen.
+Implement the change and verify the affected functionality; include only files
+belonging to this task in the commit. Before each commit, check whether the version,
+README, changelog or other documentation needs to be updated.
 
-Mit `git diff` die Änderungen prüfen, die gewünschten Dateien gezielt mit `git add`
-vormerken und anschließend mit `git diff --cached` den vollständigen Commit-Inhalt
-kontrollieren.
+Review the changes with `git diff`, stage the intended files explicitly with `git add`
+and then check the full commit content with `git diff --cached`.
 
 ```powershell
 git commit -m "Describe the change"
 ```
 
-Die Beispielnachricht durch eine konkrete Beschreibung der Änderung ersetzen.
+Replace the example message with a specific description of the change.
 
-## 5. Branch in den eigenen Fork pushen
+## 5. Push the branch to your own fork
 
-Für den Beispielbranch:
+For the example branch:
 
 ```powershell
 git push -u origin feature/gui-scaling
 ```
 
-Wenn Codex die Arbeit ausführt, benötigt jeder Push eine ausdrückliche Freigabe;
-die Befehle in dieser Anleitung sind selbst keine Freigabe.
+When Codex performs the work, every push requires explicit authorization;
+the commands in this guide do not themselves constitute authorization.
 
-## 6. Pull Request ans Originalprojekt erstellen
+## 6. Create a pull request to the original project
 
-Auf GitHub einen Pull Request mit diesen Einstellungen öffnen:
+On GitHub, open a pull request with these settings:
 
-- Zielrepository (base repository): `tomluchowski/OpenDungeonsPlus`.
-- Zielbranch (base): `shaders-improvement`.
-- Quellrepository (head repository): `Rokk001/OpenDungeonsPlus`.
-- Quellbranch (compare): der eigene Arbeitsbranch, im Beispiel `feature/gui-scaling`.
+- Target repository (base repository): `tomluchowski/OpenDungeonsPlus`.
+- Target branch (base): `shaders-improvement`.
+- Source repository (head repository): `Rokk001/OpenDungeonsPlus`.
+- Source branch (compare): your own work branch, `feature/gui-scaling` in the example.
 
-Problem, Änderung und durchgeführte Prüfungen beschreiben; vor dem Erstellen unter
-"Files changed" kontrollieren, dass ausschließlich die vorgesehenen Änderungen
-enthalten sind.
+Describe the problem, change and checks performed; before creating the PR,
+check under "Files changed" that only the intended changes
+are included.
 
-## 7. Review-Kommentare bearbeiten
+## 7. Address review comments
 
-Korrekturen auf demselben Arbeitsbranch umsetzen, prüfen und committen; anschließend
-denselben Branch erneut in den eigenen Fork pushen, wodurch sich der bestehende
-Pull Request automatisch aktualisiert.
+Implement, verify and commit corrections on the same work branch; then
+push that branch to your own fork again, which automatically updates the existing
+pull request.
 
-## Dokumentation im Fork und im Pull Request
+## Documentation in the fork and in the pull request
 
-Eigene Entwicklungsnotizen liegen unter `docs/development/`. Für einen Beitrag ans
-Originalprojekt nur die dafür relevante Dokumentation ausdrücklich auf den
-Arbeitsbranch übernehmen; der Ordnername allein schließt Dateien nicht aus einem
-Pull Request aus.
+Personal development notes are stored under `docs/development/`. For a contribution to
+the original project, explicitly include only the relevant documentation on the
+work branch; the directory name alone does not exclude files from a
+pull request.

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -1,0 +1,128 @@
+# Am Originalprojekt mitarbeiten
+
+## Eigenständig im Fork arbeiten
+
+Im eigenen Fork kann das Projekt unabhängig weiterentwickelt werden; eine Aufnahme
+ins Team des Originalprojekts oder dessen Schreibrechte sind dafür nicht nötig.
+Die tatsächlichen persönlichen Schreibrechte am Originalrepository wurden nicht
+geprüft.
+
+Das Originalprojekt wird als Upstream benötigt, wenn dessen neue Änderungen
+übernommen oder eigene Änderungen per Pull Request zurückgegeben werden sollen;
+beides ist für die reine Weiterentwicklung im eigenen Fork optional.
+
+Auch im Fork einen eigenen Arbeitsbranch pro Aufgabe verwenden. Für reine
+Fork-Arbeiten diesen vom aktuellen eigenen Entwicklungsstand erstellen, damit
+bereits vorhandene eigene Änderungen erhalten bleiben. Die nachfolgenden Schritte
+beschreiben dagegen einen Beitrag ans Originalprojekt und starten dessen
+Arbeitsbranch direkt vom Upstream-Stand.
+
+## Repositories und Zielbranch
+
+- Eigener Fork: [Rokk001/OpenDungeonsPlus](https://github.com/Rokk001/OpenDungeonsPlus),
+  lokal als `origin` eingerichtet.
+- Originalprojekt für unsere Beiträge:
+  [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
+  lokal als `upstream` einzurichten.
+- Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
+  Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+
+## 1. Originalprojekt einmalig als Remote eintragen
+
+Vorhandene Remotes anzeigen:
+
+```powershell
+git remote -v
+```
+
+Falls `upstream` noch fehlt:
+
+```powershell
+git remote add upstream https://github.com/tomluchowski/OpenDungeonsPlus.git
+```
+
+## 2. Basis aktuell halten
+
+Vor einem Branchwechsel mit `git status` prüfen, dass keine ungesicherten Änderungen
+vorliegen; laufende Arbeit zuerst auf ihrem eigenen Branch sichern.
+
+```powershell
+git fetch upstream
+git switch shaders-improvement
+git merge --ff-only upstream/shaders-improvement
+```
+
+Damit wird der lokale Basisbranch aktualisiert; auf diesem Branch keine Features
+entwickeln. Falls Git den Fast-Forward ablehnt, die abweichenden Commits prüfen,
+bevor weitere Schritte erfolgen.
+
+Um auch den Basisbranch auf GitHub im eigenen Fork zu aktualisieren:
+
+```powershell
+git push origin shaders-improvement
+```
+
+## 3. Für jede Änderung einen eigenen Branch erstellen
+
+Beispiel für eine Arbeit an der GUI-Skalierung:
+
+```powershell
+git switch -c feature/gui-scaling upstream/shaders-improvement
+```
+
+Den Namen an die konkrete Aufgabe anpassen. Der Branch startet direkt vom zuvor
+abgerufenen Originalstand, damit bestehende Änderungen nur im Fork nicht automatisch
+Teil des Beitrags werden.
+
+## 4. Entwickeln, prüfen und committen
+
+Die Änderung umsetzen und die betroffene Funktion prüfen; im Commit nur Dateien
+aufnehmen, die zu dieser Aufgabe gehören. Vor jedem Commit prüfen, ob Version,
+README, Änderungsprotokoll oder weitere Dokumentation angepasst werden müssen.
+
+Mit `git diff` die Änderungen prüfen, die gewünschten Dateien gezielt mit `git add`
+vormerken und anschließend mit `git diff --cached` den vollständigen Commit-Inhalt
+kontrollieren.
+
+```powershell
+git commit -m "Describe the change"
+```
+
+Die Beispielnachricht durch eine konkrete Beschreibung der Änderung ersetzen.
+
+## 5. Branch in den eigenen Fork pushen
+
+Für den Beispielbranch:
+
+```powershell
+git push -u origin feature/gui-scaling
+```
+
+Wenn Codex die Arbeit ausführt, benötigt jeder Push eine ausdrückliche Freigabe;
+die Befehle in dieser Anleitung sind selbst keine Freigabe.
+
+## 6. Pull Request ans Originalprojekt erstellen
+
+Auf GitHub einen Pull Request mit diesen Einstellungen öffnen:
+
+- Zielrepository (base repository): `tomluchowski/OpenDungeonsPlus`.
+- Zielbranch (base): `shaders-improvement`.
+- Quellrepository (head repository): `Rokk001/OpenDungeonsPlus`.
+- Quellbranch (compare): der eigene Arbeitsbranch, im Beispiel `feature/gui-scaling`.
+
+Problem, Änderung und durchgeführte Prüfungen beschreiben; vor dem Erstellen unter
+"Files changed" kontrollieren, dass ausschließlich die vorgesehenen Änderungen
+enthalten sind.
+
+## 7. Review-Kommentare bearbeiten
+
+Korrekturen auf demselben Arbeitsbranch umsetzen, prüfen und committen; anschließend
+denselben Branch erneut in den eigenen Fork pushen, wodurch sich der bestehende
+Pull Request automatisch aktualisiert.
+
+## Dokumentation im Fork und im Pull Request
+
+Eigene Entwicklungsnotizen liegen unter `docs/development/`. Für einen Beitrag ans
+Originalprojekt nur die dafür relevante Dokumentation ausdrücklich auf den
+Arbeitsbranch übernehmen; der Ordnername allein schließt Dateien nicht aus einem
+Pull Request aus.

--- a/docs/development/CONTRIBUTING-WORKFLOW.md
+++ b/docs/development/CONTRIBUTING-WORKFLOW.md
@@ -23,9 +23,69 @@ Arbeitsbranch direkt vom Upstream-Stand.
   lokal als `origin` eingerichtet.
 - Originalprojekt für unsere Beiträge:
   [tomluchowski/OpenDungeonsPlus](https://github.com/tomluchowski/OpenDungeonsPlus),
-  lokal als `upstream` einzurichten.
+  lokal als `upstream` eingerichtet.
 - Zielbranch im Originalprojekt: `shaders-improvement` (Stand: 5. September 2026).
   Vor einem Pull Request den gewünschten Zielbranch auf GitHub prüfen.
+
+## Aktuell eingerichtet: Windows-Unterstützung
+
+Stand: 5. September 2026. Unser Arbeitsbranch im Fork ist
+`feature/windows-support`; hier setzen wir die Windows-Arbeit fort.
+Auch Dokumentation und die Vorbereitung einer Build-Umgebung gehören auf einen
+Arbeitsbranch; ein Branch ist nicht auf neue Spielfunktionen beschränkt.
+
+Der Branch wurde vom vorhandenen Fork-Stand `a8ffa583` erstellt und übernimmt
+die bis dahin uncommittierten Setup-Skripte und Entwicklungsnotizen.
+Der Standardbranch `shaders-improvement` bleibt auf diesem Stand;
+seinen bereits vorhandenen Dokumentationscommit schreiben wir nicht um.
+Beim Abruf zeigte der bestätigte Standardbranch des Originals,
+`upstream/shaders-improvement`, auf den Commit `be44649f`.
+Der Fork-Standardbranch liegt damit zum Einrichtungszeitpunkt einen
+Dokumentationscommit vor dem Original.
+
+Die Einrichtung wird in zwei Commits festgehalten: zuerst die bisherigen lokalen
+Windows-Setup-Skripte, danach die Dokumentation einschließlich dieser Arbeitsweise.
+Es gibt dabei noch keine Änderung am Spielcode oder an der Spielversion;
+README und Entwicklungsdokumentation beschreiben den tatsächlichen Stand,
+ein zusätzlicher Spiele-Changelog-Eintrag ist für diese Einrichtung nicht nötig.
+
+### Tägliche Arbeit
+
+Beim Wiederaufnehmen `git status` prüfen und auf `feature/windows-support`
+weiterarbeiten; Umgebung und Buildbefehle stehen in [BUILDING.md](BUILDING.md).
+Für diese laufende Windows-Aufgabe nicht bei jeder Sitzung einen neuen Branch
+erstellen. Fachlich abgeschlossene Änderungen separat committen und gemeinsam
+mit ihrer zugehörigen allgemeinen Build-Dokumentation prüfen; persönliche
+Rechnernotizen in einem eigenen Dokumentationscommit halten.
+
+Der Standardbranch wird für diese Arbeit nicht verändert. Neue Originaländerungen
+zunächst mit `git fetch upstream` abrufen und vor einer Übernahme vergleichen;
+ein Abruf allein verändert weder Arbeitsdateien noch lokale Arbeitsbranches.
+
+`origin` ist lokal als Standardziel für spätere Pushes gesetzt, für den
+Windows-Arbeitsbranch ebenfalls ausdrücklich als Push-Remote.
+Der neue Branch ist bisher nur lokal vorhanden und hat noch keinen Remote-Tracking-Branch;
+das Hauptprojekt ist als Quelle zum Abrufen und als späteres PR-Ziel eingerichtet.
+Ein Push wird weiterhin nur nach ausdrücklicher Freigabe ausgeführt.
+
+### Weg zum späteren Windows-PR
+
+Der Arbeitsbranch enthält unseren Fork-Kontext einschließlich persönlicher Pfade
+und Notizen; diese werden durch den Ordnernamen oder einen separaten Commit
+nicht automatisch aus einem Pull Request ausgeschlossen.
+Deshalb wird der fertige Beitrag später auf einem separaten PR-Branch direkt
+vom dann aktuellen `upstream/shaders-improvement` zusammengestellt.
+Dieser PR-Branch ist jetzt noch nicht angelegt.
+
+Vorher den Windows-Build tatsächlich zum Laufen bringen, die Setup-Skripte für
+andere Rechner nutzbar machen und die Ergebnisse der Spieltests durch den Nutzer
+dokumentieren. Für den PR nur die geprüften, allgemein nutzbaren Änderungen und
+ihre Anleitung übernehmen; lokale Installationsprotokolle und Agentenvorgaben
+aus diesem Fork bleiben außerhalb des Beitrags.
+Die Auswahl und alle betroffenen Dateiunterschiede vor dem PR ausdrücklich prüfen
+und den zusammengestellten Stand erneut bauen, da er den privaten Fork-Kontext
+nicht voraussetzen darf. Erst nach ausdrücklicher Push-Freigabe den PR-Branch in
+den eigenen Fork veröffentlichen und gegen den Standardbranch des Originals anbieten.
 
 ## 1. Originalprojekt einmalig als Remote eintragen
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -20,6 +20,8 @@ is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
   build Release/Debug and find logs.
 - [Windows build errors and fixes](WINDOWS-BUILD-FIXES.md): confirmed
   compiler errors, their causes, targeted fixes and build evidence.
+- [Windows startup errors and fixes](WINDOWS-STARTUP-FIXES.md): actual startup
+  failures, runtime preparation, resource-path correction and outstanding verification.
 - [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
   checksums, installation scripts, order and resolved installation problems.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -3,20 +3,28 @@
 Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
 mit einer Markdown-Datei pro Thema.
 
+Für eine neue Sitzung zuerst [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md)
+und [Konfigurieren und kompilieren](BUILDING.md) lesen; der Einstieg für Agenten
+ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
+
 ## Vorhandene Anleitungen
 
 - [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
-  Arbeitsbranches, Pull Requests und eigenständige Weiterentwicklung im Fork.
+  eingerichteter Windows-Arbeitsbranch, getrennte Commits und der Weg zum späteren
+  Pull Request ins Originalprojekt.
 - [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
   Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
-- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): besprochene Werkzeuge,
-  im Build-Code bestätigte Abhängigkeiten und noch offene Prüfungen.
+- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): installierte Versionen,
+  genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
+- [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
+  Release/Debug bauen und Protokolle finden.
+- [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
+  Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
 
 ## Weitere Notizen ablegen
 
 Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
 
-- `BUILDING.md`: überprüfte Build-Schritte und Voraussetzungen.
 - `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
 - `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
 - `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,28 @@
+# Entwicklungsdokumentation
+
+Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
+mit einer Markdown-Datei pro Thema.
+
+## Vorhandene Anleitungen
+
+- [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
+  Arbeitsbranches, Pull Requests und eigenständige Weiterentwicklung im Fork.
+- [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
+  Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
+- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): besprochene Werkzeuge,
+  im Build-Code bestätigte Abhängigkeiten und noch offene Prüfungen.
+
+## Weitere Notizen ablegen
+
+Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
+
+- `BUILDING.md`: überprüfte Build-Schritte und Voraussetzungen.
+- `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
+- `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
+- `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.
+
+Bei technischen Erkenntnissen den betroffenen Code, die Schritte zur Prüfung und
+offene Fragen festhalten; noch nicht überprüfte Aussagen entsprechend kennzeichnen.
+
+Die Sammlung ist zunächst für den eigenen Fork gedacht; welche Dokumentation ins
+Originalprojekt übernommen wird, entscheiden wir für den jeweiligen Pull Request.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,38 +1,38 @@
-# Entwicklungsdokumentation
+# Development documentation
 
-Hier sammeln wir Anleitungen und Erkenntnisse zur Mitarbeit an OpenDungeonsPlus,
-mit einer Markdown-Datei pro Thema.
+Here we collect guides and findings on contributing to OpenDungeonsPlus,
+with one Markdown file per topic.
 
-Für eine neue Sitzung zuerst [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md)
-und [Konfigurieren und kompilieren](BUILDING.md) lesen; der Einstieg für Agenten
-ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
+For a new session, first read [Windows development environment](WINDOWS-DEV-SETUP.md)
+and [Configuring and compiling](BUILDING.md); the entry point for agents
+is also recorded in [AGENTS.md](../../AGENTS.md) at the project root.
 
-## Vorhandene Anleitungen
+## Available guides
 
-- [Am Originalprojekt mitarbeiten](CONTRIBUTING-WORKFLOW.md): Fork, Synchronisierung,
-  eingerichteter Windows-Arbeitsbranch, getrennte Commits und der Weg zum späteren
-  Pull Request ins Originalprojekt.
-- [Aufgaben und Arbeitsteilung](TASKS.md): bisherige Einschätzung zur autonomen
-  Umsetzung, Beteiligung beim Testen und vorgeschlagener Einstieg.
-- [Windows-Entwicklungsumgebung](WINDOWS-DEV-SETUP.md): installierte Versionen,
-  genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
-- [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
-  Release/Debug bauen und Protokolle finden.
-- [Windows-Buildfehler und Korrekturen](WINDOWS-BUILD-FIXES.md): nachgewiesene
-  Compilerfehler, ihre Ursachen, gezielte Korrekturen und Buildnachweise.
-- [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
-  Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
+- [Contributing to the original project](CONTRIBUTING-WORKFLOW.md): fork, synchronization,
+  the configured Windows work branch, separate commits and the path to a later
+  pull request to the original project.
+- [Tasks and division of work](TASKS.md): assessment so far of autonomous
+  implementation, participation in testing and the suggested starting point.
+- [Windows development environment](WINDOWS-DEV-SETUP.md): installed versions,
+  exact locations, connections to the project and verified status.
+- [Configuring and compiling](BUILDING.md): load the environment, run CMake,
+  build Release/Debug and find logs.
+- [Windows build errors and fixes](WINDOWS-BUILD-FIXES.md): confirmed
+  compiler errors, their causes, targeted fixes and build evidence.
+- [Restoring prerequisites](WINDOWS-PREREQUISITES.md): sources,
+  checksums, installation scripts, order and resolved installation problems.
 
-## Weitere Notizen ablegen
+## Adding further notes
 
-Neue Dateien bei Bedarf hier ergänzen und oben verlinken, zum Beispiel:
+Add new files here as needed and link them above, for example:
 
-- `DEBUGGING.md`: nachvollziehbare Fehleranalysen und Lösungen.
-- `ARCHITECTURE-NOTES.md`: Erkenntnisse zum bestehenden Code und dessen Zusammenhängen.
-- `GUI-SCALING.md`: Erkenntnisse zur GUI-Skalierung, sobald daran gearbeitet wird.
+- `DEBUGGING.md`: traceable error analyses and solutions.
+- `ARCHITECTURE-NOTES.md`: findings about the existing code and its relationships.
+- `GUI-SCALING.md`: findings on GUI scaling once work on it begins.
 
-Bei technischen Erkenntnissen den betroffenen Code, die Schritte zur Prüfung und
-offene Fragen festhalten; noch nicht überprüfte Aussagen entsprechend kennzeichnen.
+For technical findings, record the affected code, verification steps and
+open questions; label statements that have not yet been verified accordingly.
 
-Die Sammlung ist zunächst für den eigenen Fork gedacht; welche Dokumentation ins
-Originalprojekt übernommen wird, entscheiden wir für den jeweiligen Pull Request.
+The collection is initially intended for our own fork; we decide which documentation
+to include in the original project for each pull request.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -18,6 +18,8 @@ ist zusätzlich in [AGENTS.md](../../AGENTS.md) im Projektstamm verankert.
   genaue Speicherorte, Verbindungen zum Projekt und überprüfter Stand.
 - [Konfigurieren und kompilieren](BUILDING.md): Umgebung laden, CMake ausführen,
   Release/Debug bauen und Protokolle finden.
+- [Windows-Buildfehler und Korrekturen](WINDOWS-BUILD-FIXES.md): nachgewiesene
+  Compilerfehler, ihre Ursachen, gezielte Korrekturen und Buildnachweise.
 - [Voraussetzungen wiederherstellen](WINDOWS-PREREQUISITES.md): Quellen,
   Prüfsummen, Installationsskripte, Reihenfolge und behobene Installationsprobleme.
 

--- a/docs/development/TASKS.md
+++ b/docs/development/TASKS.md
@@ -1,41 +1,41 @@
-# Aufgaben und Arbeitsteilung
+# Tasks and division of work
 
-Stand: 5. September 2026, festgehalten aus dem bisherigen Gespräch.
+As of September 5, 2026, recorded from the conversation so far.
 
-## Ziel der Zusammenarbeit
+## Goal of the collaboration
 
-Codex soll die Umsetzung möglichst selbstständig übernehmen; der Nutzer möchte
-hauptsächlich das Testen und die visuelle Beurteilung übernehmen.
+Codex should handle implementation as independently as possible; the user wants
+to focus mainly on testing and visual assessment.
 
-Die folgenden Bewertungen sind die bisherige Einschätzung aus dem Gespräch, keine
-Garantie einer vollständig autonomen Umsetzung. Eine technische Detailprüfung der
-einzelnen Aufgaben und ihrer konkreten Anforderungen steht noch aus.
+The following assessments reflect the conversation so far, not a
+guarantee of fully autonomous implementation. A detailed technical review of
+the individual tasks and their specific requirements is still pending.
 
-## Besprochene Aufgaben
+## Tasks discussed
 
-| Nr. | Aufgabe | Bisherige Einschätzung | Beteiligung oder offene Voraussetzung |
+| No. | Task | Assessment so far | Participation or outstanding prerequisite |
 | --- | --- | --- | --- |
-| 1 | Windows-Build zuverlässig machen | Sehr gut machbar, aber vollständige Autonomie nicht garantiert. | Lokale Windows- oder Abhängigkeitsprobleme können Eingriffe des Nutzers erfordern. |
-| 2 | Ogre-14-Port stabilisieren | Machbar eingeschätzt, aber großer Architektur- und Kompatibilitätsbereich ohne belastbare Vollständigkeitsgarantie. | Umfang und Hindernisse müssen zunächst am Code geprüft werden. |
-| 3 | GUI skalierbar machen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer testet insbesondere die Darstellung; eine lokal baubare und startende Spielversion wird für die Ergebnisprüfung benötigt. |
-| 4 | Maus/Cursor sauber lösen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer prüft das Verhalten im Spiel; der konkrete Änderungsumfang ist noch festzulegen. |
-| 5 | UI verständlicher machen | Größtenteils durch Codex umsetzbar eingeschätzt. | Offene Entscheidungen zu Bedienung und Texten müssen geklärt oder ausdrücklich delegiert werden. |
-| 6 | Tutorial / Onboarding | Durch Codex umsetzbar eingeschätzt, sofern Inhalt und Ablauf selbst definiert werden dürfen. | Die dafür notwendige Entscheidungsfreiheit wurde bisher nur als Voraussetzung genannt und noch nicht erteilt. |
+| 1 | Make the Windows build reliable | Very feasible, but full autonomy is not guaranteed. | Local Windows or dependency problems may require user intervention. |
+| 2 | Stabilize the Ogre 14 port | Assessed as feasible, but a large architecture and compatibility area without a reliable guarantee of completeness. | The scope and obstacles must first be examined in the code. |
+| 3 | Make the GUI scalable | Assessed as likely to be fully implementable by Codex. | The user tests the visual presentation in particular; a game version that builds and starts locally is needed to verify the result. |
+| 4 | Resolve mouse/cursor handling cleanly | Assessed as likely to be fully implementable by Codex. | The user checks the behavior in the game; the specific scope of changes still needs to be defined. |
+| 5 | Make the UI easier to understand | Assessed as largely implementable by Codex. | Open decisions about interaction and wording must be clarified or explicitly delegated. |
+| 6 | Tutorial / onboarding | Assessed as implementable by Codex, provided it may define the content and flow itself. | The necessary decision-making authority has so far only been mentioned as a prerequisite and has not yet been granted. |
 
-## Vorgeschlagener Einstieg
+## Suggested starting point
 
-Im Gespräch wurden Aufgabe 3 und 4 als Einstieg für möglichst wenig Eigenaufwand
-vorgeschlagen; das ist noch kein Auftrag zur Umsetzung dieser Aufgaben.
+In the conversation, tasks 3 and 4 were suggested as a starting point to minimize
+the user's own effort; this is not yet an instruction to implement these tasks.
 
-Für die GUI-Skalierung zuerst eine Umgebung herstellen, in der das Spiel lokal
-kompiliert und startet; die besprochenen Voraussetzungen stehen in der
-[Windows-Dokumentation](WINDOWS-DEV-SETUP.md).
+For GUI scaling, first establish an environment in which the game
+compiles and starts locally; the prerequisites discussed are in the
+[Windows documentation](WINDOWS-DEV-SETUP.md).
 
-## Offene Entscheidungen und Prüfung
+## Open decisions and verification
 
-Fehlende funktionale, gestalterische oder inhaltliche Entscheidungen werden nicht
-stillschweigend getroffen; sie müssen aus dem Projekt eindeutig hervorgehen, vom
-Nutzer beantwortet oder ausdrücklich an Codex delegiert werden.
+Missing functional, design or content decisions are not made
+silently; they must be unambiguously determined from the project, answered by the
+user or explicitly delegated to Codex.
 
-Manuelle Spieltests, QA und die visuelle Abnahme übernimmt der Nutzer; Ergebnisse
-und dabei gefundene Fehler werden anschließend gemeinsam ausgewertet.
+The user handles manual game tests, QA and visual acceptance; results
+and any errors found are then evaluated together.

--- a/docs/development/TASKS.md
+++ b/docs/development/TASKS.md
@@ -1,0 +1,41 @@
+# Aufgaben und Arbeitsteilung
+
+Stand: 5. September 2026, festgehalten aus dem bisherigen Gespräch.
+
+## Ziel der Zusammenarbeit
+
+Codex soll die Umsetzung möglichst selbstständig übernehmen; der Nutzer möchte
+hauptsächlich das Testen und die visuelle Beurteilung übernehmen.
+
+Die folgenden Bewertungen sind die bisherige Einschätzung aus dem Gespräch, keine
+Garantie einer vollständig autonomen Umsetzung. Eine technische Detailprüfung der
+einzelnen Aufgaben und ihrer konkreten Anforderungen steht noch aus.
+
+## Besprochene Aufgaben
+
+| Nr. | Aufgabe | Bisherige Einschätzung | Beteiligung oder offene Voraussetzung |
+| --- | --- | --- | --- |
+| 1 | Windows-Build zuverlässig machen | Sehr gut machbar, aber vollständige Autonomie nicht garantiert. | Lokale Windows- oder Abhängigkeitsprobleme können Eingriffe des Nutzers erfordern. |
+| 2 | Ogre-14-Port stabilisieren | Machbar eingeschätzt, aber großer Architektur- und Kompatibilitätsbereich ohne belastbare Vollständigkeitsgarantie. | Umfang und Hindernisse müssen zunächst am Code geprüft werden. |
+| 3 | GUI skalierbar machen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer testet insbesondere die Darstellung; eine lokal baubare und startende Spielversion wird für die Ergebnisprüfung benötigt. |
+| 4 | Maus/Cursor sauber lösen | Als voraussichtlich vollständig durch Codex umsetzbar eingeschätzt. | Nutzer prüft das Verhalten im Spiel; der konkrete Änderungsumfang ist noch festzulegen. |
+| 5 | UI verständlicher machen | Größtenteils durch Codex umsetzbar eingeschätzt. | Offene Entscheidungen zu Bedienung und Texten müssen geklärt oder ausdrücklich delegiert werden. |
+| 6 | Tutorial / Onboarding | Durch Codex umsetzbar eingeschätzt, sofern Inhalt und Ablauf selbst definiert werden dürfen. | Die dafür notwendige Entscheidungsfreiheit wurde bisher nur als Voraussetzung genannt und noch nicht erteilt. |
+
+## Vorgeschlagener Einstieg
+
+Im Gespräch wurden Aufgabe 3 und 4 als Einstieg für möglichst wenig Eigenaufwand
+vorgeschlagen; das ist noch kein Auftrag zur Umsetzung dieser Aufgaben.
+
+Für die GUI-Skalierung zuerst eine Umgebung herstellen, in der das Spiel lokal
+kompiliert und startet; die besprochenen Voraussetzungen stehen in der
+[Windows-Dokumentation](WINDOWS-DEV-SETUP.md).
+
+## Offene Entscheidungen und Prüfung
+
+Fehlende funktionale, gestalterische oder inhaltliche Entscheidungen werden nicht
+stillschweigend getroffen; sie müssen aus dem Projekt eindeutig hervorgehen, vom
+Nutzer beantwortet oder ausdrücklich an Codex delegiert werden.
+
+Manuelle Spieltests, QA und die visuelle Abnahme übernimmt der Nutzer; Ergebnisse
+und dabei gefundene Fehler werden anschließend gemeinsam ausgewertet.

--- a/docs/development/WINDOWS-BUILD-FIXES.md
+++ b/docs/development/WINDOWS-BUILD-FIXES.md
@@ -1,125 +1,125 @@
-# Windows-Build: Fehler und Korrekturen
+# Windows build: errors and fixes
 
-Stand: 5. September 2026. Die Fehler wurden beim tatsächlichen Build mit
-Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 und x64
-untersucht. Die verwendeten Bibliotheken und die lokale Umgebung sind in
-[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md) dokumentiert.
+As of September 5, 2026. The errors were investigated during the actual build with
+Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 and x64.
+The libraries used and the local environment are documented in
+[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md).
 
-## Fenster-Icon: ungeeignete 32-Bit-Schnittstelle
+## Window icon: unsuitable 32-bit interface
 
-Der erste Release-Build scheiterte in [ODApplication.cpp](../../source/ODApplication.cpp)
-beim Setzen des Fenster-Icons:
+The first Release build failed in [ODApplication.cpp](../../source/ODApplication.cpp)
+when setting the window icon:
 
 ```text
-error C2065: GCL_HICON: nichtdeklarierter Bezeichner
-warning C4311 / C4302: Zeigerverkürzung von HICON zu LONG
+error C2065: GCL_HICON: undeclared identifier
+warning C4311 / C4302: pointer truncation from HICON to LONG
 ```
 
-Der betroffene Windows-Code verwendete `SetClassLong`, `GCL_HICON` und eine
-Umwandlung des Icon-Handles in `LONG`. Der installierte Windows-SDK-Header
-`um/WinUser.h` entfernt `GCL_HICON` ausdrücklich bei gesetztem `_WIN64`;
-außerdem ist `LONG` nicht breit genug für einen 64-Bit-Zeiger.
+The affected Windows code used `SetClassLong`, `GCL_HICON` and a
+cast of the icon handle to `LONG`. The installed Windows SDK header
+`um/WinUser.h` explicitly removes `GCL_HICON` when `_WIN64` is defined;
+in addition, `LONG` is not wide enough for a 64-bit pointer.
 
-Die Korrektur verwendet an derselben Stelle `SetClassLongPtr`, `GCLP_HICON`
-und `LONG_PTR`. Das bestehende Icon und der Zeitpunkt seiner Zuweisung bleiben
-erhalten; die Änderung liegt weiterhin ausschließlich im Windows-Codepfad.
+The fix uses `SetClassLongPtr`, `GCLP_HICON`
+and `LONG_PTR` at the same location. The existing icon and the timing of its assignment
+are preserved; the change remains exclusively in the Windows code path.
 
-Nachweis des Ausgangsfehlers: `build/windows/game-Release-initial.log`.
-Die ursprüngliche Buildausgabe bleibt zur Nachvollziehbarkeit lokal erhalten.
+Evidence of the original error: `build/windows/game-Release-initial.log`.
+The original build output is retained locally for traceability.
 
-## CEGUI-Makro verändert Boost-Header
+## CEGUI macro changes Boost headers
 
-Derselbe Build meldete `C2039: _snprintf ist kein Member von std`, unter anderem
-beim Übersetzen von `ODClient.cpp`, `SettingsWindow.cpp` und `ModeManager.cpp`.
-Die Fehlermeldung zeigt auf `boost/assert/source_location.hpp`;
-dort verwendet Boost auf aktuellen MSVC-Versionen korrekt `std::snprintf`.
+The same build reported `C2039: _snprintf is not a member of std`, including
+when compiling `ODClient.cpp`, `SettingsWindow.cpp` and `ModeManager.cpp`.
+The error message points to `boost/assert/source_location.hpp`;
+there, Boost correctly uses `std::snprintf` on current MSVC versions.
 
-Die Ursache liegt im zuvor eingebundenen `CEGUI/PropertyHelper.h` des verwendeten
-CEGUI-Tags: Ein für alle MSVC-Versionen gesetztes Makro ersetzt `snprintf` durch
-`_snprintf` und verändert damit auch den späteren Boost-Code zu `std::_snprintf`.
-Das Projekt selbst definiert dieses Makro nicht.
+The cause is in `CEGUI/PropertyHelper.h` from the CEGUI tag in use, which was included
+earlier: a macro defined for all MSVC versions replaces `snprintf` with
+`_snprintf`, also changing the subsequent Boost code to `std::_snprintf`.
+The project itself does not define this macro.
 
-Der [CEGUI-Patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) begrenzt
-diesen Ersatz auf `_MSC_VER < 1900`; für neuere Compiler bleibt die vorhandene
-Standardfunktion verwendbar. Das
-[Installationsskript](../../scripts/win32/install-cegui-prereq.ps1) wendet den
-Patch vor dem CEGUI-Build an und erkennt einen bereits angewendeten Patch.
-CEGUI wurde anschließend in Release und Debug erfolgreich neu gebaut und
-installiert; der installierte Header ist per SHA-256 mit der gepatchten Quelle
-abgeglichen. Die Erkennung des bereits angewendeten Patches wurde mit
-`git apply --reverse --check` erfolgreich geprüft.
-Protokolle: `build/windows/cegui-rebuild-driver.log` im Projekt und
-`cegui-Release.log` / `cegui-Debug.log` im externen Bibliotheks-Logordner.
+The [CEGUI patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) limits
+this replacement to `_MSC_VER < 1900`; for newer compilers, the existing
+standard function remains usable. The
+[installation script](../../scripts/win32/install-cegui-prereq.ps1) applies the
+patch before the CEGUI build and recognizes a patch that has already been applied.
+CEGUI was subsequently rebuilt and installed successfully in Release and Debug;
+the installed header has been compared with the patched source using SHA-256.
+Detection of the already-applied patch was successfully verified with
+`git apply --reverse --check`.
+Logs: `build/windows/cegui-rebuild-driver.log` in the project and
+`cegui-Release.log` / `cegui-Debug.log` in the external library log directory.
 
-## Boost-Linkerpfad zeigt in den Headerordner
+## Boost linker path points to the header directory
 
-Nach den beiden Compilerkorrekturen erreichte Release den Linker und scheiterte
-mit `LNK1104` für `libboost_filesystem-vc143-mt-x64-1_82.lib`.
-Die passende Datei war installiert und im CMake-Cache bereits korrekt gefunden.
-Das generierte Visual-Studio-Projekt enthielt jedoch als zusätzlichen Suchpfad
-`include/boost-1_82/stage/lib`, wo diese Bibliothek nicht liegt.
+After the two compiler fixes, Release reached the linker and failed
+with `LNK1104` for `libboost_filesystem-vc143-mt-x64-1_82.lib`.
+The matching file was installed and had already been found correctly in the CMake cache.
+However, the generated Visual Studio project contained the additional search path
+`include/boost-1_82/stage/lib`, where this library is not located.
 
-Ursache war in [CMakeLists.txt](../../CMakeLists.txt) die Ableitung des
-MSVC-Linkerpfads aus `Boost_INCLUDE_DIRS`. Stattdessen wird jetzt das von
-der Paketsuche ermittelte `Boost_LIBRARY_DIRS` verwendet; so benötigt die
-Korrektur keinen rechnerabhängigen Pfad und erhält die bisherige automatische
-Boost-Verknüpfung unter MSVC.
-Nachweis des Linkerfehlers: `build/windows/game-Release-pass1.log`.
+The cause in [CMakeLists.txt](../../CMakeLists.txt) was deriving the
+MSVC linker path from `Boost_INCLUDE_DIRS`. It now uses
+`Boost_LIBRARY_DIRS`, determined by the package search, instead; this means the
+fix does not require a computer-specific path and preserves the existing automatic
+Boost linking under MSVC.
+Evidence of the linker error: `build/windows/game-Release-pass1.log`.
 
-## Python-Debug-Bibliothek und Headerauswahl widersprechen sich
+## Python debug library and header selection conflict
 
-Der vollständige Debug-Compilerlauf war erfolgreich, der Linker brach jedoch
-mit `LNK1104` für `python310.lib` ab. CMake hatte bereits die vorhandene
-`python310_d.lib` als explizite Debug-Abhängigkeit eingetragen.
+The full Debug compiler run succeeded, but the linker aborted
+with `LNK1104` for `python310.lib`. CMake had already added the existing
+`python310_d.lib` as an explicit Debug dependency.
 
-`pybind11/detail/common.h` setzt beim Einbinden von Python unter MSVC das Makro
-`_DEBUG` vorübergehend außer Kraft, solange `Py_DEBUG` nicht definiert ist.
-Dadurch erzeugt `Python/include/pyconfig.h` eine zusätzliche automatische
-Linkanforderung für `python310.lib`, obwohl CMake die Debug-Bibliothek auswählt.
+When including Python under MSVC, `pybind11/detail/common.h` temporarily
+undefines the `_DEBUG` macro unless `Py_DEBUG` is defined.
+As a result, `Python/include/pyconfig.h` generates an additional automatic
+link request for `python310.lib`, even though CMake selects the debug library.
 
-Wenn eine Python-Debug-Bibliothek konfiguriert ist und pybind11 den Debug-Modus
-nicht bereits aktiviert hat, definiert das Spieltarget unter MSVC deshalb
-`Py_DEBUG` ausschließlich für die Debug-Konfiguration.
-Der leere Makrowert entspricht der Definition im Windows-Python-Header;
-Release und Konfigurationen ohne gefundene Debug-Bibliothek bleiben unverändert.
-Damit werden Header und Bibliotheksvariante konsistent ausgewählt, statt die
-gleichzeitige Verwendung beider Varianten durch einen zusätzlichen Suchpfad zu ermöglichen.
-Nachweis: `build/windows/game-Debug-pass2.log`.
+If a Python debug library is configured and pybind11 has not already
+activated debug mode, the game target under MSVC therefore defines
+`Py_DEBUG` exclusively for the Debug configuration.
+The empty macro value matches the definition in the Windows Python header;
+Release and configurations without a detected debug library remain unchanged.
+This selects headers and the library variant consistently instead of allowing
+both variants to be used simultaneously through an additional search path.
+Evidence: `build/windows/game-Debug-pass2.log`.
 
-## Verifikation
+## Verification
 
-Nach erneutem Konfigurieren enthält das generierte Visual-Studio-Projekt für
-Release und Debug den tatsächlichen Boost-Library-Ordner.
+After reconfiguring, the generated Visual Studio project contains the
+actual Boost library directory for Release and Debug.
 
-| Prüfung | Ergebnis / Nachweis |
+| Check | Result / evidence |
 | --- | --- |
-| CEGUI mit Patch, Release und Debug | Erfolgreich gebaut und installiert; Treiberprotokoll `build/windows/cegui-rebuild-driver.log` |
-| Spiel Release nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Release-pass3.log`, Ausgabe `build/windows/opendungeons-plus.exe` |
-| Spiel Debug nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Debug-pass3.log`, Ausgabe `build/windows/opendungeons-plus_d.exe` |
-| Binärdateien | PE-Kennung und AMD64-Maschinenkennung beider erzeugter Programme geprüft |
-| Python-Varianten | Statische Importprüfung: Release verwendet ausschließlich `python310.dll`, Debug ausschließlich `python310_d.dll` als Python-Laufzeit; `build/windows/game-Release-dependencies.log` und `game-Debug-dependencies.log` |
+| CEGUI with patch, Release and Debug | Successfully built and installed; driver log `build/windows/cegui-rebuild-driver.log` |
+| Release game build after all four fixes | Exit code 0, `build/windows/game-Release-pass3.log`, output `build/windows/opendungeons-plus.exe` |
+| Debug game build after all four fixes | Exit code 0, `build/windows/game-Debug-pass3.log`, output `build/windows/opendungeons-plus_d.exe` |
+| Binaries | PE signature and AMD64 machine identifier checked for both generated programs |
+| Python variants | Static import check: Release uses only `python310.dll`, Debug only `python310_d.dll` as the Python runtime; `build/windows/game-Release-dependencies.log` and `game-Debug-dependencies.log` |
 
-Beide abschließenden Buildprotokolle enthalten keine Compiler- oder Linkerfehler.
-Die vorherigen Fehlversuche bleiben bewusst als getrennte Protokolle erhalten.
-Die Python-DLL-Prüfung erfolgte mit `dumpbin /dependents` auf beiden Programmen;
-es wurde keine Spielinstanz gestartet.
+Both final build logs contain no compiler or linker errors.
+The earlier failed attempts are deliberately retained as separate logs.
+The Python DLL check was performed with `dumpbin /dependents` on both programs;
+no game instance was started.
 
-Die Spielbuilds werden über `cmake --build build/windows --config Release --parallel 4`
-bzw. dieselbe Anweisung mit `--config Debug` ausgeführt, nach dem Konfigurieren
-mit dem [Windows-Konfigurationsskript](../../scripts/win32/configure-windows-prereqs.ps1).
-Spielstart, manuelle QA und die sichtbare Darstellung des Icons sind davon
-getrennte Prüfungen durch den Nutzer.
+The game builds are run using `cmake --build build/windows --config Release --parallel 4`
+or the same command with `--config Debug`, after configuring
+with the [Windows configuration script](../../scripts/win32/configure-windows-prereqs.ps1).
+Game startup, manual QA and the visible appearance of the icon are
+separate checks performed by the user.
 
-Die Builds sind nicht warnungsfrei: Unter anderem
-bleiben Warnungen zu numerischen Konvertierungen, die veraltete Option `/Gm` und
-im Release-Linkschritt `LNK4075` zur Kombination von Edit-and-Continue mit
-Linkeroptimierung sowie im Debug-Linkschritt zur Kombination von `/INCREMENTAL`
-und `/FORCE` bestehen. Diese Arbeit behebt die nachgewiesenen Buildabbrüche;
-sie schaltet keine Warnungen ab.
+The builds are not warning-free: among other things,
+warnings about numeric conversions, the deprecated `/Gm` option and,
+in the Release linking step, `LNK4075` for combining Edit-and-Continue with
+linker optimization remain, as does the warning in the Debug linking step about
+combining `/INCREMENTAL` and `/FORCE`. This work fixes the confirmed build failures;
+it does not disable warnings.
 
-## Version und Umfang
+## Version and scope
 
-Die Spielversion bleibt 0.7.1; diese Arbeit behebt Buildfehler und veröffentlicht
-keine neue Spielversion. Die technische Änderung wird zusammen mit diesem
-Fehlerprotokoll committed; lokale Status- und Einstiegshinweise werden in einem
-separaten Dokumentationscommit aktualisiert.
+The game version remains 0.7.1; this work fixes build errors and does not
+publish a new game version. The technical change is committed together with this
+error log; local status and getting-started notes are updated in a
+separate documentation commit.

--- a/docs/development/WINDOWS-BUILD-FIXES.md
+++ b/docs/development/WINDOWS-BUILD-FIXES.md
@@ -1,0 +1,125 @@
+# Windows-Build: Fehler und Korrekturen
+
+Stand: 5. September 2026. Die Fehler wurden beim tatsächlichen Build mit
+Visual Studio 2022, MSVC 19.44.35228.0, Windows SDK 10.0.26100.0 und x64
+untersucht. Die verwendeten Bibliotheken und die lokale Umgebung sind in
+[WINDOWS-DEV-SETUP.md](WINDOWS-DEV-SETUP.md) dokumentiert.
+
+## Fenster-Icon: ungeeignete 32-Bit-Schnittstelle
+
+Der erste Release-Build scheiterte in [ODApplication.cpp](../../source/ODApplication.cpp)
+beim Setzen des Fenster-Icons:
+
+```text
+error C2065: GCL_HICON: nichtdeklarierter Bezeichner
+warning C4311 / C4302: Zeigerverkürzung von HICON zu LONG
+```
+
+Der betroffene Windows-Code verwendete `SetClassLong`, `GCL_HICON` und eine
+Umwandlung des Icon-Handles in `LONG`. Der installierte Windows-SDK-Header
+`um/WinUser.h` entfernt `GCL_HICON` ausdrücklich bei gesetztem `_WIN64`;
+außerdem ist `LONG` nicht breit genug für einen 64-Bit-Zeiger.
+
+Die Korrektur verwendet an derselben Stelle `SetClassLongPtr`, `GCLP_HICON`
+und `LONG_PTR`. Das bestehende Icon und der Zeitpunkt seiner Zuweisung bleiben
+erhalten; die Änderung liegt weiterhin ausschließlich im Windows-Codepfad.
+
+Nachweis des Ausgangsfehlers: `build/windows/game-Release-initial.log`.
+Die ursprüngliche Buildausgabe bleibt zur Nachvollziehbarkeit lokal erhalten.
+
+## CEGUI-Makro verändert Boost-Header
+
+Derselbe Build meldete `C2039: _snprintf ist kein Member von std`, unter anderem
+beim Übersetzen von `ODClient.cpp`, `SettingsWindow.cpp` und `ModeManager.cpp`.
+Die Fehlermeldung zeigt auf `boost/assert/source_location.hpp`;
+dort verwendet Boost auf aktuellen MSVC-Versionen korrekt `std::snprintf`.
+
+Die Ursache liegt im zuvor eingebundenen `CEGUI/PropertyHelper.h` des verwendeten
+CEGUI-Tags: Ein für alle MSVC-Versionen gesetztes Makro ersetzt `snprintf` durch
+`_snprintf` und verändert damit auch den späteren Boost-Code zu `std::_snprintf`.
+Das Projekt selbst definiert dieses Makro nicht.
+
+Der [CEGUI-Patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch) begrenzt
+diesen Ersatz auf `_MSC_VER < 1900`; für neuere Compiler bleibt die vorhandene
+Standardfunktion verwendbar. Das
+[Installationsskript](../../scripts/win32/install-cegui-prereq.ps1) wendet den
+Patch vor dem CEGUI-Build an und erkennt einen bereits angewendeten Patch.
+CEGUI wurde anschließend in Release und Debug erfolgreich neu gebaut und
+installiert; der installierte Header ist per SHA-256 mit der gepatchten Quelle
+abgeglichen. Die Erkennung des bereits angewendeten Patches wurde mit
+`git apply --reverse --check` erfolgreich geprüft.
+Protokolle: `build/windows/cegui-rebuild-driver.log` im Projekt und
+`cegui-Release.log` / `cegui-Debug.log` im externen Bibliotheks-Logordner.
+
+## Boost-Linkerpfad zeigt in den Headerordner
+
+Nach den beiden Compilerkorrekturen erreichte Release den Linker und scheiterte
+mit `LNK1104` für `libboost_filesystem-vc143-mt-x64-1_82.lib`.
+Die passende Datei war installiert und im CMake-Cache bereits korrekt gefunden.
+Das generierte Visual-Studio-Projekt enthielt jedoch als zusätzlichen Suchpfad
+`include/boost-1_82/stage/lib`, wo diese Bibliothek nicht liegt.
+
+Ursache war in [CMakeLists.txt](../../CMakeLists.txt) die Ableitung des
+MSVC-Linkerpfads aus `Boost_INCLUDE_DIRS`. Stattdessen wird jetzt das von
+der Paketsuche ermittelte `Boost_LIBRARY_DIRS` verwendet; so benötigt die
+Korrektur keinen rechnerabhängigen Pfad und erhält die bisherige automatische
+Boost-Verknüpfung unter MSVC.
+Nachweis des Linkerfehlers: `build/windows/game-Release-pass1.log`.
+
+## Python-Debug-Bibliothek und Headerauswahl widersprechen sich
+
+Der vollständige Debug-Compilerlauf war erfolgreich, der Linker brach jedoch
+mit `LNK1104` für `python310.lib` ab. CMake hatte bereits die vorhandene
+`python310_d.lib` als explizite Debug-Abhängigkeit eingetragen.
+
+`pybind11/detail/common.h` setzt beim Einbinden von Python unter MSVC das Makro
+`_DEBUG` vorübergehend außer Kraft, solange `Py_DEBUG` nicht definiert ist.
+Dadurch erzeugt `Python/include/pyconfig.h` eine zusätzliche automatische
+Linkanforderung für `python310.lib`, obwohl CMake die Debug-Bibliothek auswählt.
+
+Wenn eine Python-Debug-Bibliothek konfiguriert ist und pybind11 den Debug-Modus
+nicht bereits aktiviert hat, definiert das Spieltarget unter MSVC deshalb
+`Py_DEBUG` ausschließlich für die Debug-Konfiguration.
+Der leere Makrowert entspricht der Definition im Windows-Python-Header;
+Release und Konfigurationen ohne gefundene Debug-Bibliothek bleiben unverändert.
+Damit werden Header und Bibliotheksvariante konsistent ausgewählt, statt die
+gleichzeitige Verwendung beider Varianten durch einen zusätzlichen Suchpfad zu ermöglichen.
+Nachweis: `build/windows/game-Debug-pass2.log`.
+
+## Verifikation
+
+Nach erneutem Konfigurieren enthält das generierte Visual-Studio-Projekt für
+Release und Debug den tatsächlichen Boost-Library-Ordner.
+
+| Prüfung | Ergebnis / Nachweis |
+| --- | --- |
+| CEGUI mit Patch, Release und Debug | Erfolgreich gebaut und installiert; Treiberprotokoll `build/windows/cegui-rebuild-driver.log` |
+| Spiel Release nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Release-pass3.log`, Ausgabe `build/windows/opendungeons-plus.exe` |
+| Spiel Debug nach allen vier Korrekturen | Exitcode 0, `build/windows/game-Debug-pass3.log`, Ausgabe `build/windows/opendungeons-plus_d.exe` |
+| Binärdateien | PE-Kennung und AMD64-Maschinenkennung beider erzeugter Programme geprüft |
+| Python-Varianten | Statische Importprüfung: Release verwendet ausschließlich `python310.dll`, Debug ausschließlich `python310_d.dll` als Python-Laufzeit; `build/windows/game-Release-dependencies.log` und `game-Debug-dependencies.log` |
+
+Beide abschließenden Buildprotokolle enthalten keine Compiler- oder Linkerfehler.
+Die vorherigen Fehlversuche bleiben bewusst als getrennte Protokolle erhalten.
+Die Python-DLL-Prüfung erfolgte mit `dumpbin /dependents` auf beiden Programmen;
+es wurde keine Spielinstanz gestartet.
+
+Die Spielbuilds werden über `cmake --build build/windows --config Release --parallel 4`
+bzw. dieselbe Anweisung mit `--config Debug` ausgeführt, nach dem Konfigurieren
+mit dem [Windows-Konfigurationsskript](../../scripts/win32/configure-windows-prereqs.ps1).
+Spielstart, manuelle QA und die sichtbare Darstellung des Icons sind davon
+getrennte Prüfungen durch den Nutzer.
+
+Die Builds sind nicht warnungsfrei: Unter anderem
+bleiben Warnungen zu numerischen Konvertierungen, die veraltete Option `/Gm` und
+im Release-Linkschritt `LNK4075` zur Kombination von Edit-and-Continue mit
+Linkeroptimierung sowie im Debug-Linkschritt zur Kombination von `/INCREMENTAL`
+und `/FORCE` bestehen. Diese Arbeit behebt die nachgewiesenen Buildabbrüche;
+sie schaltet keine Warnungen ab.
+
+## Version und Umfang
+
+Die Spielversion bleibt 0.7.1; diese Arbeit behebt Buildfehler und veröffentlicht
+keine neue Spielversion. Die technische Änderung wird zusammen mit diesem
+Fehlerprotokoll committed; lokale Status- und Einstiegshinweise werden in einem
+separaten Dokumentationscommit aktualisiert.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,63 +1,124 @@
 # Windows-Entwicklungsumgebung
 
-Stand: 5. September 2026. Diese Notiz hält die besprochene Vorbereitung für
-Aufgabe 3, GUI-Skalierung, fest; sie ist noch keine praktisch verifizierte
-Installations- oder Build-Anleitung.
+Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
+Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
+CMake-Konfiguration des Spiels waren erfolgreich.
+Der vollständige Spielbuild, Spielstart und die Paketierung sind noch ungeprüft.
 
-## Reicht VS Code allein?
+## Einstieg und Zuständigkeit der Dateien
 
-Nein. VS Code dient als Editor; um die Änderungen im Spiel zu prüfen, müssen
-zusätzlich Compiler, Build-Werkzeuge und Projektabhängigkeiten verfügbar sein,
-sodass das Spiel lokal kompiliert und startet.
+Diese Dokumentation und die Skripte unter [scripts/win32](../../scripts/win32)
+sind der gepflegte Projektbezug zur externen Installation.
+Für die tägliche Arbeit [BUILDING.md](BUILDING.md) verwenden;
+Quellen und Neuaufbau stehen in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
+[AGENTS.md](../../AGENTS.md) verweist neue Agentensitzungen auf diese Dateien.
 
-## Im Gespräch vorgeschlagene Werkzeuge
+Die großen Downloads, Bibliotheksquellen und kompilierten Dateien liegen außerhalb
+des Git-Repositories, damit sie unabhängig vom Arbeitsbranch wiederverwendbar sind.
+Die Skripte enthalten bewusst die konkreten Pfade dieser lokalen Installation;
+auf einem anderen Rechner müssen diese Pfade geprüft und angepasst werden.
+VS Code ist der Editor; Compiler, SDK und Bibliotheken werden zusätzlich benötigt.
 
-- VS Code als Editor.
-- Git für die Versionsverwaltung.
-- CMake für die Build-Konfiguration.
-- Visual Studio 2022 Build Tools mit dem Workload "Desktop development with C++",
-  MSVC-Compiler und Windows SDK.
-- Der lokale Klon des eigenen OpenDungeonsPlus-Forks.
+## Speicherorte
 
-Visual Studio 2022 wurde im Gespräch vorgeschlagen; eine funktionierende
-Kombination mit diesem Projekt und seinen Abhängigkeiten ist noch nicht bestätigt.
-Die vorhandene [Windows-Build-Konfiguration](../../appveyor.yml) enthält stattdessen
-ältere Einträge für Visual Studio 12 und MinGW, die keinen erfolgreichen Build mit
-Visual Studio 2022 belegen.
+| Zweck | Tatsächlicher Pfad |
+| --- | --- |
+| Projekt | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
+| Externer Entwicklungsordner | `C:\Users\mario\od-deps` |
+| Installationspräfix der Bibliotheken | `C:\Users\mario\od-deps\install` |
+| Header / Linkbibliotheken / DLLs | Unter `install\include`, `install\lib`, `install\bin`; einige DLLs liegen auch unter `install\lib` |
+| Bibliotheksquellen | `C:\Users\mario\od-deps\src` |
+| Bibliotheksbuilds | `C:\Users\mario\od-deps\build` |
+| Archive und Prüfsummen | `C:\Users\mario\od-deps\downloads` |
+| Konfigurations- und Bibliotheksprotokolle | `C:\Users\mario\od-deps\logs` |
+| CMake | `C:\Users\mario\od-deps\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` |
+| Visual Studio Build Tools | `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools` |
+| Python | `C:\Users\mario\AppData\Local\Programs\Python\Python310` |
+| 7-Zip für die Quellarchive | `C:\Users\mario\scoop\shims\7z.exe` |
+| Generierter Spielbuild | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
+| Vorgesehener Installationsordner des Spiels | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (noch nicht installiert) |
 
-## Im aktuellen Build-Code bestätigte Abhängigkeiten
+Unter `od-deps\setup-scripts`, `od-deps\Enter-OpenDungeonsPlus.ps1`,
+`od-deps\INSTALLATION.md` und dem ignorierten Projektordner `build` liegen noch
+Kopien aus der Installation; für weitere Arbeit die gepflegten Projektdateien
+verwenden, da die alten Kopien nicht automatisch aktualisiert werden.
+Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Installation.
 
-Die [Build-Datei](../../CMakeLists.txt) sucht folgende Bibliotheken:
+## Installierter Stand
 
-- OGRE, einschließlich der vom Spiel verknüpften Komponenten.
-- CEGUI einschließlich des OGRE-Renderers.
-- SFML.
-- OIS.
-- Boost.
-- Python-Entwicklungsbibliotheken und Header.
-- pybind11 für die Python-Einbettung.
+| Komponente | Version / Konfiguration |
+| --- | --- |
+| Visual Studio 2022 Build Tools | 17.14.39, MSVC-Toolsetordner 14.44.35207, von CMake erkannter Compiler 19.44.35228.0, Ziel und Host x64 |
+| Windows SDK | 10.0.26100.0 |
+| CMake | 3.31.8, portable Installation |
+| Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
+| OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
+| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer und Expat |
+| OIS | 1.5.1 |
+| SFML | 2.5.1 |
+| Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
+| pybind11 | 2.10.4 |
+| FreeType | 2.12.1 |
+| Expat | 2.8.4 |
+| PCRE | 8.45 mit UTF und Unicode-Properties |
 
-Die Build-Datei nennt CMake 3.5 als Mindestversion, prüft OGRE ab 1.9 und CEGUI ab
-0.8 und sucht SFML 2. Diese Angaben beschreiben die vorhandenen Build-Prüfungen;
-sie belegen keine konkret funktionierende Kombination aktueller Paketversionen
-und keinen stabilen Ogre-14-Port.
+Die kompilierten Bibliotheken liegen für x64 in Release und Debug vor;
+Boost zusätzlich statisch und dynamisch, jeweils mit dynamischer C++-Laufzeit.
+pybind11 stellt Header und CMake-Konfiguration bereit.
+Git, VS Code, 7-Zip und eine passende Visual-C++-Laufzeit waren bereits vorhanden.
 
-## Im Gespräch genannte optionale Ergänzungen
+OGRE, CEGUI, OIS, SFML und Python 3.10 orientieren sich an der vorhandenen
+[Snap-Baurezeptur](../../snap/snapcraft.yaml); die konkreten Windows-Optionen stehen
+in den Skripten. Dies dokumentiert OGRE 13.6.5 und belegt keinen Ogre-14-Port.
+Die älteren allgemeinen Angaben in README und AppVeyor ersetzen diesen lokalen Stand nicht.
 
-- CMake Tools für VS Code.
-- C/C++-Erweiterung für VS Code.
-- Codex in VS Code.
+## Wie Projekt und externe Installation zusammenfinden
 
-## Noch zu prüfen
+[Enter-OpenDungeonsPlus.ps1](../../scripts/win32/Enter-OpenDungeonsPlus.ps1)
+lädt die Visual-Studio-Entwicklungsumgebung für x64 und setzt in der aktuellen
+PowerShell-Sitzung:
 
-- Welche Werkzeuge und Abhängigkeiten auf dem Rechner bereits installiert sind.
-- Welche konkreten Versionen, Compiler und Zielarchitektur zusammen funktionieren.
-- Wie die Abhängigkeiten für diese Kombination bereitgestellt und gefunden werden.
-- Ob das Spiel damit tatsächlich gebaut und gestartet werden kann.
+- `PATH` für CMake, Bibliotheks-DLLs und Python.
+- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` und `OIS_HOME` auf `od-deps\install`.
+- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` auf die installierten Boost-Dateien.
+- `LIB` zusätzlich auf `od-deps\install\lib` für MSVCs automatische Verknüpfung.
 
-Die Bibliotheksliste wurde statisch mit dem Repository abgeglichen; im Rahmen
-dieser Dokumentation wurden keine Programme installiert und keine Builds oder
-Spieltests gestartet.
+CMake wurde bei der Installation außerdem dem Benutzer-PATH hinzugefügt;
+für einen eindeutigen Build trotzdem den Starthelfer laden.
+Die Compilerinitialisierung verwendet unter den Build Tools
+`Common7\Tools\Microsoft.VisualStudio.DevShell.dll`;
+Boost verwendet zusätzlich `VC\Auxiliary\Build\vcvarsall.bat`.
+Der Compiler liegt dort unter
+`VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\cl.exe`.
 
-Sobald ein funktionierender Ablauf feststeht, die tatsächlich verwendeten Versionen
-und Build-Schritte in einer eigenen Build-Anleitung festhalten und hier verlinken.
+[configure-windows-prereqs.ps1](../../scripts/win32/configure-windows-prereqs.ps1)
+ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
+benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
+Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
+und deaktiviert die Testtargets. Die Spielquellen und `CMakeLists.txt` wurden für
+diese Einrichtung nicht geändert.
+
+## Überprüft und noch offen
+
+| Schritt | Stand / Nachweis |
+| --- | --- |
+| Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
+| Bibliotheken bauen und installieren | Release und Debug erfolgreich; Protokolle unter `od-deps\logs` |
+| Unverändertes Spiel konfigurieren | Erfolgreich; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
+| Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
+| Spiel kompilieren | Noch nicht ausgeführt; Befehle in [BUILDING.md](BUILDING.md) |
+| Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
+| Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
+
+CMake hat Python, pybind11, OIS, OGRE, CEGUI samt OgreRenderer, SFML und die
+benötigten Boost-Linkbibliotheken gefunden. Die Meldung
+`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` betrifft die separate DLL-Suche für die
+Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
+Installationspaket ableiten.
+Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
+MSVC 19.44.35228.0; die Generierung gelingt trotzdem, die tatsächliche
+Verknüpfung des Spiels bleibt bis zum ersten Spielbuild ungeprüft.
+
+Für die Fortsetzung zuerst den Spielbuild durchführen, sobald er beauftragt ist,
+und dessen tatsächliches Ergebnis hier nachtragen; erst danach kann die Umgebung
+als für das Spiel vollständig geprüft gelten.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -3,8 +3,13 @@
 As of September 5, 2026, Mario's local computer, Windows x64.
 The prerequisites are installed; their library builds and the game's
 CMake configuration succeeded.
-The Release and Debug game builds succeeded after four targeted fixes;
-game startup and packaging remain unverified.
+The Release and Debug game builds succeeded after four targeted fixes.
+The Release runtime files are now staged for testing the executable directly
+from File Explorer. The user's startup attempts exposed incorrect handling of
+absolute Windows resource paths; both builds now include the correction.
+A subsequent Release run loaded the main-menu scene and shut down normally
+without the earlier errors; the user confirmed that direct Release startup works
+without errors. Broader gameplay tests and packaging remain unverified.
 
 ## Entry point and file responsibilities
 
@@ -110,7 +115,9 @@ from the actual compilation are recorded in the [build error log](WINDOWS-BUILD-
 | Configuration using the scripts added to the project | Successfully rerun, also from `docs\development`; the project path and adjacent environment helper are resolved correctly |
 | Compile the game | Release and Debug successful with exit code 0; commands in [BUILDING.md](BUILDING.md), evidence in the [build error log](WINDOWS-BUILD-FIXES.md) |
 | Check generated programs | Both files have the AMD64 PE signature; Release imports only `python310.dll`, Debug only `python310_d.dll` as the Python runtime |
-| Start the game, test GUI and cursor | Not yet verified; manual QA by the user |
+| Prepare direct Release startup | 22 DLLs staged beside the executable, Python module paths recorded locally and OGRE media paths corrected; static checks of 23 PE files, four plugins and 14 resource directories passed; see [BUILDING.md](BUILDING.md) and `build\windows\runtime-validation.json` |
+| Start the Release game directly | User confirmed error-free startup after the path fix; the 14:07 logs show main-menu scene loading and normal shutdown without the earlier loading errors; see [startup fixes](WINDOWS-STARTUP-FIXES.md) |
+| Test gameplay, GUI and cursor | Broader manual gameplay and visual QA remain with the user |
 | Create an installation package | Not yet verified; older packaging logic cannot find some expected Boost DLL names |
 
 CMake found Python, pybind11, OIS, OGRE, CEGUI including OgreRenderer, SFML and the
@@ -124,5 +131,10 @@ after correcting the Boost search path described in the
 [build error log](WINDOWS-BUILD-FIXES.md).
 
 The build errors are fixed; existing compiler/linker warnings are recorded in the
-build error log. Runtime verification by the user is next;
-successful builds do not replace this check.
+build error log. The configuration script now also runs
+[prepare-windows-runtime.ps1](../../scripts/win32/prepare-windows-runtime.ps1)
+to stage the local Release runtime without requiring a prepared shell for startup.
+Debug runtime staging is still pending; its generated plugin list also mixes
+Debug plugins with Release variants of Codec_STBI and RenderSystem_GL3Plus.
+Direct Release startup is verified by the user's confirmation and runtime logs;
+broader gameplay tests remain with the user.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -9,7 +9,13 @@ from File Explorer. The user's startup attempts exposed incorrect handling of
 absolute Windows resource paths; both builds now include the correction.
 A subsequent Release run loaded the main-menu scene and shut down normally
 without the earlier errors; the user confirmed that direct Release startup works
-without errors. Broader gameplay tests and packaging remain unverified.
+without errors. Enabling dynamic shadows later exposed a separate resource-group
+failure: the resource template now also registers OGRE's Main media in its internal
+group, retaining the existing Graphics registration for shader includes.
+Reconfiguration and the headless OGRE resource test succeeded; actual startup
+verification with shadows enabled is pending; see
+[startup fixes](WINDOWS-STARTUP-FIXES.md).
+Broader gameplay tests and packaging remain unverified.
 
 ## Entry point and file responsibilities
 

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -3,7 +3,8 @@
 Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
 Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
 CMake-Konfiguration des Spiels waren erfolgreich.
-Der vollständige Spielbuild, Spielstart und die Paketierung sind noch ungeprüft.
+Die Spielbuilds für Release und Debug sind nach vier gezielten Korrekturen
+erfolgreich; Spielstart und Paketierung bleiben ungeprüft.
 
 ## Einstieg und Zuständigkeit der Dateien
 
@@ -53,7 +54,7 @@ Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Inst
 | CMake | 3.31.8, portable Installation |
 | Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
 | OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
-| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer und Expat |
+| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer, Expat und dem gespeicherten MSVC-Kompatibilitätspatch |
 | OIS | 1.5.1 |
 | SFML | 2.5.1 |
 | Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
@@ -95,18 +96,20 @@ Der Compiler liegt dort unter
 ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
 benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
 Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
-und deaktiviert die Testtargets. Die Spielquellen und `CMakeLists.txt` wurden für
-diese Einrichtung nicht geändert.
+und deaktiviert die Testtargets. Bei der ursprünglichen Einrichtung wurden die
+Spielquellen und `CMakeLists.txt` nicht geändert; die anschließenden Korrekturen
+aus der tatsächlichen Kompilierung stehen im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md).
 
 ## Überprüft und noch offen
 
 | Schritt | Stand / Nachweis |
 | --- | --- |
 | Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
-| Bibliotheken bauen und installieren | Release und Debug erfolgreich; Protokolle unter `od-deps\logs` |
-| Unverändertes Spiel konfigurieren | Erfolgreich; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
+| Bibliotheken bauen und installieren | Release und Debug erfolgreich; CEGUI anschließend mit dem gespeicherten MSVC-Patch neu gebaut und installiert; Protokolle unter `od-deps\logs` |
+| Spiel konfigurieren | Mit den Buildkorrekturen erfolgreich erneut konfiguriert; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
 | Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
-| Spiel kompilieren | Noch nicht ausgeführt; Befehle in [BUILDING.md](BUILDING.md) |
+| Spiel kompilieren | Release und Debug erfolgreich mit Exitcode 0; Befehle in [BUILDING.md](BUILDING.md), Nachweise im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) |
+| Erzeugte Programme prüfen | Beide Dateien tragen die AMD64-PE-Kennung; Release importiert nur `python310.dll`, Debug nur `python310_d.dll` als Python-Laufzeit |
 | Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
 | Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
 
@@ -116,9 +119,10 @@ benötigten Boost-Linkbibliotheken gefunden. Die Meldung
 Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
 Installationspaket ableiten.
 Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
-MSVC 19.44.35228.0; die Generierung gelingt trotzdem, die tatsächliche
-Verknüpfung des Spiels bleibt bis zum ersten Spielbuild ungeprüft.
+MSVC 19.44.35228.0; die Generierung und beide Linkschritte gelingen trotzdem,
+nachdem der im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) beschriebene
+Boost-Suchpfad korrigiert wurde.
 
-Für die Fortsetzung zuerst den Spielbuild durchführen, sobald er beauftragt ist,
-und dessen tatsächliches Ergebnis hier nachtragen; erst danach kann die Umgebung
-als für das Spiel vollständig geprüft gelten.
+Die Buildfehler sind behoben; vorhandene Compiler-/Linkerwarnungen sind im
+Buildfehlerprotokoll festgehalten. Als Nächstes steht die Laufzeitprüfung durch
+den Nutzer an; erfolgreiche Builds ersetzen diese Prüfung nicht.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,128 +1,128 @@
-# Windows-Entwicklungsumgebung
+# Windows development environment
 
-Stand: 5. September 2026, lokaler Rechner von Mario, Windows x64.
-Die Voraussetzungen sind installiert; ihre Bibliotheksbuilds und die
-CMake-Konfiguration des Spiels waren erfolgreich.
-Die Spielbuilds für Release und Debug sind nach vier gezielten Korrekturen
-erfolgreich; Spielstart und Paketierung bleiben ungeprüft.
+As of September 5, 2026, Mario's local computer, Windows x64.
+The prerequisites are installed; their library builds and the game's
+CMake configuration succeeded.
+The Release and Debug game builds succeeded after four targeted fixes;
+game startup and packaging remain unverified.
 
-## Einstieg und Zuständigkeit der Dateien
+## Entry point and file responsibilities
 
-Diese Dokumentation und die Skripte unter [scripts/win32](../../scripts/win32)
-sind der gepflegte Projektbezug zur externen Installation.
-Für die tägliche Arbeit [BUILDING.md](BUILDING.md) verwenden;
-Quellen und Neuaufbau stehen in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
-[AGENTS.md](../../AGENTS.md) verweist neue Agentensitzungen auf diese Dateien.
+This documentation and the scripts under [scripts/win32](../../scripts/win32)
+are the maintained connection between the project and the external installation.
+Use [BUILDING.md](BUILDING.md) for daily work;
+sources and rebuilding are covered in [WINDOWS-PREREQUISITES.md](WINDOWS-PREREQUISITES.md).
+[AGENTS.md](../../AGENTS.md) directs new agent sessions to these files.
 
-Die großen Downloads, Bibliotheksquellen und kompilierten Dateien liegen außerhalb
-des Git-Repositories, damit sie unabhängig vom Arbeitsbranch wiederverwendbar sind.
-Die Skripte enthalten bewusst die konkreten Pfade dieser lokalen Installation;
-auf einem anderen Rechner müssen diese Pfade geprüft und angepasst werden.
-VS Code ist der Editor; Compiler, SDK und Bibliotheken werden zusätzlich benötigt.
+The large downloads, library sources and compiled files are stored outside
+the Git repository so they can be reused independently of the work branch.
+The scripts deliberately contain the specific paths of this local installation;
+on another computer, these paths must be checked and adjusted.
+VS Code is the editor; the compiler, SDK and libraries are also required.
 
-## Speicherorte
+## Locations
 
-| Zweck | Tatsächlicher Pfad |
+| Purpose | Actual path |
 | --- | --- |
-| Projekt | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
-| Externer Entwicklungsordner | `C:\Users\mario\od-deps` |
-| Installationspräfix der Bibliotheken | `C:\Users\mario\od-deps\install` |
-| Header / Linkbibliotheken / DLLs | Unter `install\include`, `install\lib`, `install\bin`; einige DLLs liegen auch unter `install\lib` |
-| Bibliotheksquellen | `C:\Users\mario\od-deps\src` |
-| Bibliotheksbuilds | `C:\Users\mario\od-deps\build` |
-| Archive und Prüfsummen | `C:\Users\mario\od-deps\downloads` |
-| Konfigurations- und Bibliotheksprotokolle | `C:\Users\mario\od-deps\logs` |
+| Project | `C:\Users\mario\GitHub\OpenDungeonsPlus` |
+| External development directory | `C:\Users\mario\od-deps` |
+| Library installation prefix | `C:\Users\mario\od-deps\install` |
+| Headers / link libraries / DLLs | Under `install\include`, `install\lib`, `install\bin`; some DLLs are also under `install\lib` |
+| Library sources | `C:\Users\mario\od-deps\src` |
+| Library builds | `C:\Users\mario\od-deps\build` |
+| Archives and checksums | `C:\Users\mario\od-deps\downloads` |
+| Configuration and library logs | `C:\Users\mario\od-deps\logs` |
 | CMake | `C:\Users\mario\od-deps\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` |
 | Visual Studio Build Tools | `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools` |
 | Python | `C:\Users\mario\AppData\Local\Programs\Python\Python310` |
-| 7-Zip für die Quellarchive | `C:\Users\mario\scoop\shims\7z.exe` |
-| Generierter Spielbuild | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
-| Vorgesehener Installationsordner des Spiels | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (noch nicht installiert) |
+| 7-Zip for source archives | `C:\Users\mario\scoop\shims\7z.exe` |
+| Generated game build | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows` |
+| Intended game installation directory | `C:\Users\mario\GitHub\OpenDungeonsPlus\build\windows\install` (not yet installed) |
 
-Unter `od-deps\setup-scripts`, `od-deps\Enter-OpenDungeonsPlus.ps1`,
-`od-deps\INSTALLATION.md` und dem ignorierten Projektordner `build` liegen noch
-Kopien aus der Installation; für weitere Arbeit die gepflegten Projektdateien
-verwenden, da die alten Kopien nicht automatisch aktualisiert werden.
-Ein neuer Klon enthält die Anleitungen und Skripte, aber nicht die externe Installation.
+Copies from the installation still exist under `od-deps\setup-scripts`,
+`od-deps\Enter-OpenDungeonsPlus.ps1`, `od-deps\INSTALLATION.md` and the ignored
+project directory `build`; use the maintained project files for further work,
+as the old copies are not updated automatically.
+A new clone contains the instructions and scripts, but not the external installation.
 
-## Installierter Stand
+## Installed state
 
-| Komponente | Version / Konfiguration |
+| Component | Version / configuration |
 | --- | --- |
-| Visual Studio 2022 Build Tools | 17.14.39, MSVC-Toolsetordner 14.44.35207, von CMake erkannter Compiler 19.44.35228.0, Ziel und Host x64 |
+| Visual Studio 2022 Build Tools | 17.14.39, MSVC toolset directory 14.44.35207, compiler detected by CMake 19.44.35228.0, target and host x64 |
 | Windows SDK | 10.0.26100.0 |
-| CMake | 3.31.8, portable Installation |
-| Python | 3.10.11 mit Headern, Release- und Debug-Importbibliotheken und Debug-Binärdateien |
+| CMake | 3.31.8, portable installation |
+| Python | 3.10.11 with headers, Release and Debug import libraries and debug binaries |
 | OGRE | 13.6.5, GL3Plus; OgreMain, Bites, Overlay, RTShaderSystem, Octree, ParticleFX, STBI |
-| CEGUI | 0.9999.0 aus `tomluchowski/cegui`, Tag `scissors_test_disabled`, mit OgreRenderer, Expat und dem gespeicherten MSVC-Kompatibilitätspatch |
+| CEGUI | 0.9999.0 from `tomluchowski/cegui`, tag `scissors_test_disabled`, with OgreRenderer, Expat and the saved MSVC compatibility patch |
 | OIS | 1.5.1 |
 | SFML | 2.5.1 |
 | Boost | 1.82.0; filesystem, locale, program_options, thread, system, chrono, date_time, atomic |
 | pybind11 | 2.10.4 |
 | FreeType | 2.12.1 |
 | Expat | 2.8.4 |
-| PCRE | 8.45 mit UTF und Unicode-Properties |
+| PCRE | 8.45 with UTF and Unicode properties |
 
-Die kompilierten Bibliotheken liegen für x64 in Release und Debug vor;
-Boost zusätzlich statisch und dynamisch, jeweils mit dynamischer C++-Laufzeit.
-pybind11 stellt Header und CMake-Konfiguration bereit.
-Git, VS Code, 7-Zip und eine passende Visual-C++-Laufzeit waren bereits vorhanden.
+The compiled libraries are available for x64 in Release and Debug;
+Boost is also available in static and shared variants, each using the dynamic C++ runtime.
+pybind11 provides headers and CMake configuration.
+Git, VS Code, 7-Zip and a suitable Visual C++ runtime were already present.
 
-OGRE, CEGUI, OIS, SFML und Python 3.10 orientieren sich an der vorhandenen
-[Snap-Baurezeptur](../../snap/snapcraft.yaml); die konkreten Windows-Optionen stehen
-in den Skripten. Dies dokumentiert OGRE 13.6.5 und belegt keinen Ogre-14-Port.
-Die älteren allgemeinen Angaben in README und AppVeyor ersetzen diesen lokalen Stand nicht.
+OGRE, CEGUI, OIS, SFML and Python 3.10 follow the existing
+[Snap build recipe](../../snap/snapcraft.yaml); the specific Windows options are
+in the scripts. This documents OGRE 13.6.5 and does not establish an Ogre 14 port.
+The older general information in README and AppVeyor does not supersede this local state.
 
-## Wie Projekt und externe Installation zusammenfinden
+## How the project and external installation connect
 
 [Enter-OpenDungeonsPlus.ps1](../../scripts/win32/Enter-OpenDungeonsPlus.ps1)
-lädt die Visual-Studio-Entwicklungsumgebung für x64 und setzt in der aktuellen
-PowerShell-Sitzung:
+loads the Visual Studio development environment for x64 and sets the following
+in the current PowerShell session:
 
-- `PATH` für CMake, Bibliotheks-DLLs und Python.
-- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` und `OIS_HOME` auf `od-deps\install`.
-- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` auf die installierten Boost-Dateien.
-- `LIB` zusätzlich auf `od-deps\install\lib` für MSVCs automatische Verknüpfung.
+- `PATH` for CMake, library DLLs and Python.
+- `CMAKE_PREFIX_PATH`, `CEGUI_HOME` and `OIS_HOME` to `od-deps\install`.
+- `BOOST_ROOT`, `BOOST_INCLUDEDIR`, `BOOST_LIBRARYDIR` to the installed Boost files.
+- `LIB` additionally to `od-deps\install\lib` for MSVC's automatic linking.
 
-CMake wurde bei der Installation außerdem dem Benutzer-PATH hinzugefügt;
-für einen eindeutigen Build trotzdem den Starthelfer laden.
-Die Compilerinitialisierung verwendet unter den Build Tools
-`Common7\Tools\Microsoft.VisualStudio.DevShell.dll`;
-Boost verwendet zusätzlich `VC\Auxiliary\Build\vcvarsall.bat`.
-Der Compiler liegt dort unter
+CMake was also added to the user PATH during installation;
+still load the environment helper to ensure an unambiguous build environment.
+Compiler initialization uses
+`Common7\Tools\Microsoft.VisualStudio.DevShell.dll` under the Build Tools;
+Boost additionally uses `VC\Auxiliary\Build\vcvarsall.bat`.
+The compiler is located there under
 `VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\cl.exe`.
 
 [configure-windows-prereqs.ps1](../../scripts/win32/configure-windows-prereqs.ps1)
-ermittelt den Projektstamm relativ zu seinem eigenen Speicherort, lädt den
-benachbarten Starthelfer und konfiguriert `build\windows` mit Visual Studio 2022/x64.
-Es übergibt Python-Executable, Header und beide Importbibliotheken explizit
-und deaktiviert die Testtargets. Bei der ursprünglichen Einrichtung wurden die
-Spielquellen und `CMakeLists.txt` nicht geändert; die anschließenden Korrekturen
-aus der tatsächlichen Kompilierung stehen im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md).
+determines the project root relative to its own location, loads the
+adjacent environment helper and configures `build\windows` with Visual Studio 2022/x64.
+It explicitly passes the Python executable, headers and both import libraries
+and disables the test targets. During the original setup, the
+game sources and `CMakeLists.txt` were not changed; the subsequent fixes
+from the actual compilation are recorded in the [build error log](WINDOWS-BUILD-FIXES.md).
 
-## Überprüft und noch offen
+## Verified and still pending
 
-| Schritt | Stand / Nachweis |
+| Step | Status / evidence |
 | --- | --- |
-| Compiler, CMake und Python laden | Über den Starthelfer erfolgreich geprüft |
-| Bibliotheken bauen und installieren | Release und Debug erfolgreich; CEGUI anschließend mit dem gespeicherten MSVC-Patch neu gebaut und installiert; Protokolle unter `od-deps\logs` |
-| Spiel konfigurieren | Mit den Buildkorrekturen erfolgreich erneut konfiguriert; `opendungeons-configure.log` endet mit erfolgreicher Konfiguration und Generierung |
-| Konfiguration über die ins Projekt übernommenen Skripte | Erfolgreich erneut ausgeführt, auch aus `docs\development`; Projektpfad und benachbarter Starthelfer werden korrekt aufgelöst |
-| Spiel kompilieren | Release und Debug erfolgreich mit Exitcode 0; Befehle in [BUILDING.md](BUILDING.md), Nachweise im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) |
-| Erzeugte Programme prüfen | Beide Dateien tragen die AMD64-PE-Kennung; Release importiert nur `python310.dll`, Debug nur `python310_d.dll` als Python-Laufzeit |
-| Spiel starten, GUI und Cursor testen | Noch nicht geprüft; manuelle QA durch den Nutzer |
-| Installationspaket erstellen | Noch nicht geprüft; ältere Paketlogik findet einige erwartete Boost-DLL-Namen nicht |
+| Load compiler, CMake and Python | Successfully verified using the environment helper |
+| Build and install libraries | Release and Debug successful; CEGUI subsequently rebuilt and installed with the saved MSVC patch; logs under `od-deps\logs` |
+| Configure the game | Successfully reconfigured with the build fixes; `opendungeons-configure.log` ends with successful configuration and generation |
+| Configuration using the scripts added to the project | Successfully rerun, also from `docs\development`; the project path and adjacent environment helper are resolved correctly |
+| Compile the game | Release and Debug successful with exit code 0; commands in [BUILDING.md](BUILDING.md), evidence in the [build error log](WINDOWS-BUILD-FIXES.md) |
+| Check generated programs | Both files have the AMD64 PE signature; Release imports only `python310.dll`, Debug only `python310_d.dll` as the Python runtime |
+| Start the game, test GUI and cursor | Not yet verified; manual QA by the user |
+| Create an installation package | Not yet verified; older packaging logic cannot find some expected Boost DLL names |
 
-CMake hat Python, pybind11, OIS, OGRE, CEGUI samt OgreRenderer, SFML und die
-benötigten Boost-Linkbibliotheken gefunden. Die Meldung
-`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` betrifft die separate DLL-Suche für die
-Paketierung; daraus weder einen fehlgeschlagenen Linktest noch ein funktionierendes
-Installationspaket ableiten.
-Die erneute Konfiguration meldet außerdem `Boost toolset is unknown` für
-MSVC 19.44.35228.0; die Generierung und beide Linkschritte gelingen trotzdem,
-nachdem der im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) beschriebene
-Boost-Suchpfad korrigiert wurde.
+CMake found Python, pybind11, OIS, OGRE, CEGUI including OgreRenderer, SFML and the
+required Boost link libraries. The message
+`DEPS_BOOST_FILESYSTEM_BIN_REL-NOTFOUND` concerns the separate DLL search for
+packaging; do not infer either a failed link test or a working
+installation package from it.
+The reconfiguration also reports `Boost toolset is unknown` for
+MSVC 19.44.35228.0; generation and both linking steps still succeed
+after correcting the Boost search path described in the
+[build error log](WINDOWS-BUILD-FIXES.md).
 
-Die Buildfehler sind behoben; vorhandene Compiler-/Linkerwarnungen sind im
-Buildfehlerprotokoll festgehalten. Als Nächstes steht die Laufzeitprüfung durch
-den Nutzer an; erfolgreiche Builds ersetzen diese Prüfung nicht.
+The build errors are fixed; existing compiler/linker warnings are recorded in the
+build error log. Runtime verification by the user is next;
+successful builds do not replace this check.

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -12,8 +12,13 @@ without the earlier errors; the user confirmed that direct Release startup works
 without errors. Enabling dynamic shadows later exposed a separate resource-group
 failure: the resource template now also registers OGRE's Main media in its internal
 group, retaining the existing Graphics registration for shader includes.
-Reconfiguration and the headless OGRE resource test succeeded; actual startup
-verification with shadows enabled is pending; see
+Reconfiguration, the headless OGRE resource test and the user's subsequent
+main-menu startup with shadows enabled succeeded. Exception logging added for a
+subsequent Legacy test-map failure captured the cause in the user's 15:05 run:
+OGRE's automatic illumination splitting removed DirtInstanced's fragment shader.
+RenderManager now selects integrated additive texture shadows; both builds and
+the isolated OGRE pass test succeeded, with the user's map retest and visual
+acceptance still pending; see
 [startup fixes](WINDOWS-STARTUP-FIXES.md).
 Broader gameplay tests and packaging remain unverified.
 

--- a/docs/development/WINDOWS-DEV-SETUP.md
+++ b/docs/development/WINDOWS-DEV-SETUP.md
@@ -1,0 +1,63 @@
+# Windows-Entwicklungsumgebung
+
+Stand: 5. September 2026. Diese Notiz hält die besprochene Vorbereitung für
+Aufgabe 3, GUI-Skalierung, fest; sie ist noch keine praktisch verifizierte
+Installations- oder Build-Anleitung.
+
+## Reicht VS Code allein?
+
+Nein. VS Code dient als Editor; um die Änderungen im Spiel zu prüfen, müssen
+zusätzlich Compiler, Build-Werkzeuge und Projektabhängigkeiten verfügbar sein,
+sodass das Spiel lokal kompiliert und startet.
+
+## Im Gespräch vorgeschlagene Werkzeuge
+
+- VS Code als Editor.
+- Git für die Versionsverwaltung.
+- CMake für die Build-Konfiguration.
+- Visual Studio 2022 Build Tools mit dem Workload "Desktop development with C++",
+  MSVC-Compiler und Windows SDK.
+- Der lokale Klon des eigenen OpenDungeonsPlus-Forks.
+
+Visual Studio 2022 wurde im Gespräch vorgeschlagen; eine funktionierende
+Kombination mit diesem Projekt und seinen Abhängigkeiten ist noch nicht bestätigt.
+Die vorhandene [Windows-Build-Konfiguration](../../appveyor.yml) enthält stattdessen
+ältere Einträge für Visual Studio 12 und MinGW, die keinen erfolgreichen Build mit
+Visual Studio 2022 belegen.
+
+## Im aktuellen Build-Code bestätigte Abhängigkeiten
+
+Die [Build-Datei](../../CMakeLists.txt) sucht folgende Bibliotheken:
+
+- OGRE, einschließlich der vom Spiel verknüpften Komponenten.
+- CEGUI einschließlich des OGRE-Renderers.
+- SFML.
+- OIS.
+- Boost.
+- Python-Entwicklungsbibliotheken und Header.
+- pybind11 für die Python-Einbettung.
+
+Die Build-Datei nennt CMake 3.5 als Mindestversion, prüft OGRE ab 1.9 und CEGUI ab
+0.8 und sucht SFML 2. Diese Angaben beschreiben die vorhandenen Build-Prüfungen;
+sie belegen keine konkret funktionierende Kombination aktueller Paketversionen
+und keinen stabilen Ogre-14-Port.
+
+## Im Gespräch genannte optionale Ergänzungen
+
+- CMake Tools für VS Code.
+- C/C++-Erweiterung für VS Code.
+- Codex in VS Code.
+
+## Noch zu prüfen
+
+- Welche Werkzeuge und Abhängigkeiten auf dem Rechner bereits installiert sind.
+- Welche konkreten Versionen, Compiler und Zielarchitektur zusammen funktionieren.
+- Wie die Abhängigkeiten für diese Kombination bereitgestellt und gefunden werden.
+- Ob das Spiel damit tatsächlich gebaut und gestartet werden kann.
+
+Die Bibliotheksliste wurde statisch mit dem Repository abgeglichen; im Rahmen
+dieser Dokumentation wurden keine Programme installiert und keine Builds oder
+Spieltests gestartet.
+
+Sobald ein funktionierender Ablauf feststeht, die tatsächlich verwendeten Versionen
+und Build-Schritte in einer eigenen Build-Anleitung festhalten und hier verlinken.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -1,116 +1,116 @@
-# Windows-Voraussetzungen wiederherstellen
+# Restoring Windows prerequisites
 
-Installationsprotokoll vom 5. September 2026; die Voraussetzungen sind auf Marios
-Rechner bereits vorhanden. Für die tägliche Arbeit genügt [BUILDING.md](BUILDING.md).
-Diese Anleitung hält die tatsächlich verwendeten Quellen und Optionen fest;
-die spätere Verfügbarkeit der Downloads ist damit nicht garantiert.
+Installation log from September 5, 2026; the prerequisites are already present on
+Mario's computer. For daily work, [BUILDING.md](BUILDING.md) is sufficient.
+This guide records the sources and options actually used;
+it does not guarantee that the downloads will remain available later.
 
-## Verzeichnisse und Werkzeuge
+## Directories and tools
 
-Externer Stamm: `C:\Users\mario\od-deps`, mit den Unterordnern `src`, `build`,
-`install`, `tools`, `downloads` und `logs`.
-Bei einer leeren Installation diese Ordner vor dem Ausführen der Skripte anlegen.
-Git, VS Code, 7-Zip und die Visual-C++-Laufzeit waren bereits installiert.
-Das verwendete 7-Zip ist `C:\Users\mario\scoop\shims\7z.exe`.
+External root: `C:\Users\mario\od-deps`, with the subdirectories `src`, `build`,
+`install`, `tools`, `downloads` and `logs`.
+For an empty installation, create these directories before running the scripts.
+Git, VS Code, 7-Zip and the Visual C++ runtime were already installed.
+The 7-Zip used is `C:\Users\mario\scoop\shims\7z.exe`.
 
-Die ursprünglichen Werkzeuginstallationen wurden mit diesen Befehlen durchgeführt:
+The original tool installations were performed with these commands:
 
 ```powershell
 winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --source winget --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
 winget install --id Python.Python.3.10 --exact --source winget --scope user --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Include_debug=1 /quiet"
 ```
 
-Dabei wurden Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 und
-Python 3.10.11 installiert. Die Befehle selbst fixieren diese Patchversionen nicht;
-bei einem späteren Neuaufbau die tatsächlich installierten Versionen abgleichen.
-Python benötigt auch `libs\python310_d.lib`; eine reine Laufzeitinstallation reicht
-für die dokumentierte Debug-Konfiguration nicht aus.
+This installed Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 and
+Python 3.10.11. The commands themselves do not pin these patch versions;
+compare the versions actually installed when rebuilding at a later date.
+Python also requires `libs\python310_d.lib`; a runtime-only installation is not
+sufficient for the documented Debug configuration.
 
-CMake wurde als [Version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
-heruntergeladen und unter `od-deps\tools` entpackt, sodass
-`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` existiert.
-Die dokumentierten Skripte verwenden diesen Stand; die ältere Buildlogik wurde
-nicht mit einer beliebigen neueren CMake-Version geprüft.
+CMake was downloaded as [version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
+and extracted under `od-deps\tools`, so that
+`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` exists.
+The documented scripts use this version; the older build logic has not been
+tested with an arbitrary newer CMake version.
 
-## Git-Quellen
+## Git sources
 
-Alle Zielpfade sind relativ zu `C:\Users\mario\od-deps`.
-Die Commits wurden an den vorhandenen lokalen Quellklonen abgeglichen.
+All target paths are relative to `C:\Users\mario\od-deps`.
+The commits were checked against the existing local source clones.
 
-| Quelle | Tag | Zielpfad | Commit |
+| Source | Tag | Target path | Commit |
 | --- | --- | --- | --- |
 | [OGRE](https://github.com/OGRECave/ogre) | `v13.6.5` | `src\ogre` | `856cf743ebcce8250d181a621ee47a70b12ed17e` |
-| [CEGUI-Projektfork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
+| [CEGUI project fork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
 | [OIS](https://github.com/wgois/OIS) | `v1.5.1` | `src\ois` | `6edb487cccb54d59e5b0fff86549d5eef475dea6` |
 | [SFML](https://github.com/SFML/SFML) | `2.5.1` | `src\sfml` | `2f11710abc5aa478503a7ff3f9e654bd2078ebab` |
 | [FreeType](https://github.com/freetype/freetype) | `VER-2-12-1` | `src\freetype` | `e8ebfe988b5f57bfb9a3ecb13c70d9791bce9ecf` |
 | [Expat](https://github.com/libexpat/libexpat) | `R_2_8_4` | `src\expat` | `12cf0b1f25f026a022fe728ad8f7e3d017285b80` |
 | [pybind11](https://github.com/pybind/pybind11) | `v2.10.4` | `src\pybind11` | `5b0a6fc2017fcc176545afe3e09c9f9885283242` |
 
-Für einen fehlenden Quellordner das betreffende Repository mit
-`git clone --depth 1 --branch <Tag> <Repository-URL>.git <Zielpfad>` klonen und
-`git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
-Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
-Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
-Zusätzlich zum aufgeführten CEGUI-Basiscommit wird beim Windows-Neuaufbau der
-[MSVC-Kompatibilitätspatch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
-angewendet; die Ursache ist im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) belegt.
+For a missing source directory, clone the relevant repository with
+`git clone --depth 1 --branch <Tag> <Repository-URL>.git <TargetPath>` and
+compare `git -C <TargetPath> rev-parse HEAD` with the table.
+Preserve existing sources when doing so. `scissors_test_disabled` is a tag.
+Expat is configured from the subdirectory `src\expat\expat`.
+In addition to the listed CEGUI base commit, the
+[MSVC compatibility patch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
+is applied when rebuilding on Windows; the cause is documented in the [build error log](WINDOWS-BUILD-FIXES.md).
 
-## Archive und Prüfsummen
+## Archives and checksums
 
-Die Downloadarchive liegen unter `od-deps\downloads`; die folgenden Hashes wurden
-bei der Installation geprüft und vor der Übernahme in diese Dokumentation erneut
-mit den vorhandenen Dateien abgeglichen.
-Downloads erst nach erfolgreichem Hashvergleich entpacken.
+The download archives are stored under `od-deps\downloads`; the following hashes were
+verified during installation and checked against the existing files again before
+being added to this documentation.
+Extract downloads only after a successful hash comparison.
 
-| Archiv / Download | Entpacktes Ziel |
+| Archive / download | Extraction target |
 | --- | --- |
 | [cmake-3.31.8-windows-x86_64.zip](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-windows-x86_64.zip) | `tools\cmake-3.31.8-windows-x86_64` |
 | [boost_1_82_0.zip](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip) | `src\boost_1_82_0` |
-| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), lokal als `pcre-8.45-verified.zip` | `src\pcre-8.45` |
+| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), locally named `pcre-8.45-verified.zip` | `src\pcre-8.45` |
 
-CMake, SHA-256 aus der
-[Release-Prüfsummendatei](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
+CMake, SHA-256 from the
+[release checksum file](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
 
 ```text
 81aa9964dbabd71fe02e7ec50472fd3ad56138c49944515ece9001efbff8d719
 ```
 
-Boost, SHA-256 aus den
-[Archivmetadaten](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
+Boost, SHA-256 from the
+[archive metadata](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
 
 ```text
 f7c9e28d242abcd7a2c1b962039fcdd463ca149d1883c3a950bbcc0ce6f7c6d9
 ```
 
-PCRE, SHA-512 abgeglichen mit dem
-[vcpkg-Port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
-zum Installationszeitpunkt; vcpkg selbst wurde nicht benötigt oder installiert:
+PCRE, SHA-512 checked against the
+[vcpkg port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
+at the time of installation; vcpkg itself was neither required nor installed:
 
 ```text
 71f246c0abbf356222933ad1604cab87a1a2a3cd8054a0b9d6deb25e0735ce9f40f923d14cbd21f32fdac7283794270afcb0f221ad24662ac35934fcb73675cd
 ```
 
-Zum Prüfen und Entpacken beispielsweise:
+For example, to verify and extract:
 
 ```powershell
 Get-FileHash -Algorithm SHA512 -LiteralPath 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip'
-# Nur bei Übereinstimmung mit dem oben dokumentierten Hash:
+# Only if it matches the hash documented above:
 & 'C:\Users\mario\scoop\shims\7z.exe' x 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip' '-oC:\Users\mario\od-deps\src'
 ```
 
-Für CMake und Boost `SHA256` verwenden; CMake nach `tools`, Boost nach `src`
-entpacken. Ein früherer PCRE-Download namens `pcre-8.45.zip` enthält HTML und
-ist kein verwendbares Archiv; die geprüfte Datei trägt den Zusatz `-verified`.
+Use `SHA256` for CMake and Boost; extract CMake to `tools` and Boost to `src`.
+An earlier PCRE download named `pcre-8.45.zip` contains HTML and
+is not a usable archive; the verified file has the suffix `-verified`.
 
-## Bibliotheken neu bauen, falls erforderlich
+## Rebuild libraries if necessary
 
-Die Skripte wurden aus der erfolgreichen Einrichtung übernommen und erwarten die
-oben vorbereiteten Quellen und Werkzeuge; sie laden selbst keine Quellen herunter.
-Sie konfigurieren, bauen und installieren ins gemeinsame Präfix `od-deps\install`.
-Release und Debug werden jeweils nacheinander gebaut.
+The scripts were taken from the successful setup and expect the
+sources and tools prepared above; they do not download sources themselves.
+They configure, build and install into the shared prefix `od-deps\install`.
+Release and Debug are built sequentially for each library.
 
-Aus dem Projektstamm, bei einem notwendigen vollständigen Neuaufbau:
+From the project root, when a complete rebuild is necessary:
 
 ```powershell
 Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
@@ -123,47 +123,47 @@ $taskInstallScripts = @(
 foreach ($taskInstallScript in $taskInstallScripts) {
     $taskScriptPath = Join-Path $PWD.Path "scripts\win32\$taskInstallScript"
     & powershell.exe -NoProfile -File $taskScriptPath
-    if ($LASTEXITCODE -ne 0) { throw "Installation fehlgeschlagen: $taskInstallScript" }
+    if ($LASTEXITCODE -ne 0) { throw "Installation failed: $taskInstallScript" }
 }
 ```
 
-Die separaten PowerShell-Prozesse halten die Verzeichnis- und Umgebungsänderungen
-des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenfolge.
+The separate PowerShell processes keep the Boost script's directory and environment
+changes out of the calling session; errors stop the sequence.
 
-| Skript | Zuständigkeit / Reihenfolge |
+| Script | Responsibility / order |
 | --- | --- |
-| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
-| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
-| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
-| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Wendet den gespeicherten MSVC-Patch einmalig an und baut CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, then FreeType, pybind11, PCRE; can be filtered with `-Only` for targeted needs |
+| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost build tool and libraries; generates `od-deps\boost-user-config.jam` |
+| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE with GL3Plus and the required components |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Applies the saved MSVC patch once and builds CEGUI with OgreRenderer and Expat, after OGRE and the base libraries |
 
-Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
-konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
-Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
+Then load the environment helper and configure the game following [BUILDING.md](BUILDING.md);
+a library build alone does not establish a successful game build.
+Logs are stored under `od-deps\logs`; each new script run replaces its logs.
 
-## Behobene Installationsprobleme erhalten
+## Preserve fixes for installation problems
 
-- **SFML / FreeType:** SFML installiert eine alte mitgelieferte statische
-  `freetype.lib` über die selbst gebaute Datei im gemeinsamen Präfix; das führte
-  beim Linken von OgreOverlay zu `sprintf` / `LNK2019`.
-  Deshalb FreeType nach SFML installieren; diese Reihenfolge steht im Basisskript.
-  Die endgültige Datei wurde per Hash mit dem eigenen FreeType-Build abgeglichen.
-- **Boost / Compilerinitialisierung:** Die automatische Suche verwendete einen
-  falschen Pfad zu `vcvarsall.bat`. Das Skript erzeugt deshalb eine Jam-Konfiguration
-  mit dem tatsächlich gefundenen `cl.exe` und
-  `VC\Auxiliary\Build\vcvarsall.bat`, verwendet `--user-config`, `--reconfigure`
-  sowie `architecture=x86 address-model=64` für den x64-Build.
-- **MSVC-Optionen:** OGRE und CEGUI verwenden
-  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; `/EHsc` beim Anpassen der Parallelität
-  erhalten. OGRE verwendet vorkompilierte Header und
-  `OGRE_BUILD_MSVC_MP=OFF`, da `/MP4` bereits explizit gesetzt ist.
-- **PCRE-Download:** Den HTML-Fehldownload nicht erneut verwenden; Archiv und Hash
-  sind oben eindeutig festgehalten.
-- **Paketierung:** Die alte Windows-Paketlogik findet einige Boost-DLL-Namen nicht,
-  obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
-  ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
+- **SFML / FreeType:** SFML installs an old bundled static
+  `freetype.lib` over the locally built file in the shared prefix; this caused
+  `sprintf` / `LNK2019` when linking OgreOverlay.
+  Therefore, install FreeType after SFML; this order is recorded in the base script.
+  The final file was compared with the local FreeType build by hash.
+- **Boost / compiler initialization:** The automatic search used an
+  incorrect path to `vcvarsall.bat`. The script therefore generates a Jam configuration
+  with the actual detected `cl.exe` and
+  `VC\Auxiliary\Build\vcvarsall.bat`, uses `--user-config`, `--reconfigure`
+  and `architecture=x86 address-model=64` for the x64 build.
+- **MSVC options:** OGRE and CEGUI use
+  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; preserve `/EHsc` when adjusting
+  parallelism. OGRE uses precompiled headers and
+  `OGRE_BUILD_MSVC_MP=OFF`, since `/MP4` is already set explicitly.
+- **PCRE download:** Do not reuse the failed HTML download; the archive and hash
+  are clearly recorded above.
+- **Packaging:** The old Windows packaging logic cannot find some Boost DLL names,
+  although CMake finds the link libraries; packaging and runtime remain
+  unverified, see the [current status](WINDOWS-DEV-SETUP.md).
 
-Die ursprüngliche Einrichtung benötigte für diese Lösungen keine Quellpatches;
-bei der anschließenden Spielkompilierung wurde der oben verlinkte CEGUI-Patch
-erforderlich. Die konkreten CMake- und Boost-Optionen stehen vollständig in den
-Skripten, die Änderung am CEGUI-Header in der zugehörigen Patchdatei.
+The original setup did not require source patches for these solutions;
+the CEGUI patch linked above became necessary during the subsequent game
+compilation. The specific CMake and Boost options are fully recorded in the
+scripts, and the change to the CEGUI header is in the corresponding patch file.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -52,6 +52,9 @@ Für einen fehlenden Quellordner das betreffende Repository mit
 `git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
 Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
 Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
+Zusätzlich zum aufgeführten CEGUI-Basiscommit wird beim Windows-Neuaufbau der
+[MSVC-Kompatibilitätspatch](../../scripts/win32/patches/cegui-msvc-snprintf.patch)
+angewendet; die Ursache ist im [Buildfehlerprotokoll](WINDOWS-BUILD-FIXES.md) belegt.
 
 ## Archive und Prüfsummen
 
@@ -132,7 +135,7 @@ des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenf
 | [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
 | [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
 | [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
-| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | Wendet den gespeicherten MSVC-Patch einmalig an und baut CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
 
 Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
 konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
@@ -160,5 +163,7 @@ Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
   obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
   ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
 
-Die Dependency-Quellen wurden für diese Lösungen nicht gepatcht; die konkreten
-CMake- und Boost-Optionen stehen vollständig in den übernommenen Skripten.
+Die ursprüngliche Einrichtung benötigte für diese Lösungen keine Quellpatches;
+bei der anschließenden Spielkompilierung wurde der oben verlinkte CEGUI-Patch
+erforderlich. Die konkreten CMake- und Boost-Optionen stehen vollständig in den
+Skripten, die Änderung am CEGUI-Header in der zugehörigen Patchdatei.

--- a/docs/development/WINDOWS-PREREQUISITES.md
+++ b/docs/development/WINDOWS-PREREQUISITES.md
@@ -1,0 +1,164 @@
+# Windows-Voraussetzungen wiederherstellen
+
+Installationsprotokoll vom 5. September 2026; die Voraussetzungen sind auf Marios
+Rechner bereits vorhanden. Für die tägliche Arbeit genügt [BUILDING.md](BUILDING.md).
+Diese Anleitung hält die tatsächlich verwendeten Quellen und Optionen fest;
+die spätere Verfügbarkeit der Downloads ist damit nicht garantiert.
+
+## Verzeichnisse und Werkzeuge
+
+Externer Stamm: `C:\Users\mario\od-deps`, mit den Unterordnern `src`, `build`,
+`install`, `tools`, `downloads` und `logs`.
+Bei einer leeren Installation diese Ordner vor dem Ausführen der Skripte anlegen.
+Git, VS Code, 7-Zip und die Visual-C++-Laufzeit waren bereits installiert.
+Das verwendete 7-Zip ist `C:\Users\mario\scoop\shims\7z.exe`.
+
+Die ursprünglichen Werkzeuginstallationen wurden mit diesen Befehlen durchgeführt:
+
+```powershell
+winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --source winget --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
+winget install --id Python.Python.3.10 --exact --source winget --scope user --accept-package-agreements --accept-source-agreements --silent --disable-interactivity --override "InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Include_debug=1 /quiet"
+```
+
+Dabei wurden Build Tools 17.14.39 / MSVC 14.44.35207 / SDK 10.0.26100.0 und
+Python 3.10.11 installiert. Die Befehle selbst fixieren diese Patchversionen nicht;
+bei einem späteren Neuaufbau die tatsächlich installierten Versionen abgleichen.
+Python benötigt auch `libs\python310_d.lib`; eine reine Laufzeitinstallation reicht
+für die dokumentierte Debug-Konfiguration nicht aus.
+
+CMake wurde als [Version 3.31.8](https://github.com/Kitware/CMake/releases/tag/v3.31.8)
+heruntergeladen und unter `od-deps\tools` entpackt, sodass
+`tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe` existiert.
+Die dokumentierten Skripte verwenden diesen Stand; die ältere Buildlogik wurde
+nicht mit einer beliebigen neueren CMake-Version geprüft.
+
+## Git-Quellen
+
+Alle Zielpfade sind relativ zu `C:\Users\mario\od-deps`.
+Die Commits wurden an den vorhandenen lokalen Quellklonen abgeglichen.
+
+| Quelle | Tag | Zielpfad | Commit |
+| --- | --- | --- | --- |
+| [OGRE](https://github.com/OGRECave/ogre) | `v13.6.5` | `src\ogre` | `856cf743ebcce8250d181a621ee47a70b12ed17e` |
+| [CEGUI-Projektfork](https://github.com/tomluchowski/cegui) | `scissors_test_disabled` | `src\cegui` | `d8c7290c0eabc62e4319af4168a81757c6267403` |
+| [OIS](https://github.com/wgois/OIS) | `v1.5.1` | `src\ois` | `6edb487cccb54d59e5b0fff86549d5eef475dea6` |
+| [SFML](https://github.com/SFML/SFML) | `2.5.1` | `src\sfml` | `2f11710abc5aa478503a7ff3f9e654bd2078ebab` |
+| [FreeType](https://github.com/freetype/freetype) | `VER-2-12-1` | `src\freetype` | `e8ebfe988b5f57bfb9a3ecb13c70d9791bce9ecf` |
+| [Expat](https://github.com/libexpat/libexpat) | `R_2_8_4` | `src\expat` | `12cf0b1f25f026a022fe728ad8f7e3d017285b80` |
+| [pybind11](https://github.com/pybind/pybind11) | `v2.10.4` | `src\pybind11` | `5b0a6fc2017fcc176545afe3e09c9f9885283242` |
+
+Für einen fehlenden Quellordner das betreffende Repository mit
+`git clone --depth 1 --branch <Tag> <Repository-URL>.git <Zielpfad>` klonen und
+`git -C <Zielpfad> rev-parse HEAD` mit der Tabelle vergleichen.
+Bestehende Quellen dabei erhalten. `scissors_test_disabled` ist ein Tag.
+Expat wird aus dem Unterordner `src\expat\expat` konfiguriert.
+
+## Archive und Prüfsummen
+
+Die Downloadarchive liegen unter `od-deps\downloads`; die folgenden Hashes wurden
+bei der Installation geprüft und vor der Übernahme in diese Dokumentation erneut
+mit den vorhandenen Dateien abgeglichen.
+Downloads erst nach erfolgreichem Hashvergleich entpacken.
+
+| Archiv / Download | Entpacktes Ziel |
+| --- | --- |
+| [cmake-3.31.8-windows-x86_64.zip](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-windows-x86_64.zip) | `tools\cmake-3.31.8-windows-x86_64` |
+| [boost_1_82_0.zip](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip) | `src\boost_1_82_0` |
+| [pcre-8.45.zip](https://pilotfiber.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip), lokal als `pcre-8.45-verified.zip` | `src\pcre-8.45` |
+
+CMake, SHA-256 aus der
+[Release-Prüfsummendatei](https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-SHA-256.txt):
+
+```text
+81aa9964dbabd71fe02e7ec50472fd3ad56138c49944515ece9001efbff8d719
+```
+
+Boost, SHA-256 aus den
+[Archivmetadaten](https://archives.boost.io/release/1.82.0/source/boost_1_82_0.zip.json):
+
+```text
+f7c9e28d242abcd7a2c1b962039fcdd463ca149d1883c3a950bbcc0ce6f7c6d9
+```
+
+PCRE, SHA-512 abgeglichen mit dem
+[vcpkg-Port](https://github.com/microsoft/vcpkg/blob/master/ports/pcre/portfile.cmake)
+zum Installationszeitpunkt; vcpkg selbst wurde nicht benötigt oder installiert:
+
+```text
+71f246c0abbf356222933ad1604cab87a1a2a3cd8054a0b9d6deb25e0735ce9f40f923d14cbd21f32fdac7283794270afcb0f221ad24662ac35934fcb73675cd
+```
+
+Zum Prüfen und Entpacken beispielsweise:
+
+```powershell
+Get-FileHash -Algorithm SHA512 -LiteralPath 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip'
+# Nur bei Übereinstimmung mit dem oben dokumentierten Hash:
+& 'C:\Users\mario\scoop\shims\7z.exe' x 'C:\Users\mario\od-deps\downloads\pcre-8.45-verified.zip' '-oC:\Users\mario\od-deps\src'
+```
+
+Für CMake und Boost `SHA256` verwenden; CMake nach `tools`, Boost nach `src`
+entpacken. Ein früherer PCRE-Download namens `pcre-8.45.zip` enthält HTML und
+ist kein verwendbares Archiv; die geprüfte Datei trägt den Zusatz `-verified`.
+
+## Bibliotheken neu bauen, falls erforderlich
+
+Die Skripte wurden aus der erfolgreichen Einrichtung übernommen und erwarten die
+oben vorbereiteten Quellen und Werkzeuge; sie laden selbst keine Quellen herunter.
+Sie konfigurieren, bauen und installieren ins gemeinsame Präfix `od-deps\install`.
+Release und Debug werden jeweils nacheinander gebaut.
+
+Aus dem Projektstamm, bei einem notwendigen vollständigen Neuaufbau:
+
+```powershell
+Set-Location -LiteralPath 'C:\Users\mario\GitHub\OpenDungeonsPlus'
+$taskInstallScripts = @(
+    'install-base-prereqs.ps1'
+    'install-boost-prereq.ps1'
+    'install-ogre-prereq.ps1'
+    'install-cegui-prereq.ps1'
+)
+foreach ($taskInstallScript in $taskInstallScripts) {
+    $taskScriptPath = Join-Path $PWD.Path "scripts\win32\$taskInstallScript"
+    & powershell.exe -NoProfile -File $taskScriptPath
+    if ($LASTEXITCODE -ne 0) { throw "Installation fehlgeschlagen: $taskInstallScript" }
+}
+```
+
+Die separaten PowerShell-Prozesse halten die Verzeichnis- und Umgebungsänderungen
+des Boost-Skripts aus der aufrufenden Sitzung heraus; Fehler beenden die Reihenfolge.
+
+| Skript | Zuständigkeit / Reihenfolge |
+| --- | --- |
+| [install-base-prereqs.ps1](../../scripts/win32/install-base-prereqs.ps1) | Expat, OIS, SFML, danach FreeType, pybind11, PCRE; bei gezieltem Bedarf filterbar mit `-Only` |
+| [install-boost-prereq.ps1](../../scripts/win32/install-boost-prereq.ps1) | Boost-Buildwerkzeug und Bibliotheken; erzeugt `od-deps\boost-user-config.jam` |
+| [install-ogre-prereq.ps1](../../scripts/win32/install-ogre-prereq.ps1) | OGRE mit GL3Plus und den benötigten Komponenten |
+| [install-cegui-prereq.ps1](../../scripts/win32/install-cegui-prereq.ps1) | CEGUI mit OgreRenderer und Expat, nach OGRE und den Basisbibliotheken |
+
+Danach den Starthelfer laden und das Spiel nach [BUILDING.md](BUILDING.md)
+konfigurieren; ein Bibliotheksbuild allein belegt keinen erfolgreichen Spielbuild.
+Logs liegen unter `od-deps\logs`; jeder erneute Skriptlauf ersetzt seine Logs.
+
+## Behobene Installationsprobleme erhalten
+
+- **SFML / FreeType:** SFML installiert eine alte mitgelieferte statische
+  `freetype.lib` über die selbst gebaute Datei im gemeinsamen Präfix; das führte
+  beim Linken von OgreOverlay zu `sprintf` / `LNK2019`.
+  Deshalb FreeType nach SFML installieren; diese Reihenfolge steht im Basisskript.
+  Die endgültige Datei wurde per Hash mit dem eigenen FreeType-Build abgeglichen.
+- **Boost / Compilerinitialisierung:** Die automatische Suche verwendete einen
+  falschen Pfad zu `vcvarsall.bat`. Das Skript erzeugt deshalb eine Jam-Konfiguration
+  mit dem tatsächlich gefundenen `cl.exe` und
+  `VC\Auxiliary\Build\vcvarsall.bat`, verwendet `--user-config`, `--reconfigure`
+  sowie `architecture=x86 address-model=64` für den x64-Build.
+- **MSVC-Optionen:** OGRE und CEGUI verwenden
+  `/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4`; `/EHsc` beim Anpassen der Parallelität
+  erhalten. OGRE verwendet vorkompilierte Header und
+  `OGRE_BUILD_MSVC_MP=OFF`, da `/MP4` bereits explizit gesetzt ist.
+- **PCRE-Download:** Den HTML-Fehldownload nicht erneut verwenden; Archiv und Hash
+  sind oben eindeutig festgehalten.
+- **Paketierung:** Die alte Windows-Paketlogik findet einige Boost-DLL-Namen nicht,
+  obwohl CMake die Linkbibliotheken findet; Paketierung und Laufzeit bleiben
+  ungeprüft, siehe [aktueller Status](WINDOWS-DEV-SETUP.md).
+
+Die Dependency-Quellen wurden für diese Lösungen nicht gepatcht; die konkreten
+CMake- und Boost-Optionen stehen vollständig in den übernommenen Skripten.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -1,0 +1,90 @@
+# Windows startup failures and verification
+
+As of September 5, 2026, the user confirmed that the Release executable starts
+directly without errors. This result is supported by the runtime evidence below,
+in addition to successful builds and static DLL checks.
+See [BUILDING.md](BUILDING.md) for the executable and runtime setup.
+
+## Runtime files and generated resource configuration
+
+The initial build directory contained no dependency DLLs, while `plugins.cfg`
+loads OGRE plugins from that directory. The maintained
+[runtime preparation script](../../scripts/win32/prepare-windows-runtime.ps1)
+now stages the Release DLLs, including the dynamically loaded OGRE and CEGUI
+modules, and configures the existing Python installation's module paths.
+
+The generated `resources.cfg` initially pointed at
+`build/windows/install/share/OGRE/Media`, although the installed Windows OGRE
+media is under `C:\Users\mario\od-deps\install\Media`. The script corrects those
+paths and excludes the shader subdirectories absent from this OGRE installation.
+Both standalone preparation and preparation through the configuration script
+completed successfully; the copied DLL hashes match their installed sources.
+
+The static report `build/windows/runtime-validation.json` checked the Release
+executable and 22 DLLs, four OGRE plugins and 14 resource directories. It found
+no missing imported DLLs or architecture mismatches, but did not execute the
+resource-loading code and therefore did not detect the path error below.
+
+## Absolute Windows resource paths were prefixed with the game directory
+
+The user's 14:00 startup reached OGRE and its OpenGL 3+ renderer, but reported
+that `OgreUnifiedShader.h` could not be found in the Graphics resource group.
+Cloud2, DirtInstanced, Fog and ReflMetal shader/material errors followed.
+
+The actual paths in both the game and OGRE logs were malformed, for example:
+
+```text
+./C:/Users/mario/od-deps/install/Media/Main
+```
+
+In [ResourceManager.cpp](../../source/utils/ResourceManager.cpp),
+`setupOgreResources` treated a path as absolute only if it began with `/`.
+It therefore prefixed valid drive-qualified Windows paths with `./`, even though
+the configured directories and `OgreUnifiedShader.h` existed on disk.
+The condition now uses the existing Boost filesystem path API's `is_absolute()`
+check, preserving absolute paths and continuing to prefix relative game paths.
+
+The original runtime evidence is retained locally in:
+
+- `build/windows/startup-before-path-fix-Ogre.log`.
+- `build/windows/startup-before-path-fix-game.log`.
+
+Both binaries were rebuilt successfully after this correction:
+
+- `build/windows/game-Release-startup-path-fix.log`, exit code 0.
+- `build/windows/game-Debug-startup-path-fix.log`, exit code 0.
+
+The Release executable was replaced with the corrected build. A subsequent run
+from 14:07:36 to 14:07:52 registered the absolute OGRE media paths correctly,
+initialized CEGUI and its skin, loaded the main-menu scene, rendered its materials
+and followed the normal shutdown path. The earlier missing-resource and material
+errors are absent from the new OGRE, game and CEGUI logs.
+The game reached the normal post-render-loop disconnect and shutdown statements
+in `ODApplication.cpp`; these are not reached by an exception unwinding that loop.
+
+The preserved post-fix evidence is:
+
+- `build/windows/startup-after-path-fix-Ogre.log`.
+- `build/windows/startup-after-path-fix-game.log`.
+- `build/windows/startup-after-path-fix-CEGUI.log`.
+- `build/windows/startup-path-fix-validation.json`, including the checked binary's SHA-256.
+
+These logs verify the resource-path fix during an actual startup. Existing shader
+extension, shader-version and deprecated material-syntax warnings remain; no
+warnings were disabled. The user subsequently confirmed error-free startup on
+September 5, 2026, completing the verification of the direct Release startup.
+
+## Build process note
+
+The sandboxed process environment supplied both `Path` and `PATH`, causing the
+Visual Studio environment helper and MSBuild to reject the duplicate dictionary
+key before compilation. Running the same build in the approved normal process
+environment succeeded; no system environment setting was changed.
+
+## Verified outcome and remaining scope
+
+The direct Release startup objective is complete: the user confirmed error-free
+startup and the runtime logs verify that the earlier loading failures are gone.
+Broader gameplay and visual QA remain with the user; Debug runtime staging and
+packaging remain separate, unverified work. The game version remains 0.7.1;
+no release has been published.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -3,6 +3,8 @@
 As of September 5, 2026, the user confirmed that the Release executable starts
 directly without errors. This result is supported by the runtime evidence below,
 in addition to successful builds and static DLL checks.
+That confirmation preceded enabling dynamic shadows; the resulting startup
+failure and its resource-group correction are documented below.
 See [BUILDING.md](BUILDING.md) for the executable and runtime setup.
 
 ## Runtime files and generated resource configuration
@@ -74,6 +76,59 @@ extension, shader-version and deprecated material-syntax warnings remain; no
 warnings were disabled. The user subsequently confirmed error-free startup on
 September 5, 2026, completing the verification of the direct Release startup.
 
+## Enabling dynamic shadows prevented subsequent startup
+
+At 14:24:35 on September 5, 2026, the settings handler saved `Dynamic Shadows=Yes`
+and explicitly called `exit(0)`. The preceding run reached the main menu at
+3440 x 1440 fullscreen with shadows disabled. The subsequent attempts at 14:24:38,
+14:24:41 and 14:27:21 failed before CEGUI initialization with shadows enabled.
+The abrupt exit on saving is existing behavior in
+[SettingsWindow.cpp](../../source/modes/SettingsWindow.cpp); the failure on the
+next startup is a separate resource-loading bug.
+
+[RenderManager.cpp](../../source/render/RenderManager.cpp) enables texture shadows
+during construction. OGRE 13.6.5 then looks up its four shadow-extrusion programs
+through `OgreInternal`. The installed library uses
+`OGRE_RESOURCEMANAGER_STRICT=2`, but the generated configuration registered
+`Media/Main` only in the isolated `Graphics` group. The files were parsed there,
+yet the internal lookup could not find them. The DLL and shader files exist;
+this failure does not require reinstalling dependencies.
+
+The [resource template](../../cmake/config/resources.cfg.in) now also registers
+the same `Media/Main` directory under `OgreInternal`. Its existing `Graphics`
+registration is deliberately retained: game shaders include `OgreUnifiedShader.h`
+using strict group-local file lookup. Moving the directory out of `Graphics`
+would reintroduce missing-header errors. The two resource pools remain separate;
+no dependency files, user settings or game C++ sources are changed.
+The maintained Windows configuration script regenerates the template and resolves
+both entries to the existing local OGRE installation.
+
+The preserved evidence under `build/windows` is:
+
+- `startup-shadow-setting-change-game.log`: successful startup with shadows off,
+  followed by the explicit exit after saving the shadow setting.
+- `startup-before-shadow-fix-Ogre.log` and `startup-before-shadow-fix-game.log`:
+  the failed startup with shadows enabled.
+- `shadow-resources-before.cfg`: the original resource-group assignment.
+- `shadow-resource-probe.cpp`: an isolated check using the installed OGRE DLL and
+  its own script parser, without creating a renderer or game window.
+- `shadow-probe-before.log`: all four internal shadow lookups fail, exit code 1;
+  the game shader header remains accessible.
+- `shadow-probe-after.log`: all four internal shadow lookups and their source-file
+  loads succeed, and the game shader header remains accessible, exit code 0.
+- `shadow-resource-validation.json`: configuration, probe and unchanged executable
+  evidence, with actual game startup explicitly marked as pending.
+
+The probe checks resource registration, program lookup and source-file loading;
+without a renderer, OGRE uses null shader programs, so it does not verify shader
+compilation or rendering. The maintained Windows configuration script succeeded
+and prepared the corrected configuration beside the existing Release executable.
+The user configuration still enables dynamic shadows at 3440 x 1440 fullscreen.
+The executable is unchanged, so no C++ rebuild is required for this template-only
+fix. The game version remains 0.7.1; the root README already links to this startup
+record, and no separate release changelog entry is needed for this unreleased fix.
+The user's actual game startup with shadows enabled is still pending.
+
 ## Build process note
 
 The sandboxed process environment supplied both `Path` and `PATH`, causing the
@@ -83,8 +138,9 @@ environment succeeded; no system environment setting was changed.
 
 ## Verified outcome and remaining scope
 
-The direct Release startup objective is complete: the user confirmed error-free
-startup and the runtime logs verify that the earlier loading failures are gone.
+The earlier resource-path fix was verified by the user's error-free startup.
+The later dynamic-shadow resource-group correction still requires the checks
+described above; do not treat the earlier confirmation as verification of shadows.
 Broader gameplay and visual QA remain with the user; Debug runtime staging and
 packaging remain separate, unverified work. The game version remains 0.7.1;
 no release has been published.

--- a/docs/development/WINDOWS-STARTUP-FIXES.md
+++ b/docs/development/WINDOWS-STARTUP-FIXES.md
@@ -117,7 +117,7 @@ The preserved evidence under `build/windows` is:
 - `shadow-probe-after.log`: all four internal shadow lookups and their source-file
   loads succeed, and the game shader header remains accessible, exit code 0.
 - `shadow-resource-validation.json`: configuration, probe and unchanged executable
-  evidence, with actual game startup explicitly marked as pending.
+  evidence from before the user's subsequent startup attempt.
 
 The probe checks resource registration, program lookup and source-file loading;
 without a renderer, OGRE uses null shader programs, so it does not verify shader
@@ -127,7 +127,98 @@ The user configuration still enables dynamic shadows at 3440 x 1440 fullscreen.
 The executable is unchanged, so no C++ rebuild is required for this template-only
 fix. The game version remains 0.7.1; the root README already links to this startup
 record, and no separate release changelog entry is needed for this unreleased fix.
-The user's actual game startup with shadows enabled is still pending.
+The user's subsequent 14:52:23 run had shadows enabled and reached CEGUI and the
+main-menu scene at 14:52:24, confirming that the blocking shadow-program lookup is
+resolved during actual startup. A later failure while entering a level is tracked
+separately below; shadow appearance and broader gameplay remain unverified.
+
+## Legacy test-map exception after successful startup
+
+The same user-launched run selected
+`levels/skirmish/TestLegacyNoScripts.level` at 14:52:53. Client/server setup
+completed, the client was accepted at 14:52:55 and the server started its first
+turn at 14:52:58. The frame listener then began destruction without reaching the
+normal post-render-loop `Disconnecting client...` message in `ODApplication.cpp`.
+CEGUI and OGRE subsequently shut down. This identifies exception unwinding after
+entering the level, but the existing logs do not contain the exception text.
+
+The logs contain rejected legacy skills, missing mesh material assignments and
+server-side attempts to rotate objects without rendering nodes. These messages
+precede further execution and do not by themselves identify the fatal exception;
+none has been changed speculatively.
+
+The diagnostic gap is in the exception path: `startGame` owns the file logger,
+which was destroyed before `main.cpp` displayed caught exceptions in a Windows
+dialog. [ODApplication.cpp](../../source/ODApplication.cpp) now logs
+`std::exception::what()` while that logger remains alive, then rethrows the same
+exception to preserve the existing dialog and exit behavior. This covers OGRE,
+CEGUI and standard C++ exceptions; it is diagnostic instrumentation, not a claim
+that the gameplay failure is fixed.
+
+Both diagnostic builds, Release and Debug, completed successfully with exit code 0:
+`build/windows/game-Release-exception-diagnostics.log` and
+`build/windows/game-Debug-exception-diagnostics.log`.
+The pre-change logs are preserved as `build/windows/legacy-crash-before-Ogre.log`,
+`legacy-crash-before-game.log` and `legacy-crash-before-CEGUI.log`.
+
+### Captured cause and correction
+
+The user's diagnostic run reached the main menu at 15:05:03 and selected the same
+map at 15:05:11. At 15:05:19, the added logging captured an
+`Ogre::InvalidStateException` before the dialog:
+
+```text
+RenderSystem does not support FixedFunction, but technique of 'DirtInstanced'
+has no Fragment Shader. Use the RTSS or write custom shaders.
+```
+
+The exception originates in OGRE 13.6.5's `SceneManager::_setPass`,
+`OgreMain/src/OgreSceneManager.cpp:935`, in the installed dependency source tree.
+The captured logs are preserved under `build/windows` as
+`legacy-crash-diagnostic-Ogre.log`, `legacy-crash-diagnostic-game.log` (line 897)
+and `legacy-crash-diagnostic-CEGUI.log`.
+
+The original [DirtInstanced material](../../materials/scripts/DirtInstanced.material)
+already defines both a vertex and a fragment program. The missing program is on
+a derived pass: the game enabled `SHADOWTYPE_TEXTURE_ADDITIVE`, causing OGRE to
+split opaque material passes into ambient, per-light and decal stages. In
+`OgreTechnique.cpp`, this automatic splitting clears fragment programs on derived
+ambient and per-light passes. GL3Plus cannot draw these fixed-function passes.
+The material is used by the instanced unrevealed ground tiles created when the
+level starts, explaining why startup could succeed before entering the map.
+
+[RenderManager.cpp](../../source/render/RenderManager.cpp) now uses
+`SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED`. This keeps texture-shadow generation
+enabled while retaining the existing custom lighting/shadow shader passes instead
+of generating incompatible illumination passes. The game's shaders already
+calculate lighting and sample shadow maps; this matches OGRE's documented
+[integrated texture-shadow mode](https://ogrecave.github.io/ogre/api/13/_shadows.html#Integrated-Texture-Shadows).
+The shadow toggle, material definitions and user configuration are unchanged.
+
+### Verification
+
+- The user's reproduction verified that exception logging records the actual
+  fatal error before the existing Windows dialog.
+- `build/windows/illumination-pass-probe.cpp` exercises the installed OGRE DLL's
+  real material-pass splitting and render queue, without a renderer or game
+  window. Its representative programmable pass has the same default lighting,
+  ambient and diffuse state as DirtInstanced; it uses null shader programs and
+  no textures. The queue flags follow `SceneManager::updateRenderQueueSplitOptions`.
+- `illumination-pass-additive.log`: two queued passes, both missing their fragment
+  programs, exit code 1.
+- `illumination-pass-integrated.log`: one unchanged original pass with its fragment
+  program, exit code 0. `illumination-pass-off.log` also passes, exit code 0.
+- Release and Debug rebuilt successfully, exit code 0, with logs in
+  `game-Release-integrated-shadows.log` and `game-Debug-integrated-shadows.log`.
+  The Release executable was rebuilt at 15:17:22 and Debug at 15:17:29.
+  Binary hashes and test scope are recorded in `integrated-shadow-validation.json`.
+
+These checks verify the identified pass-generation failure and successful builds;
+they do not compile the actual GLSL on the GPU or verify the rendered scene.
+The user must launch the rebuilt Release executable and enter
+`TestLegacyNoScripts.level` again with dynamic shadows enabled, then check both
+stability and lighting/shadow appearance. This correction is ready for that test;
+the actual gameplay result and shadow coverage remain unverified.
 
 ## Build process note
 
@@ -139,8 +230,12 @@ environment succeeded; no system environment setting was changed.
 ## Verified outcome and remaining scope
 
 The earlier resource-path fix was verified by the user's error-free startup.
-The later dynamic-shadow resource-group correction still requires the checks
-described above; do not treat the earlier confirmation as verification of shadows.
+The later dynamic-shadow resource-group correction passed the isolated resource
+check and the user's subsequent main-menu startup with shadows enabled.
+The separate Legacy test-map exception was captured and traced to automatic
+illumination-pass splitting; the integrated shadow-mode correction passed the
+isolated OGRE pass test and both builds. Verification in the user's game session
+is still pending.
 Broader gameplay and visual QA remain with the user; Debug runtime staging and
 packaging remain separate, unverified work. The game version remains 0.7.1;
 no release has been published.

--- a/materials/scripts/Arena.material
+++ b/materials/scripts/Arena.material
@@ -24,6 +24,7 @@ fragment_program myArenaFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/ChickenCoop.material
+++ b/materials/scripts/ChickenCoop.material
@@ -24,6 +24,7 @@ fragment_program myChickenCoopFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Claimed.material
+++ b/materials/scripts/Claimed.material
@@ -24,6 +24,7 @@ fragment_program myClaimedTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour  
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Claimed2.material
+++ b/materials/scripts/Claimed2.material
@@ -24,6 +24,7 @@ fragment_program myClaimed2TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Creatures/Adventurer.material
+++ b/materials/scripts/Creatures/Adventurer.material
@@ -24,6 +24,7 @@ fragment_program myAdventurerFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetBody.material
+++ b/materials/scripts/Creatures/CaveHornetBody.material
@@ -24,6 +24,7 @@ fragment_program myCaveHornetBodyFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetWings.material
+++ b/materials/scripts/Creatures/CaveHornetWings.material
@@ -24,6 +24,7 @@ fragment_program myCaveHornetWingsFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Cultist.material
+++ b/materials/scripts/Creatures/Cultist.material
@@ -24,6 +24,7 @@ fragment_program myCultistFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0  
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/DarkElf.material
+++ b/materials/scripts/Creatures/DarkElf.material
@@ -24,6 +24,7 @@ fragment_program myDarkElfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Defender.material
+++ b/materials/scripts/Creatures/Defender.material
@@ -24,6 +24,7 @@ fragment_program myDefenderFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dragon.material
+++ b/materials/scripts/Creatures/Dragon.material
@@ -24,6 +24,7 @@ fragment_program myDragonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf1.material
+++ b/materials/scripts/Creatures/Dwarf1.material
@@ -24,6 +24,7 @@ fragment_program myDwarf1FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf2.material
+++ b/materials/scripts/Creatures/Dwarf2.material
@@ -24,6 +24,7 @@ fragment_program myDwarf2FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Elf.material
+++ b/materials/scripts/Creatures/Elf.material
@@ -24,6 +24,7 @@ fragment_program myElfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Gnome.material
+++ b/materials/scripts/Creatures/Gnome.material
@@ -24,6 +24,7 @@ fragment_program myGnomeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Goblin.material
+++ b/materials/scripts/Creatures/Goblin.material
@@ -24,6 +24,7 @@ fragment_program myGoblinFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Knight.material
+++ b/materials/scripts/Creatures/Knight.material
@@ -24,6 +24,7 @@ fragment_program myKnightFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kobold.material
+++ b/materials/scripts/Creatures/Kobold.material
@@ -24,6 +24,7 @@ fragment_program myKoboldFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kreatur.material
+++ b/materials/scripts/Creatures/Kreatur.material
@@ -24,6 +24,7 @@ fragment_program myKreaturFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/LavaSpawn.material
+++ b/materials/scripts/Creatures/LavaSpawn.material
@@ -24,6 +24,7 @@ fragment_program myLavaSpawnFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Lizardman.material
+++ b/materials/scripts/Creatures/Lizardman.material
@@ -24,6 +24,7 @@ fragment_program myLizardmanFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Monk.material
+++ b/materials/scripts/Creatures/Monk.material
@@ -24,6 +24,7 @@ fragment_program myMonkFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/NatureMonster.material
+++ b/materials/scripts/Creatures/NatureMonster.material
@@ -24,6 +24,7 @@ fragment_program myNatureMonsterFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Orc.material
+++ b/materials/scripts/Creatures/Orc.material
@@ -24,6 +24,7 @@ fragment_program myOrcFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/PitDemon.material
+++ b/materials/scripts/Creatures/PitDemon.material
@@ -20,6 +20,7 @@ fragment_program myPitDemonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Rat.material
+++ b/materials/scripts/Creatures/Rat.material
@@ -24,6 +24,7 @@ fragment_program myRatFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Roach.material
+++ b/materials/scripts/Creatures/Roach.material
@@ -24,6 +24,7 @@ fragment_program myRoachFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/RunelordDwarf.material
+++ b/materials/scripts/Creatures/RunelordDwarf.material
@@ -24,6 +24,7 @@ fragment_program myRunelordDwarfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Scarab.material
+++ b/materials/scripts/Creatures/Scarab.material
@@ -24,6 +24,7 @@ fragment_program myScarabFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Slime.material
+++ b/materials/scripts/Creatures/Slime.material
@@ -24,6 +24,7 @@ fragment_program mySlimeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Spider.material
+++ b/materials/scripts/Creatures/Spider.material
@@ -24,6 +24,7 @@ fragment_program mySpiderFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleAlbine.material
+++ b/materials/scripts/Creatures/TentacleAlbine.material
@@ -24,6 +24,7 @@ fragment_program myTentacleAlbineFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleGreen.material
+++ b/materials/scripts/Creatures/TentacleGreen.material
@@ -24,6 +24,7 @@ fragment_program myTentacleGreenFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Troll.material
+++ b/materials/scripts/Creatures/Troll.material
@@ -24,6 +24,7 @@ fragment_program myTrollFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wizard.material
+++ b/materials/scripts/Creatures/Wizard.material
@@ -24,6 +24,7 @@ fragment_program myWizardFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wyvern.material
+++ b/materials/scripts/Creatures/Wyvern.material
@@ -24,6 +24,7 @@ fragment_program myWyvernFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/undead Army.material
+++ b/materials/scripts/Creatures/undead Army.material
@@ -24,6 +24,7 @@ fragment_program myundeadFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Crypt.material
+++ b/materials/scripts/Crypt.material
@@ -24,6 +24,7 @@ fragment_program myCryptFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/DCW0000.material
+++ b/materials/scripts/DCW0000.material
@@ -24,6 +24,7 @@ fragment_program myDCW0000TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position 
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0100.material
+++ b/materials/scripts/DCW0100.material
@@ -24,6 +24,7 @@ fragment_program myDCW0100TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0101.material
+++ b/materials/scripts/DCW0101.material
@@ -24,6 +24,7 @@ fragment_program myDCW0101TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position  
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0110.material
+++ b/materials/scripts/DCW0110.material
@@ -25,6 +25,7 @@ fragment_program myDCW0110TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW1110.material
+++ b/materials/scripts/DCW1110.material
@@ -24,6 +24,7 @@ fragment_program myDCW1110TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW1111.material
+++ b/materials/scripts/DCW1111.material
@@ -25,6 +25,7 @@ source DCW.frag
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0           

--- a/materials/scripts/Dirt.material
+++ b/materials/scripts/Dirt.material
@@ -10,6 +10,7 @@ vertex_program myDirtTileVertexShader glsl
         param_named_auto worldMatrix world_matrix
         param_named_auto projectionMatrix projection_matrix          
         param_named_auto viewMatrix view_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
     }
   
 }
@@ -23,8 +24,10 @@ fragment_program myDirtTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
+        param_named shadowingEnabled bool false
     }
 }
 
@@ -45,7 +48,8 @@ material Dirt //: RTSS/NormalMapping_MultiPass
             fragment_program_ref myDirtTileFragmentShader
             { 
                 param_named decalmap int 0
-                param_named normalmap int 1     
+                param_named normalmap int 1
+                param_named shadowmap int 2
             }            
             
             
@@ -58,6 +62,13 @@ material Dirt //: RTSS/NormalMapping_MultiPass
             texture_unit normalmap
             {
                 texture DirtNormal.png               
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
         }
 

--- a/materials/scripts/DirtInstanced.material
+++ b/materials/scripts/DirtInstanced.material
@@ -24,6 +24,7 @@ fragment_program myDirtInstancedTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named shadowingEnabled bool false         

--- a/materials/scripts/Dojo.material
+++ b/materials/scripts/Dojo.material
@@ -24,6 +24,7 @@ fragment_program myDojoFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named shadowingEnabled bool false  
     }

--- a/materials/scripts/Dormitory.material
+++ b/materials/scripts/Dormitory.material
@@ -24,6 +24,7 @@ fragment_program myDormitoryFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1011.material
+++ b/materials/scripts/Dormitory1011.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1100.material
+++ b/materials/scripts/Dormitory1100.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1111.material
+++ b/materials/scripts/Dormitory1111.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1111FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Farm.material
+++ b/materials/scripts/Farm.material
@@ -24,6 +24,7 @@ fragment_program myFarmFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm0000.material
+++ b/materials/scripts/Farm0000.material
@@ -24,6 +24,7 @@ fragment_program myFarm0000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1000.material
+++ b/materials/scripts/Farm1000.material
@@ -24,6 +24,7 @@ fragment_program myFarm1000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1010.material
+++ b/materials/scripts/Farm1010.material
@@ -24,6 +24,7 @@ fragment_program myFarm1010FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1011.material
+++ b/materials/scripts/Farm1011.material
@@ -24,6 +24,7 @@ fragment_program myFarm1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1100.material
+++ b/materials/scripts/Farm1100.material
@@ -24,6 +24,7 @@ fragment_program myFarm1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Forge.material
+++ b/materials/scripts/Forge.material
@@ -24,6 +24,7 @@ fragment_program myForgeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Gold.material
+++ b/materials/scripts/Gold.material
@@ -9,6 +9,7 @@ vertex_program myVertexShader glsl
         param_named_auto projectionMatrix projection_matrix
         param_named_auto viewMatrix view_matrix
         param_named_auto worldMatrix world_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
         param_named height float 0.0
     }
   
@@ -23,8 +24,10 @@ fragment_program myFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
+        param_named shadowingEnabled bool false
     }
 }
 
@@ -47,6 +50,7 @@ material Gold //: RTSS/NormalMapping_MultiPass
             { 
                 param_named decalmap int 0
                 param_named normalmap int 1
+                param_named shadowmap int 2
             }
  
             texture_unit 
@@ -58,6 +62,13 @@ material Gold //: RTSS/NormalMapping_MultiPass
             {
                 texture GoldNormal.png
 
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
             
             

--- a/materials/scripts/GoldGround.material
+++ b/materials/scripts/GoldGround.material
@@ -11,6 +11,7 @@ vertex_program myGoldGroundVertexShader glsl
         param_named_auto projectionMatrix projection_matrix
         param_named_auto viewMatrix view_matrix
         param_named_auto worldMatrix world_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
     }
   
 }
@@ -24,7 +25,9 @@ fragment_program myGoldGroundFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
+        param_named shadowingEnabled bool false
         
     }
 }
@@ -47,6 +50,7 @@ material GoldGround //: RTSS/NormalMapping_MultiPass
             { 
                 param_named decalmap int 0
                 param_named normalmap int 1
+                param_named shadowmap int 2
             }            
             
             
@@ -59,6 +63,13 @@ material GoldGround //: RTSS/NormalMapping_MultiPass
             texture_unit normalmap
             {
                 texture DirtNormal.png               
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
         }
 

--- a/materials/scripts/Library.material
+++ b/materials/scripts/Library.material
@@ -24,6 +24,7 @@ fragment_program myLibraryFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0000.material
+++ b/materials/scripts/Library0000.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0001.material
+++ b/materials/scripts/Library0001.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0001FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0101.material
+++ b/materials/scripts/Library0101.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0101FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1011.material
+++ b/materials/scripts/Library1011.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1100.material
+++ b/materials/scripts/Library1100.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1111.material
+++ b/materials/scripts/Library1111.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1111FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Prison.material
+++ b/materials/scripts/Prison.material
@@ -24,6 +24,7 @@ fragment_program myPrisonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Rock.material
+++ b/materials/scripts/Rock.material
@@ -25,6 +25,7 @@ fragment_program myRockFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Steel.material
+++ b/materials/scripts/Steel.material
@@ -24,6 +24,7 @@ fragment_program mySteelFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/StoneBridge.material
+++ b/materials/scripts/StoneBridge.material
@@ -23,6 +23,7 @@ fragment_program myStoneBridgeTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/WoodBridge.material
+++ b/materials/scripts/WoodBridge.material
@@ -24,6 +24,7 @@ fragment_program myWoodBridgeTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/Workshop.material
+++ b/materials/scripts/Workshop.material
@@ -24,6 +24,7 @@ fragment_program myWorkshopFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -14,3 +14,4 @@ $ErrorActionPreference = 'Continue'
 $ErrorActionPreference = 'Stop'
 if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
 Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,6 +1,15 @@
 $ErrorActionPreference = 'Stop'
 $taskRoot = 'C:\Users\mario\od-deps'
 $taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
     "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/shaders/ClaimedTile.frag
+++ b/shaders/ClaimedTile.frag
@@ -1,4 +1,7 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -33,14 +36,8 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
-    if(shadowingEnabled){
-        // compute shadowmap
-        if(tmpVertexPos.z > 0.00001 ){
-            tmpVertexPos /= tmpVertexPos.w;
-            shadow = texture(shadowmap, tmpVertexPos.xy); 
-        }
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     // compute lightDir
     vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
@@ -62,7 +59,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 ) *shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.05)

--- a/shaders/ClaimedTile.vert
+++ b/shaders/ClaimedTile.vert
@@ -53,7 +53,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
-    vec4 P_prim = inverse(worldMatrix) * P4;
+    vec4 P_prim = inverse(worldMatrix) * vec4(P, 1.0);
     VertexPos = lightMatrix * P_prim;    
  
     out_UV0 = uv_0;

--- a/shaders/Creature.frag
+++ b/shaders/Creature.frag
@@ -1,5 +1,7 @@
 #version 330  core
-#define epsilon 0.00001
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
@@ -29,15 +31,10 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > epsilon ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
     // compute lightDir
@@ -59,7 +56,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb * ambient )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb * ambient;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/DCW.frag
+++ b/shaders/DCW.frag
@@ -1,4 +1,7 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -33,15 +36,10 @@ void main (void)
     
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > 0 ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     // compute lightDir
     vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
     
@@ -61,7 +59,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 ) * shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.00005)

--- a/shaders/DCW.vert
+++ b/shaders/DCW.vert
@@ -52,7 +52,7 @@ void main() {
     
     FragPos = P;
     
-    vec4 P_prim = inverse(worldMatrix) * P4;
+    vec4 P_prim = inverse(worldMatrix) * vec4(P, 1.0);
     VertexPos = lightMatrix * P_prim;
  
  

--- a/shaders/DirtTile.frag
+++ b/shaders/DirtTile.frag
@@ -1,8 +1,12 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
+uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
 uniform vec4 lightDiffuseColour; 
@@ -14,6 +18,7 @@ uniform bool shadowingEnabled;
 in vec2 out_UV0;
 in vec2 out_UV1;
 in vec3 FragPos;
+in vec4 VertexPos;
 in mat3 TBN;
  
 out vec4 color;
@@ -27,6 +32,8 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
         
     // compute lightDir
@@ -48,7 +55,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/DirtTile.vert
+++ b/shaders/DirtTile.vert
@@ -20,6 +20,7 @@ out vec2 out_UV0;
 out vec2 out_UV1;
 
 out vec3 FragPos;
+out vec4 VertexPos;
 
  
 out mat3 TBN;
@@ -52,6 +53,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
+    VertexPos = lightMatrix * vec4(P, 1.0);
  
     out_UV0 = uv_0;
     out_UV1 = uv_1;

--- a/shaders/DirtTileInstanced.frag
+++ b/shaders/DirtTileInstanced.frag
@@ -1,4 +1,6 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -62,7 +64,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/GoldDistortion.frag
+++ b/shaders/GoldDistortion.frag
@@ -1,8 +1,12 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
+uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
 uniform vec4 lightDiffuseColour; 
@@ -14,6 +18,7 @@ uniform bool shadowingEnabled;
 in vec2 out_UV0;
 in vec2 out_UV1;
 in vec3 FragPos;
+in vec4 VertexPos;
 in mat3 TBN;
  
 out vec4 color;
@@ -46,7 +51,10 @@ void main (void)
     
     
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 );
+    vec4 shadow = vec4(1.0);
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     if(diffuseSurface.rgb != vec3(1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);

--- a/shaders/GoldDistortion.vert
+++ b/shaders/GoldDistortion.vert
@@ -7,6 +7,7 @@
 uniform    mat4 projectionMatrix;
 uniform    mat4 viewMatrix;
 uniform    mat4 worldMatrix;
+uniform    mat4 lightMatrix;
 uniform    float height;
 layout (location = 0) in vec4 position;
 layout (location = 2)  in vec3 normal;
@@ -17,6 +18,7 @@ layout (location = 8) in vec2 uv_1;
 out vec2 out_UV0;
 out vec2 out_UV1; 
 out vec3 FragPos;
+out vec4 VertexPos;
  
 out mat3 TBN;
  
@@ -49,6 +51,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
+    VertexPos = lightMatrix * vec4(P, 1.0);
  
     out_UV0 = uv_0;
     out_UV1 = uv_1;

--- a/shaders/LightAttenuation.glsl
+++ b/shaders/LightAttenuation.glsl
@@ -1,0 +1,14 @@
+uniform vec4 lightAttenuation;
+
+float getLightAttenuation(vec4 lightPosition, vec3 surfacePosition)
+{
+    // Directional lights have no distance falloff.
+    if(lightPosition.w == 0.0)
+        return 1.0;
+
+    float distance = length(lightPosition.xyz - surfacePosition);
+    if(distance > lightAttenuation.x)
+        return 0.0;
+
+    return 1.0 / dot(lightAttenuation.yzw, vec3(1.0, distance, distance * distance));
+}

--- a/shaders/Room.frag
+++ b/shaders/Room.frag
@@ -1,5 +1,7 @@
 #version 330  core
-#define epsilon 0.00001
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
@@ -28,15 +30,10 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > epsilon ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
     // compute lightDir
@@ -58,7 +55,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/Room.vert
+++ b/shaders/Room.vert
@@ -52,5 +52,5 @@ void main() {
  
     out_UV0 = uv0;
     out_UV1 = uv1;
-    VertexPos = lightMatrix * position;
+    VertexPos = lightMatrix * inverse(worldMatrix) * vec4(P, 1.0);
 }  

--- a/shaders/ShadowMapping.glsl
+++ b/shaders/ShadowMapping.glsl
@@ -1,0 +1,14 @@
+// Shadow texture coordinates have biased X/Y and OpenGL clip-space Z.
+float sampleShadow(sampler2D shadowMap, vec4 lightPosition)
+{
+    if(lightPosition.w <= 0.0)
+        return 1.0;
+
+    vec3 shadowPosition = lightPosition.xyz / lightPosition.w;
+    shadowPosition.z = shadowPosition.z * 0.5 + 0.5;
+    if(any(lessThan(shadowPosition, vec3(0.0))) || any(greaterThan(shadowPosition, vec3(1.0))))
+        return 1.0;
+
+    // Allow one depth-buffer step for the 16-bit shadow texture.
+    return step(shadowPosition.z - 1.0 / 65535.0, texture(shadowMap, shadowPosition.xy).r);
+}

--- a/shaders/ShadowMapping.glsl
+++ b/shaders/ShadowMapping.glsl
@@ -9,6 +9,6 @@ float sampleShadow(sampler2D shadowMap, vec4 lightPosition)
     if(any(lessThan(shadowPosition, vec3(0.0))) || any(greaterThan(shadowPosition, vec3(1.0))))
         return 1.0;
 
-    // Allow one depth-buffer step for the 16-bit shadow texture.
-    return step(shadowPosition.z - 1.0 / 65535.0, texture(shadowMap, shadowPosition.xy).r);
+    // Allow one depth-buffer step for the 24-bit shadow texture.
+    return step(shadowPosition.z - 1.0 / 16777215.0, texture(shadowMap, shadowPosition.xy).r);
 }

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,7 +235,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -65,6 +65,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <exception>
 
 void ODApplication::startGame(boost::program_options::variables_map& options)
 {
@@ -80,10 +81,20 @@ void ODApplication::startGame(boost::program_options::variables_map& options)
     logMgr.setLevel(resMgr.getLogLevel());
 
 
-    if(resMgr.isServerMode())
-        startServer();
-    else
-        startClient();
+    try
+    {
+        if(resMgr.isServerMode())
+            startServer();
+        else
+            startClient();
+    }
+    catch(const std::exception& error)
+    {
+        // Preserve the exception before the log manager is destroyed and main
+        // displays its Windows error dialog.
+        OD_LOG_ERR("Unhandled exception: " + std::string(error.what()));
+        throw;
+    }
 }
 
 void ODApplication::startServer()

--- a/source/render/GroundShadowCameraSetup.h
+++ b/source/render/GroundShadowCameraSetup.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 OpenDungeons Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef GROUNDSHADOWCAMERASETUP_H
+#define GROUNDSHADOWCAMERASETUP_H
+
+#include <OgreCamera.h>
+#include <OgreMovablePlane.h>
+#include <OgreShadowCameraSetupPlaneOptimal.h>
+
+// Fit point-light shadows to the visible dungeon floor, independently of the
+// main camera's near clip and the height of the hand light.
+class GroundShadowCameraSetup : public Ogre::ShadowCameraSetup
+{
+public:
+    GroundShadowCameraSetup() : mGroundPlane(Ogre::Vector3::UNIT_Z, 0.0f)
+    {
+    }
+
+    void getShadowCamera(const Ogre::SceneManager* scene, const Ogre::Camera* camera,
+        const Ogre::Viewport* viewport, const Ogre::Light* light, Ogre::Camera* shadowCamera,
+        size_t iteration) const override
+    {
+        Ogre::PlaneOptimalShadowCameraSetup setup(&mGroundPlane);
+        setup.getShadowCamera(scene, camera, viewport, light, shadowCamera, iteration);
+
+        // Ogre may use a separate default frustum to select shadow casters.
+        // It must cover the same projection; getViewMatrix() alone returns
+        // that old culling view instead of the shadow camera's own view.
+        Ogre::Frustum* cullingFrustum = shadowCamera->getCullingFrustum();
+        if(cullingFrustum != nullptr)
+        {
+            cullingFrustum->setCustomViewMatrix(true, shadowCamera->getViewMatrix(true));
+            cullingFrustum->setCustomProjectionMatrix(true, shadowCamera->getProjectionMatrix());
+        }
+    }
+
+private:
+    Ogre::MovablePlane mGroundPlane;
+};
+
+#endif

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "render/RenderManager.h"
+#include "render/GroundShadowCameraSetup.h"
 
 #include "entities/Creature.h"
 #include "entities/CreatureDefinition.h"
@@ -71,6 +72,8 @@
 #include <Overlay/OgreOverlayManager.h>
 #include <Overlay/OgreOverlaySystem.h>
 #include <RTShaderSystem/OgreShaderGenerator.h>
+#include <RTShaderSystem/OgreShaderRenderState.h>
+#include <RTShaderSystem/OgreShaderExIntegratedPSSM3.h>
 
 #include <sstream>
 #include <string>
@@ -120,44 +123,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     // mShaderGenerator->setShaderCacheEnabled(true);
     
     mShaderGenerator->addSceneManager(mSceneManager); 
-    if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
-    {
-        // Custom shaders apply lighting and shadows in one pass; automatic
-        // illumination splitting removes their fragment programs on GL3Plus.
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
-        // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
-        // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
-        // mSceneManager->setShadowFarDistance(100.0);
-        // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
-        // mSceneManager->setShadowTextureSelfShadow(true);
-        // donno if the below should be here -- paul424 :
-        auto myIter = Ogre::MaterialManager::getSingleton().getResourceIterator();
-        while(myIter.hasMoreElements())
-        {
-            auto myPointer = myIter.peekNextValue();
-            Ogre::SharedPtr<Ogre::Material> myCastPointer = std::dynamic_pointer_cast<Ogre::Material> (myPointer);
-            Ogre::Technique* technique;
-            technique = myCastPointer->getTechnique(0);
-
-            if( technique->getPass(technique->getNumPasses() - 1)->hasFragmentProgram())
-            {
-                if(technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->hasNamedParameters())
-                {
-                    const Ogre::GpuNamedConstants& gnc = technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->getConstantDefinitions();
-                    auto it = gnc.map.find("shadowingEnabled");
-                    if(it!=  gnc.map.end())
-                        technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->setNamedConstant("shadowingEnabled",true);
-                }
-            }
-            myIter.getNext();
-        }  
-        
-    }
-    else
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_NONE);
-
-    }
+    setDynamicShadowsEnabled(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS) == "Yes");
     ddd.setStatic(true);
     mSceneManager->addListener(&ddd);
     mSceneManager->addRenderQueueListener(overlaySystem);
@@ -212,6 +178,77 @@ void RenderManager::saveTexture(Ogre::TexturePtr texture, const std::string& fil
     pixelBuffer->unlock();
 }
 
+
+void RenderManager::setDynamicShadowsEnabled(bool enabled)
+{
+    // Custom shaders apply lighting and shadows in one pass; automatic
+    // illumination splitting removes their fragment programs on GL3Plus.
+    mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
+    if(enabled)
+    {
+        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH16);
+        mSceneManager->setShadowCameraSetup(Ogre::ShadowCameraSetupPtr(new GroundShadowCameraSetup()));
+    }
+
+    // Fixed-function materials also need a receiver when Ogre generates their
+    // shaders: integrated shadows do not add a separate receiver pass.
+    Ogre::RTShader::RenderState* renderState =
+        mShaderGenerator->getRenderState(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+#if OGRE_VERSION_MAJOR >= 13
+    const Ogre::RTShader::SubRenderStateList& subStates = renderState->getSubRenderStates();
+#else
+    const Ogre::RTShader::SubRenderStateList& subStates = renderState->getTemplateSubRenderStateList();
+#endif
+    Ogre::RTShader::SubRenderState* shadowState = nullptr;
+    for(Ogre::RTShader::SubRenderState* subState : subStates)
+    {
+        if(subState->getType() == Ogre::RTShader::SRS_INTEGRATED_PSSM3)
+            shadowState = subState;
+    }
+    if(enabled && shadowState == nullptr)
+        renderState->addTemplateSubRenderState(mShaderGenerator->createSubRenderState(Ogre::RTShader::SRS_INTEGRATED_PSSM3));
+    else if(!enabled && shadowState != nullptr)
+    {
+#if OGRE_VERSION_MAJOR >= 13
+        renderState->removeSubRenderState(shadowState);
+#else
+        renderState->removeTemplateSubRenderState(shadowState);
+#endif
+    }
+    mShaderGenerator->invalidateScheme(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+
+    // Include material clones and techniques created since the game started.
+    Ogre::ResourceManager::ResourceMapIterator materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while(materials.hasMoreElements())
+    {
+        Ogre::MaterialPtr material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+        for(unsigned short techniqueIndex = 0; techniqueIndex < material->getNumTechniques(); ++techniqueIndex)
+        {
+            Ogre::Technique* technique = material->getTechnique(techniqueIndex);
+            for(unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex)
+            {
+                Ogre::Pass* pass = technique->getPass(passIndex);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters())
+                {
+                    const Ogre::GpuNamedConstants& constants = parameters->getConstantDefinitions();
+                    if(constants.map.find("shadowingEnabled") != constants.map.end())
+                    {
+                        bool hasShadowTexture = false;
+                        for(unsigned short unit = 0; unit < pass->getNumTextureUnitStates(); ++unit)
+                        {
+                            if(pass->getTextureUnitState(unit)->getContentType() == Ogre::TextureUnitState::CONTENT_SHADOW)
+                                hasShadowTexture = true;
+                        }
+                        parameters->setNamedConstant("shadowingEnabled", enabled && hasShadowTexture);
+                    }
+                }
+            }
+        }
+    }
+}
 
 RenderManager::~RenderManager()
 {

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -122,7 +122,9 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mShaderGenerator->addSceneManager(mSceneManager); 
     if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
     {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE);
+        // Custom shaders apply lighting and shadows in one pass; automatic
+        // illumination splitting removes their fragment programs on GL3Plus.
+        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
         // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
         // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
         // mSceneManager->setShadowFarDistance(100.0);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -186,7 +186,7 @@ void RenderManager::setDynamicShadowsEnabled(bool enabled)
     mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
     if(enabled)
     {
-        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH16);
+        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH24_STENCIL8);
         mSceneManager->setShadowCameraSetup(Ogre::ShadowCameraSetupPtr(new GroundShadowCameraSetup()));
     }
 

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -98,6 +98,7 @@ public:
 
     //! \brief Sets/Updates the overall world lighting value with given factor.
     void setWorldAmbientLightingFactor(float lightFactor);
+    void setDynamicShadowsEnabled(bool enabled);
 
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);


### PR DESCRIPTION
Small creatures can lose most of their projected shadow because the current depth texture lacks enough precision at gameplay camera distances.

This change uses a 24-bit depth-stencil shadow texture and matches the receiver tolerance to one depth step.

Depends on #48.

Validation:
- Windows x64 Release build and runtime preparation
- 40 receiver-material checks and 80 shadow-toggle checks
- 64 larger-creature regression cases
- User-confirmed Rat shadow
