### PR TITLE
Fix: show readable chicken and gold hover descriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,9 @@ ENDIF ()
 # Adds the Windows icon resource file when building on windows.
 IF (WIN32)
     SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/icon.rc)
+    IF (MSVC)
+        SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/opendungeons.manifest)
+    ENDIF ()
 ENDIF ()
 
 ##################################
@@ -569,7 +572,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +663,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)
@@ -962,4 +971,3 @@ elseif(WIN32)
     install(FILES ${EXT_LIBS}
             DESTINATION ${OD_BIN_PATH})
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,7 @@ set(OD_SOURCEFILES
     ${SRC}/modes/ConsoleInterface.cpp
     ${SRC}/modes/EditorMode.cpp
     ${SRC}/modes/GameMode.cpp
+    ${SRC}/modes/InputCommand.cpp
     ${SRC}/modes/GameEditorModeBase.cpp
     ${SRC}/modes/GameEditorModeConsole.cpp
     ${SRC}/modes/InputBridge.cpp

--- a/cmake/config/resources.cfg.in
+++ b/cmake/config/resources.cfg.in
@@ -12,6 +12,11 @@ FileSystem=models
 FileSystem=particles
 FileSystem=shaders
 
+# Internal shadow programs must also be visible to OGRE's global resource pool.
+# Keep Main in Graphics above for game shader includes with strict group lookup.
+[OgreInternal]
+FileSystem=@CMAKE_INSTALL_PREFIX@/share/OGRE/Media/RTShaderLib/../Main
+
 [GUI]
 FileSystem=gui
 FileSystem=gui/fonts

--- a/dist/icon.rc
+++ b/dist/icon.rc
@@ -1,1 +1,5 @@
 1 ICON "OD-Logo.ico"
+
+#ifdef __GNUC__
+1 24 "opendungeons.manifest"
+#endif

--- a/dist/opendungeons.manifest
+++ b/dist/opendungeons.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/gui/MenuMain.layout
+++ b/gui/MenuMain.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Root" >
-        <Property name="Area" value="{{0,40},{0,10},{1,-40},{1,-10}}" />
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Window type="OD/StaticImage" name="WelcomeBanner" >
             <Property name="Area" value="{{0.5,-320},{0,52},{0.5,320},{0,191}}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -137,6 +137,15 @@
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
+        <Window type="OD/StaticText" name="ActionFeedback" >
+            <Property name="Area" value="{{0,4},{1,-225},{1,-204},{1,-135}}" />
+            <Property name="MousePassThroughEnabled" value="True" />
+            <Property name="RiseOnClickEnabled" value="False" />
+            <Property name="TextParsingEnabled" value="False" />
+            <Property name="HorzFormatting" value="WordWrapLeftAligned" />
+            <Property name="VertFormatting" value="CentreAligned" />
+            <Property name="Text" value="Dig: left-drag walls to mark or unmark them." />
+        </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
             <Property name="Area" value="{{0,0},{1,-133},{1,-200},{1,0}}" />
             <Property name="TabHeight" value="{0,35}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -6,6 +6,7 @@
         <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Window type="OD/StaticImage" name="HorizontalPipe" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="Area" value="{{0,0},{0,0},{1,0},{0,48}}" />
             <Property name="Image" value="OpenDungeonsSkin/HorizontalPipe" />
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
@@ -61,6 +62,7 @@
 
 
         <Window type="OD/StaticImage" name="MiniMap" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="BackgroundEnabled" value="False" />
             <Property name="FrameEnabled" value="False" />
             <Property name="Area" value="{{0,8},{1,-184},{0,184},{1,-8}}" />
@@ -69,6 +71,7 @@
         <UserString name="Circular" value="true" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="TabTextPadding" value="{0,6}" />
             <Property name="Area" value="{{0,188},{1,-184},{1,0},{1,0}}" />
             <Property name="TabHeight" value="{0,52}" />
@@ -95,6 +98,7 @@
             <Property name="HorzFormatting" value="LeftAligned" />
         </Window>
 <Window type="OD/ImageButton" name="OptionsButton" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="Area" value="{{0,8},{1,-52},{0,52},{1,-8}}" />
             <Property name="ButtonImage" value="OpenDungeonsIcons/OptionsIcon" />
             <Property name="AlwaysOnTop" value="True" />
@@ -103,6 +107,7 @@
             <Property name="Visible" value="True" />
         </Window>
     <Window type="OD/ImageButton" name="ObjectivesButton" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="Area" value="{{0,452},{1,-184},{0,504},{1,-132}}" />
             <Property name="ButtonImage" value="OpenDungeonsIcons/ObjectivesIcon" />
             <Property name="AlwaysOnTop" value="True" />
@@ -111,14 +116,16 @@
             <Property name="Visible" value="True" />
         </Window>
     <Window type="OD/ImageButton" name="PanelToggleButton" >
-            <Property name="Area" value="{{0,400},{1,-184},{0,448},{1,-132}}" />
+            <UserString name="AllowEdgeScrolling" value="true" />
+            <Property name="Area" value="{{0,400},{1,-184},{0,452},{1,-132}}" />
             <Property name="ButtonImage" value="OpenDungeonsSkin/TabButtonScrollLeftNormal" />
             <Property name="TooltipText" value="Hide / show control panel (G)" />
         </Window>
     <Window type="OD/ImageButton" name="EventsButton" >
+            <UserString name="AllowEdgeScrolling" value="true" />
             <Property name="Area" value="{{0,508},{1,-184},{0,560},{1,-132}}" />
             <Property name="ButtonImage" value="OpenDungeonsIcons/HelpIcon" />
-            <Property name="TooltipText" value="Messages" />
+            <Property name="TooltipText" value="Messages: left-click to read, right-click to dismiss read messages" />
         </Window>
         <Window type="OD/StaticImage" name="HandActionIcon" >
             <Property name="Area" value="{{0,0},{0,0},{0,50},{0,50}}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -68,15 +68,6 @@
             <Property name="AlwaysOnTop" value="True" />
         <UserString name="Circular" value="true" />
         </Window>
-        <Window type="OD/StaticText" name="ActionFeedback" >
-            <Property name="Area" value="{{0,188},{1,-278},{1,-4},{1,-188}}" />
-            <Property name="MousePassThroughEnabled" value="True" />
-            <Property name="RiseOnClickEnabled" value="False" />
-            <Property name="TextParsingEnabled" value="False" />
-            <Property name="HorzFormatting" value="WordWrapLeftAligned" />
-            <Property name="VertFormatting" value="CentreAligned" />
-            <Property name="Text" value="Dig: left-drag walls to mark or unmark them." />
-        </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
             <Property name="TabTextPadding" value="{0,6}" />
             <Property name="Area" value="{{0,188},{1,-184},{1,0},{1,0}}" />
@@ -128,6 +119,15 @@
             <Property name="Area" value="{{0,508},{1,-184},{0,560},{1,-132}}" />
             <Property name="ButtonImage" value="OpenDungeonsIcons/HelpIcon" />
             <Property name="TooltipText" value="Messages" />
+        </Window>
+        <Window type="OD/StaticImage" name="HandActionIcon" >
+            <Property name="Area" value="{{0,0},{0,0},{0,50},{0,50}}" />
+            <Property name="Visible" value="False" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Property name="MousePassThroughEnabled" value="True" />
+            <Property name="ClippedByParent" value="False" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
         </Window>
     </Window>
 </GUILayout>

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -2,17 +2,18 @@
 
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Root" >
-        <Property name="Area" value="{{0,-1},{0,-1},{1,-1},{1,-1}}" />
+            <Property name="Font" value="MedievalSharp-10" />
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Window type="OD/StaticImage" name="HorizontalPipe" >
-            <Property name="Area" value="{{0,0},{0,11},{1,0},{0,23}}" />
+            <Property name="Area" value="{{0,0},{0,0},{1,0},{0,48}}" />
             <Property name="Image" value="OpenDungeonsSkin/HorizontalPipe" />
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
             <Property name="FrameEnabled" value="False" />
             <Property name="BackgroundEnabled" value="False" />
             <Property name="HorzFormatting" value="Tiled" />
             <Window type="OD/StaticText" name="GoldDisplay" >
-                <Property name="Area" value="{{0,5},{0,0},{0,150},{0,24}}" />
+                <Property name="Area" value="{{0,204},{0,2},{0,400},{0,44}}" />
                 <Property name="Text" value="0" />
                 <Property name="MaxSize" value="{{1,0},{1,0}}" />
                 <Property name="TooltipText" value="Your Gold" />
@@ -32,7 +33,7 @@
                 </Window>
             </Window>
             <Window type="OD/StaticText" name="ManaDisplay" >
-                <Property name="Area" value="{{0,155},{0,0},{0,285},{0,24}}" />
+                <Property name="Area" value="{{0,4},{0,2},{0,200},{0,44}}" />
                 <Property name="Text" value="0" />
                 <Property name="MaxSize" value="{{1,0},{1,0}}" />
                 <Property name="TooltipText" value="Your Mana" />
@@ -51,94 +52,24 @@
                     <Property name="VerticalAlignment" value="Centre" />
                 </Window>
             </Window>
-            <Window type="OD/StaticText" name="TerritoryDisplay" >
-                <Property name="Area" value="{{0,290},{0,0},{0,420},{0,24}}" />
-                <Property name="Text" value="0" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="TooltipText" value="Your claimed territory" />
-                <Property name="HorzFormatting" value="RightAligned" />
-                <Property name="ClippedByParent" value="False" />
-                <Property name="VerticalAlignment" value="Centre" />
-                <Window type="OD/StaticImage" name="Icon" >
-                    <Property name="Area" value="{{0,0},{0,0},{0,30},{0,30}}" />
-                    <Property name="Image" value="OpenDungeonsIcons/TerritoryIcon" />
-                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                    <Property name="AlwaysOnTop" value="True" />
-                    <Property name="TooltipText" value="Your claimed territory" />
-                    <Property name="FrameEnabled" value="False" />
-                    <Property name="ClippedByParent" value="False" />
-                    <Property name="BackgroundEnabled" value="False" />
-                    <Property name="VerticalAlignment" value="Centre" />
-                </Window>
-            </Window>
-	    <Window type="OD/StaticText" name="CreaturesDisplay" >
-                <Property name="Area" value="{{0,425},{0,0},{0,555},{0,24}}" />
-                <Property name="Text" value="0" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="TooltipText" value="Your creatures pool" />
-                <Property name="HorzFormatting" value="RightAligned" />
-                <Property name="ClippedByParent" value="False" />
-                <Property name="VerticalAlignment" value="Centre" />
-                <Window type="OD/StaticImage" name="Icon" >
-                    <Property name="Area" value="{{0,0},{0,0},{0,30},{0,30}}" />
-                    <Property name="Image" value="OpenDungeonsIcons/CreaturesIcon" />
-                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                    <Property name="AlwaysOnTop" value="True" />
-                    <Property name="TooltipText" value="Your creatures pool" />
-                    <Property name="FrameEnabled" value="False" />
-                    <Property name="ClippedByParent" value="False" />
-                    <Property name="BackgroundEnabled" value="False" />
-                    <Property name="VerticalAlignment" value="Centre" />
-                </Window>
-            </Window>
+
+
         </Window>
-        <Window type="OD/ImageButton" name="HelpButton" >
-            <Property name="Area" value="{{1,-53},{0,5},{1,-28},{0,30}}" />
-            <Property name="ButtonImage" value="OpenDungeonsIcons/HelpIcon" />
-            <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Help (F1)" />
-            <Property name="ClippedByParent" value="False" />
-            <Property name="Visible" value="True" />
-        </Window>
-        <Window type="OD/ImageButton" name="OptionsButton" >
-            <Property name="Area" value="{{1,-27},{0,5},{1,-2},{0,30}}" />
-            <Property name="ButtonImage" value="OpenDungeonsIcons/OptionsIcon" />
-            <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Options (F10)" />
-            <Property name="ClippedByParent" value="False" />
-            <Property name="Visible" value="True" />
-        </Window>
-        <Window type="OD/ImageButton" name="SkillButton" >
-            <Property name="Area" value="{{1,-232},{1,-202},{1,-202},{1,-172}}" />
-            <Property name="ButtonImage" value="OpenDungeonsIcons/SkillIcon" />
-            <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Skill (F4)" />
-            <Property name="ClippedByParent" value="False" />
-            <Property name="Visible" value="True" />
-        </Window>
-        <Window type="OD/ImageButton" name="ObjectivesButton" >
-            <Property name="Area" value="{{1,-232},{1,-171},{1,-202},{1,-141}}" />
-            <Property name="ButtonImage" value="OpenDungeonsIcons/ObjectivesIcon" />
-            <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Objectives (F3)" />
-            <Property name="ClippedByParent" value="False" />
-            <Property name="Visible" value="True" />
-        </Window>
-        <Window type="OD/ImageButton" name="PlayerSettingsButton" >
-            <Property name="Area" value="{{1,-232},{1,-140},{1,-202},{1,-110}}" />
-            <Property name="ButtonImage" value="OpenDungeonsIcons/HammerAnvilIcon" />
-            <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Player settings (F2)" />
-            <Property name="ClippedByParent" value="False" />
-            <Property name="Visible" value="True" />
-        </Window>
+
+
+
+
+
         <Window type="OD/StaticImage" name="MiniMap" >
-            <Property name="Area" value="{{1,-201},{1,-202},{1,-1},{1,-2}}" />
+            <Property name="BackgroundEnabled" value="False" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="Area" value="{{0,8},{1,-184},{0,184},{1,-8}}" />
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
             <Property name="AlwaysOnTop" value="True" />
+        <UserString name="Circular" value="true" />
         </Window>
         <Window type="OD/StaticText" name="ActionFeedback" >
-            <Property name="Area" value="{{0,4},{1,-225},{1,-204},{1,-135}}" />
+            <Property name="Area" value="{{0,188},{1,-278},{1,-4},{1,-188}}" />
             <Property name="MousePassThroughEnabled" value="True" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Property name="TextParsingEnabled" value="False" />
@@ -147,13 +78,14 @@
             <Property name="Text" value="Dig: left-drag walls to mark or unmark them." />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,0},{1,-133},{1,-200},{1,0}}" />
-            <Property name="TabHeight" value="{0,35}" />
+            <Property name="TabTextPadding" value="{0,6}" />
+            <Property name="Area" value="{{0,188},{1,-184},{1,0},{1,0}}" />
+            <Property name="TabHeight" value="{0,52}" />
             <Property name="RiseOnClickEnabled" value="False" />
-            <LayoutImport type="DefaultWindow" filename="WindowTabRooms.layout" name="RoomsImport" />
-            <LayoutImport type="DefaultWindow" filename="WindowTabTraps.layout" name="TrapsImport" />
-            <LayoutImport type="DefaultWindow" filename="WindowTabSpells.layout" name="SpellImport" />
             <LayoutImport type="DefaultWindow" filename="WindowTabCreatures.layout" name="CreaturesImport" />
+            <LayoutImport type="DefaultWindow" filename="WindowTabRooms.layout" name="RoomsImport" />
+            <LayoutImport type="DefaultWindow" filename="WindowTabSpells.layout" name="SpellImport" />
+            <LayoutImport type="DefaultWindow" filename="WindowTabTraps.layout" name="TrapsImport" />
         </Window>
         <LayoutImport type="DefaultWindow" filename="WindowQuit.layout" name="QuitMenuImport" />
         <LayoutImport type="DefaultWindow" filename="WindowPlayerSettings.layout" name="PlayerSettingsWindowImport" />
@@ -163,5 +95,39 @@
         <LayoutImport type="DefaultWindow" filename="WindowEvent.layout" name="EventWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowChat.layout" name="ChatWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowHelp.layout" name="HelpWindowImport" />
+
+
+        <Window type="OD/StaticText" name="ContextInfo" >
+            <Property name="Area" value="{{0,404},{0,2},{1,-4},{0,44}}" />
+            <Property name="MousePassThroughEnabled" value="True" />
+            <Property name="TextParsingEnabled" value="False" />
+            <Property name="HorzFormatting" value="LeftAligned" />
+        </Window>
+<Window type="OD/ImageButton" name="OptionsButton" >
+            <Property name="Area" value="{{0,8},{1,-52},{0,52},{1,-8}}" />
+            <Property name="ButtonImage" value="OpenDungeonsIcons/OptionsIcon" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Property name="TooltipText" value="Options (F10)" />
+            <Property name="ClippedByParent" value="False" />
+            <Property name="Visible" value="True" />
+        </Window>
+    <Window type="OD/ImageButton" name="ObjectivesButton" >
+            <Property name="Area" value="{{0,452},{1,-184},{0,504},{1,-132}}" />
+            <Property name="ButtonImage" value="OpenDungeonsIcons/ObjectivesIcon" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Property name="TooltipText" value="Objectives (F3)" />
+            <Property name="ClippedByParent" value="False" />
+            <Property name="Visible" value="True" />
+        </Window>
+    <Window type="OD/ImageButton" name="PanelToggleButton" >
+            <Property name="Area" value="{{0,400},{1,-184},{0,448},{1,-132}}" />
+            <Property name="ButtonImage" value="OpenDungeonsSkin/TabButtonScrollLeftNormal" />
+            <Property name="TooltipText" value="Hide / show control panel (G)" />
+        </Window>
+    <Window type="OD/ImageButton" name="EventsButton" >
+            <Property name="Area" value="{{0,508},{1,-184},{0,560},{1,-132}}" />
+            <Property name="ButtonImage" value="OpenDungeonsIcons/HelpIcon" />
+            <Property name="TooltipText" value="Messages" />
+        </Window>
     </Window>
 </GUILayout>

--- a/gui/OD.looknfeel
+++ b/gui/OD.looknfeel
@@ -4625,6 +4625,7 @@
         <PropertyDefinition initialValue="OpenDungeonsSkin/ButtonDisabledEffect" name="DisabledImage" redrawOnWrite="true" />
         <PropertyDefinition initialValue="Stretched" name="VertImageFormatting" redrawOnWrite="true" />
         <PropertyDefinition initialValue="Stretched" name="HorzImageFormatting" redrawOnWrite="true" />
+        <PropertyDefinition initialValue="00FFFFFF" name="SelectionColour" redrawOnWrite="true" />
         <ImagerySection name="background">
             <ImageryComponent>
                 <Area>
@@ -4703,6 +4704,20 @@
                 <HorzFormatProperty name="HorzImageFormatting" />
             </ImageryComponent>
         </ImagerySection>
+        <ImagerySection name="selected">
+            <ImageryComponent>
+                <Area>
+                    <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="Width"><UnifiedDim scale="1" type="Width" /></Dim>
+                    <Dim type="Height"><UnifiedDim scale="1" type="Height" /></Dim>
+                </Area>
+                <Image name="OpenDungeonsSkin/ButtonHoverEffect" />
+                <ColourRectProperty name="SelectionColour" />
+                <VertFormatProperty name="VertImageFormatting" />
+                <HorzFormatProperty name="HorzImageFormatting" />
+            </ImageryComponent>
+        </ImagerySection>
         <StateImagery name="Normal">
             <Layer priority="0">
                 <Section section="background" />
@@ -4712,6 +4727,9 @@
             </Layer>
             <Layer priority="2">
                 <Section section="frame" />
+            </Layer>
+            <Layer priority="4">
+                <Section section="selected" />
             </Layer>
         </StateImagery>
         <StateImagery name="Hover">
@@ -4727,6 +4745,9 @@
             <Layer priority="3">
                 <Section section="hover" />
             </Layer>
+            <Layer priority="4">
+                <Section section="selected" />
+            </Layer>
         </StateImagery>
         <StateImagery name="Pushed">
             <Layer priority="0">
@@ -4740,6 +4761,9 @@
             </Layer>
             <Layer priority="3">
                 <Section section="pushed" />
+            </Layer>
+            <Layer priority="4">
+                <Section section="selected" />
             </Layer>
         </StateImagery>
         <StateImagery name="PushedOff">
@@ -4755,6 +4779,9 @@
             <Layer priority="3">
                 <Section section="hover" />
             </Layer>
+            <Layer priority="4">
+                <Section section="selected" />
+            </Layer>
         </StateImagery>
         <StateImagery name="Disabled">
             <Layer priority="0">
@@ -4768,6 +4795,9 @@
             </Layer>
             <Layer priority="3">
                 <Section section="disabled" />
+            </Layer>
+            <Layer priority="4">
+                <Section section="selected" />
             </Layer>
         </StateImagery>
     </WidgetLook>

--- a/gui/WindowEvent.layout
+++ b/gui/WindowEvent.layout
@@ -2,9 +2,10 @@
 
 <GUILayout version="4" >
     <Window type="OD/StaticText" name="GameEventText" >
-        <Property name="Area" value="{{0.0,430},{0.0,35},{0.0,830},{0.0,160}}" />
-        <Property name="FrameEnabled" value="False" />
-        <Property name="BackgroundEnabled" value="False" />
+            <Property name="Visible" value="False" />
+        <Property name="Area" value="{{0,452},{1,-410},{1,-8},{1,-188}}" />
+        <Property name="FrameEnabled" value="True" />
+        <Property name="BackgroundEnabled" value="True" />
         <Property name="VertFormatting" value="TopAligned" />
         <Property name="HorzFormatting" value="WordWrapLeftAligned" />
         <Property name="VertScrollbar" value="True" />

--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -2,51 +2,61 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="GameOptionsWindow" >
-        <Property name="Area" value="{{0.5,-110},{0.5,-190},{0.5,110},{0.5,190}}" />
+        <Property name="Area" value="{{0.5,-160},{0.5,-268},{0.5,160},{0.5,268}}" />
         <Property name="Text" value="Options" />
         <Property name="SizingEnabled" value="False" />
         <Window type="OD/IconButton" name="ObjectivesButton" >
-            <Property name="Area" value="{{0.5,-80},{0,40},{0.5,80},{0,73}}" />
+            <Property name="Area" value="{{0,24},{0,36},{1,-24},{0,74}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/ObjectivesIcon" />
             <Property name="Text" value="Objectives (F3)" />
             <Property name="TooltipText" value="View the current game objectives." />
         </Window>
         <Window type="OD/IconButton" name="SkillButton" >
-            <Property name="Area" value="{{0.5,-80},{0,83},{0.5,80},{0,116}}" />
+            <Property name="Area" value="{{0,24},{0,82},{1,-24},{0,120}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/SkillIcon" />
             <Property name="Text" value="Skill (F4)" />
         </Window>
         <Window type="OD/IconButton" name="SaveGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,136},{0.5,80},{0,169}}" />
+            <Property name="Area" value="{{0,24},{0,128},{1,-24},{0,166}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/SaveIcon" />
             <Property name="Text" value="Save Game (F5)" />
         </Window>
         <Window type="OD/IconButton" name="LoadGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,180},{0.5,80},{0,213}}" />
+            <Property name="Area" value="{{0,24},{0,174},{1,-24},{0,212}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/LoadIcon" />
             <Property name="Text" value="Load Game (F8)" />
             <Property name="Disabled" value="True" />
             <Property name="TooltipText" value="Not implemented yet" />
         </Window>
         <Window type="OD/IconButton" name="SettingsButton" >
-            <Property name="Area" value="{{0.5,-80},{0,235},{0.5,80},{0,268}}" />
+            <Property name="Area" value="{{0,24},{0,220},{1,-24},{0,258}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/OptionsIcon" />
             <Property name="Text" value="Settings" />
             <Property name="Disabled" value="False" />
             <Property name="TooltipText" value="Open the game settings window." />
         </Window>
         <Window type="OD/IconButton" name="QuitGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,278},{0.5,80},{0,311}}" />
+            <Property name="Area" value="{{0,24},{0,266},{1,-24},{0,304}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="Text" value="Quit to Menu" />
             <Property name="TooltipText" value="Leave this game and return to the main menu..." />
         </Window>
         <Window type="OD/IconButton" name="ExitGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,321},{0.5,80},{0,354}}" />
+            <Property name="Area" value="{{0,24},{0,312},{1,-24},{0,350}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="IconImageColour" value="FFBB0000" />
             <Property name="Text" value="Exit to System" />
             <Property name="TooltipText" value="Leave this game and exit to the desktop..." />
+        </Window>
+            <Window type="OD/IconButton" name="HelpButton" >
+            <Property name="Area" value="{{0,24},{0,358},{1,-24},{0,396}}" />
+            <Property name="IconImage" value="OpenDungeonsIcons/HelpIcon" />
+            <Property name="Text" value="Help (F1)" />
+        </Window>
+            <Window type="OD/IconButton" name="PlayerSettingsButton" >
+            <Property name="Area" value="{{0,24},{0,404},{1,-24},{0,442}}" />
+            <Property name="IconImage" value="OpenDungeonsIcons/SeatIcon" />
+            <Property name="Text" value="Player information (F2)" />
         </Window>
     </Window>
 </GUILayout>

--- a/gui/WindowPlayerSettings.layout
+++ b/gui/WindowPlayerSettings.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="PlayerSettingsWindow" >
-        <Property name="Area" value="{{0.5,-200},{0.5,-150},{0.5,200},{0.5,150}}" />
+        <Property name="Area" value="{{0.5,-200},{0.5,-185},{0.5,200},{0.5,185}}" />
         <Property name="Text" value="Player settings" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
@@ -40,8 +40,48 @@
             </Window>
         </Window>
         <Window type="OD/Checkbox" name="KOCreatureCheckbox" >
-            <Property name="Area" value="{{0,20},{0.6,0},{1,0},{0.6,20}}" />
+            <Property name="Area" value="{{0,20},{1,-126},{1,-15},{1,-104}}" />
             <Property name="Text" value="KO enemy creatures instead of killing" />
         </Window>
+    <Window type="OD/StaticText" name="TerritoryDisplay" >
+                <Property name="Area" value="{{0,20},{1,-96},{0,190},{1,-66}}" />
+                <Property name="Text" value="0" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="TooltipText" value="Your claimed territory" />
+                <Property name="HorzFormatting" value="RightAligned" />
+                <Property name="ClippedByParent" value="False" />
+                <Property name="VerticalAlignment" value="Centre" />
+                <Window type="OD/StaticImage" name="Icon" >
+                    <Property name="Area" value="{{0,0},{0,0},{0,30},{0,30}}" />
+                    <Property name="Image" value="OpenDungeonsIcons/TerritoryIcon" />
+                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                    <Property name="AlwaysOnTop" value="True" />
+                    <Property name="TooltipText" value="Your claimed territory" />
+                    <Property name="FrameEnabled" value="False" />
+                    <Property name="ClippedByParent" value="False" />
+                    <Property name="BackgroundEnabled" value="False" />
+                    <Property name="VerticalAlignment" value="Centre" />
+                </Window>
+            </Window>
+    <Window type="OD/StaticText" name="CreaturesDisplay" >
+                <Property name="Area" value="{{0,200},{1,-96},{0,370},{1,-66}}" />
+                <Property name="Text" value="0" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="TooltipText" value="Your creatures pool" />
+                <Property name="HorzFormatting" value="RightAligned" />
+                <Property name="ClippedByParent" value="False" />
+                <Property name="VerticalAlignment" value="Centre" />
+                <Window type="OD/StaticImage" name="Icon" >
+                    <Property name="Area" value="{{0,0},{0,0},{0,30},{0,30}}" />
+                    <Property name="Image" value="OpenDungeonsIcons/CreaturesIcon" />
+                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                    <Property name="AlwaysOnTop" value="True" />
+                    <Property name="TooltipText" value="Your creatures pool" />
+                    <Property name="FrameEnabled" value="False" />
+                    <Property name="ClippedByParent" value="False" />
+                    <Property name="BackgroundEnabled" value="False" />
+                    <Property name="VerticalAlignment" value="Centre" />
+                </Window>
+            </Window>
     </Window>
 </GUILayout>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,50},{0,750},{0,550}}" />
+        <Property name="Area" value="{{0.5,-272.5},{0.5,-250},{0.5,272.5},{0.5,250}}" />
         <Property name="Text" value="Settings" />
         <Property name="SizingEnabled" value="False" />
         <Property name="AlwaysOnTop" value="True" />
@@ -17,7 +17,7 @@
             <Property name="IconImage" value="OpenDungeonsIcons/CheckIcon" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,10},{0,20},{1,-10},{1,-70}}" />
+            <Property name="Area" value="{{0,10},{0,32},{1,-10},{1,-70}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Window type="DefaultWindow" name="Video" >
@@ -28,26 +28,26 @@
                 <Window type="OD/ScrollablePane" name="VideoSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="ResolutionText" >
-                        <Property name="Area" value="{{0,22},{0,31},{0,184},{0,43}}" />
+                        <Property name="Area" value="{{0,22},{0,20},{0,184},{0,46}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Resolution:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="ResolutionCombobox" >
-                        <Property name="Area" value="{{0,22},{0,42},{0,166},{0,162}}" />
+                        <Property name="Area" value="{{0,22},{0,48},{0,166},{0,168}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/Checkbox" name="FullscreenCheckbox" >
-                        <Property name="Area" value="{{0,202},{0,42},{0,302},{0,68}}" />
+                        <Property name="Area" value="{{0,202},{0,48},{0,302},{0,74}}" />
                         <Property name="Text" value="Fullscreen" />
                     </Window>
                     <Window type="OD/Checkbox" name="DynamicShadowsCheckbox" >
-                        <Property name="Area" value="{{0,342},{0,42},{0,542},{0,68}}" />
+                        <Property name="Area" value="{{0,322},{0,48},{0,502},{0,74}}" />
                         <Property name="Text" value="Dynamic Shadows" />
                     </Window>                   
                     <Window type="OD/StaticText" name="RendererText" >
-                        <Property name="Area" value="{{0,22},{0,78},{0,184},{0,90}}" />
+                        <Property name="Area" value="{{0,22},{0,88},{0,184},{0,114}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Renderer*:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -55,14 +55,25 @@
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Combobox" name="RendererCombobox" >
-                        <Property name="Area" value="{{0,22},{0,90},{0,266},{0,210}}" />
+                        <Property name="Area" value="{{0,22},{0,116},{0,266},{0,236}}" />
                         <Property name="ReadOnly" value="True" />
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
-                        <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
-                        <Property name="Text" value="VSync*" />
-                        <Property name="TooltipText" value="* Needs a restart to be potentially applied." />
+                        <Property name="Area" value="{{0,22},{0,156},{0,166},{0,182}}" />
+                        <Property name="Text" value="VSync" />
+                    </Window>
+                    <Window type="OD/StaticText" name="UIScaleText" >
+                        <Property name="Area" value="{{0,22},{0,194},{0,184},{0,220}}" />
+                        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                        <Property name="Text" value="UI Scale:" />
+                        <Property name="BackgroundEnabled" value="False" />
+                        <Property name="FrameEnabled" value="False" />
+                    </Window>
+                    <Window type="OD/Combobox" name="UIScaleCombobox" >
+                        <Property name="Area" value="{{0,202},{0,190},{0,346},{0,310}}" />
+                        <Property name="ReadOnly" value="True" />
+                        <Property name="TooltipText" value="Scales the interface immediately. Apply saves the setting." />
                     </Window>
                 </Window>
             </Window>
@@ -75,7 +86,7 @@
                 <Window type="OD/ScrollablePane" name="AudioSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="MusicText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,66}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Music:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -100,29 +111,29 @@
                 <Window type="OD/ScrollablePane" name="InputSP" >
                     <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                     <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,66}}" />
                         <Property name="Text" value="Keyboard grab" />
-                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
+                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,106}}" />
                         <Property name="Text" value="Mouse grab" />
-                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="AutoscrollCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,140}}" />
+                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,146}}" />
                         <Property name="Text" value="Autoscroll" />
                         <Property name="TooltipText" value="When checked, if the mouse cousor is on the screen border it will make camera fly " />
                     </Window>
                     <Window type="OD/StaticText" name="PanSpeedText" >
-                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,180}}" />
+                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,186}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Camera pan speed: 100%" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="PanSpeedSlider" >
-                        <Property name="Area" value="{{0,32},{0,180},{0,327},{0,193}}" />
+                        <Property name="Area" value="{{0,32},{0,190},{0,327},{0,203}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />
@@ -141,47 +152,47 @@
                 <Window type="OD/ScrollablePane" name="GameSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="NicknameText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,46},{0,150},{0,72}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Nickname:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Editbox" name="NicknameEdit" >
-                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,60}}" />
+                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,80}}" />
                         <Property name="Text" value="" />
                     </Window>
                     <Window type="OD/StaticText" name="KeeperVoiceText" >
-                        <Property name="Area" value="{{0,32},{0,70},{0,150},{0,90}}" />
+                        <Property name="Area" value="{{0,32},{0,90},{0,150},{0,116}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Keeper Voice:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="KeeperVoice" >
-                        <Property name="Area" value="{{0,160},{0,70},{0,320},{0,150}}" />
+                        <Property name="Area" value="{{0,160},{0,90},{0,320},{0,190}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="MinimapText" >
-                        <Property name="Area" value="{{0,32},{0,100},{0,150},{0,120}}" />
+                        <Property name="Area" value="{{0,32},{0,130},{0,150},{0,156}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Minimap Type:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="MiniMapType" >
-                        <Property name="Area" value="{{0,160},{0,100},{0,320},{0,180}}" />
+                        <Property name="Area" value="{{0,160},{0,130},{0,320},{0,230}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="LightText" >
-                        <Property name="Area" value="{{0,32},{0,130},{0,220},{0,150}}" />
+                        <Property name="Area" value="{{0,32},{0,170},{0,220},{0,196}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Ambient Light: +" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="LightSlider" >
-                        <Property name="Area" value="{{0,32},{0,150},{0,327},{0,163}}" />
+                        <Property name="Area" value="{{0,32},{0,200},{0,327},{0,213}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />

--- a/gui/WindowTabCreatures.layout
+++ b/gui/WindowTabCreatures.layout
@@ -9,7 +9,7 @@
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
         <Window type="OD/GameTabButton" name="WorkerButton" >
-            <Property name="Area" value="{{0,20},{0,6},{0,100},{0,114}}" />
+            <Property name="Area" value="{{0,20},{0,6},{0,100},{0,86}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WorkerButton" />
             <Property name="TooltipText" value="Add a worker in hand if available" />
             <Property name="InheritsAlpha" value="False" />
@@ -23,7 +23,7 @@
                 </Window>
             </Window>
         <Window type="OD/GameTabButton" name="FighterButton" >
-            <Property name="Area" value="{{0,108},{0,6},{0,188},{0,114}}" />
+            <Property name="Area" value="{{0,108},{0,6},{0,188},{0,86}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/FighterButton" />
             <Property name="TooltipText" value="Add a fighter in hand if available" />
             <Property name="InheritsAlpha" value="False" />

--- a/gui/WindowTabCreatures.layout
+++ b/gui/WindowTabCreatures.layout
@@ -3,22 +3,38 @@
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Creatures" >
         <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-        <Property name="Text" value="[image-size='w:30 h:30'][image='OpenDungeonsIcons/CreaturesIcon']" />
+        <Property name="Text" value="[image-size='w:40 h:40'][image='OpenDungeonsIcons/CreaturesIcon']" />
         <Property name="TooltipText" value="Creatures" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
         <Window type="OD/GameTabButton" name="WorkerButton" >
-            <Property name="Area" value="{{0,20},{0,25},{0,80},{0,85}}" />
+            <Property name="Area" value="{{0,20},{0,6},{0,100},{0,114}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WorkerButton" />
             <Property name="TooltipText" value="Add a worker in hand if available" />
             <Property name="InheritsAlpha" value="False" />
-        </Window>
+                        <Window type="OD/StaticText" name="Count" >
+                    <Property name="Area" value="{{0,2},{1,-30},{1,-2},{1,-2}}" />
+                    <Property name="Text" value="0" />
+                    <Property name="HorzFormatting" value="CentreAligned" />
+                    <Property name="MousePassThroughEnabled" value="True" />
+                    <Property name="FrameEnabled" value="False" />
+                    <Property name="BackgroundEnabled" value="False" />
+                </Window>
+            </Window>
         <Window type="OD/GameTabButton" name="FighterButton" >
-            <Property name="Area" value="{{0,80},{0,25},{0,140},{0,85}}" />
+            <Property name="Area" value="{{0,108},{0,6},{0,188},{0,114}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/FighterButton" />
             <Property name="TooltipText" value="Add a fighter in hand if available" />
             <Property name="InheritsAlpha" value="False" />
-        </Window>
+                        <Window type="OD/StaticText" name="Count" >
+                    <Property name="Area" value="{{0,2},{1,-30},{1,-2},{1,-2}}" />
+                    <Property name="Text" value="0" />
+                    <Property name="HorzFormatting" value="CentreAligned" />
+                    <Property name="MousePassThroughEnabled" value="True" />
+                    <Property name="FrameEnabled" value="False" />
+                    <Property name="BackgroundEnabled" value="False" />
+                </Window>
+            </Window>
     </Window>
 </GUILayout>

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -3,124 +3,124 @@
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Rooms" >
         <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-        <Property name="Text" value="[image-size='w:32 h:32'][image='OpenDungeonsIcons/RoomsButton']" />
+        <Property name="Text" value="[image-size='w:40 h:40'][image='OpenDungeonsIcons/RoomsButton']" />
         <Property name="TooltipText" value="Rooms" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="RiseOnClickEnabled" value="False" />
 
         <Window type="OD/GameTabButton" name="DestroyRoomButton" >
-            <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
+            <Property name="Area" value="{{0,20},{0,6},{0,72},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/DestroyRoomButton" />
             <Property name="TooltipText" value="Destroy a room (returns half its price)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TreasuryButton" >
-            <Property name="Area" value="{{0,100},{0,10},{0,140},{0,50}}" />
+            <Property name="Area" value="{{0,76},{0,6},{0,128},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TreasuryButton" />
             <Property name="TooltipText" value="Build a treasury" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="DormitoryButton" >
-            <Property name="Area" value="{{0,140},{0,10},{0,180},{0,50}}" />
+            <Property name="Area" value="{{0,132},{0,6},{0,184},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/DormitoryButton" />
             <Property name="TooltipText" value="Build sleeping places for your creatures" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="HatcheryButton" >
-            <Property name="Area" value="{{0,180},{0,10},{0,220},{0,50}}" />
+            <Property name="Area" value="{{0,188},{0,6},{0,240},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/HatcheryButton" />
             <Property name="TooltipText" value="Build a Hatchery" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="LibraryButton" >
-            <Property name="Area" value="{{0,220},{0,10},{0,260},{0,50}}" />
+            <Property name="Area" value="{{0,244},{0,6},{0,296},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/LibraryButton" />
             <Property name="TooltipText" value="Build a Library" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TrainingHallButton" >
-            <Property name="Area" value="{{0,260},{0,10},{0,300},{0,50}}" />
+            <Property name="Area" value="{{0,300},{0,6},{0,352},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TrainingHallButton" />
             <Property name="TooltipText" value="Build a Training Hall" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WorkshopButton" >
-            <Property name="Area" value="{{0,300},{0,10},{0,340},{0,50}}" />
+            <Property name="Area" value="{{0,356},{0,6},{0,408},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WorkshopButton" />
             <Property name="TooltipText" value="Build a Workshop (for traps)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="CryptButton" >
-            <Property name="Area" value="{{0,340},{0,10},{0,380},{0,50}}" />
+            <Property name="Area" value="{{0,412},{0,6},{0,464},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CryptButton" />
             <Property name="TooltipText" value="Build a Crypt" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="PrisonButton" >
-            <Property name="Area" value="{{0,380},{0,10},{0,420},{0,50}}" />
+            <Property name="Area" value="{{0,468},{0,6},{0,520},{0,58}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PrisonButton" />
             <Property name="TooltipText" value="Build a Prison" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WoodenBridgeButton" >
-            <Property name="Area" value="{{0,100},{0,50},{0,140},{0,90}}" />
+            <Property name="Area" value="{{0,20},{0,62},{0,72},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WoodenBridgeButton" />
             <Property name="TooltipText" value="Build a wooden bridge" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="StoneBridgeButton" >
-            <Property name="Area" value="{{0,140},{0,50},{0,180},{0,90}}" />
+            <Property name="Area" value="{{0,76},{0,62},{0,128},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/StoneBridgeButton" />
             <Property name="TooltipText" value="Build a stone bridge" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="ArenaButton" >
-            <Property name="Area" value="{{0,180},{0,50},{0,220},{0,90}}" />
+            <Property name="Area" value="{{0,132},{0,62},{0,184},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/ArenaButton" />
             <Property name="TooltipText" value="Build an arena" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="CasinoButton" >
-            <Property name="Area" value="{{0,220},{0,50},{0,260},{0,90}}" />
+            <Property name="Area" value="{{0,188},{0,62},{0,240},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CasinoButton" />
             <Property name="TooltipText" value="Build a casino" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TortureButton" >
-            <Property name="Area" value="{{0,260},{0,50},{0,300},{0,90}}" />
+            <Property name="Area" value="{{0,244},{0,62},{0,296},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TortureButton" />
             <Property name="TooltipText" value="Build a torture room" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TempleButton" >
-            <Property name="Area" value="{{0,300},{0,50},{0,340},{0,90}}" />
+            <Property name="Area" value="{{0,300},{0,62},{0,352},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TempleButton" />
             <Property name="TooltipText" value="Build a Temple (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="PortalButton" >
-            <Property name="Area" value="{{0,340},{0,50},{0,380},{0,90}}" />
+            <Property name="Area" value="{{0,356},{0,62},{0,408},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PortalButton" />
             <Property name="TooltipText" value="Build a Portal (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WavePortalButton" >
-            <Property name="Area" value="{{0,380},{0,50},{0,420},{0,90}}" />
+            <Property name="Area" value="{{0,412},{0,62},{0,464},{0,114}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WavePortalButton" />
             <Property name="TooltipText" value="Build a Wave portal (3x3), the room that sends waves of enemies" />

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -106,21 +106,21 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TempleButton" >
-            <Property name="Area" value="{{0,570},{0,20},{0,630},{0,80}}" />
+            <Property name="Area" value="{{0,300},{0,50},{0,340},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TempleButton" />
             <Property name="TooltipText" value="Build a Temple (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="PortalButton" >
-            <Property name="Area" value="{{0,630},{0,20},{0,690},{0,80}}" />
+            <Property name="Area" value="{{0,340},{0,50},{0,380},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PortalButton" />
             <Property name="TooltipText" value="Build a Portal (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WavePortalButton" >
-            <Property name="Area" value="{{0,690},{0,20},{0,750},{0,80}}" />
+            <Property name="Area" value="{{0,380},{0,50},{0,420},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WavePortalButton" />
             <Property name="TooltipText" value="Build a Wave portal (3x3), the room that sends waves of enemies" />

--- a/gui/WindowTabSpells.layout
+++ b/gui/WindowTabSpells.layout
@@ -3,7 +3,7 @@
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Spells" >
         <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-        <Property name="Text" value="[image-size='w:32 h:32'][image='OpenDungeonsIcons/SpellsButton']" />
+        <Property name="Text" value="[image-size='w:40 h:40'][image='OpenDungeonsIcons/SpellsButton']" />
         <Property name="TooltipText" value="Spells" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
@@ -13,7 +13,7 @@
              which is only window width - 200 wide, at anything close to the
              minimum window size. -->
         <Window type="OD/GameTabButton" name="SummonWorkerButton" >
-            <Property name="Area" value="{{0,100},{0,10},{0,140},{0,50}}" />
+            <Property name="Area" value="{{0,20},{0,6},{0,72},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SummonWorkerButton" />
             <Property name="TooltipText" value="Summon a worker" />
             <Property name="InheritsAlpha" value="False" />
@@ -31,7 +31,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CallToWarButton" >
-            <Property name="Area" value="{{0,140},{0,10},{0,180},{0,50}}" />
+            <Property name="Area" value="{{0,76},{0,6},{0,128},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CallToWarButton" />
             <Property name="TooltipText" value="Casts a spell that calls available creatures" />
             <Property name="InheritsAlpha" value="False" />
@@ -49,7 +49,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHealButton" >
-            <Property name="Area" value="{{0,180},{0,10},{0,220},{0,50}}" />
+            <Property name="Area" value="{{0,132},{0,6},{0,184},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHealButton" />
             <Property name="TooltipText" value="Casts a spell that heals owned creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -67,7 +67,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureExplosionButton" >
-            <Property name="Area" value="{{0,220},{0,10},{0,260},{0,50}}" />
+            <Property name="Area" value="{{0,188},{0,6},{0,240},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
             <Property name="TooltipText" value="Casts a spell that damages enemy creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -85,7 +85,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHasteButton" >
-            <Property name="Area" value="{{0,260},{0,10},{0,300},{0,50}}" />
+            <Property name="Area" value="{{0,244},{0,6},{0,296},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHasteButton" />
             <Property name="TooltipText" value="Increases, target speed. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -103,7 +103,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureDefenseButton" >
-            <Property name="Area" value="{{0,100},{0,50},{0,140},{0,90}}" />
+            <Property name="Area" value="{{0,300},{0,6},{0,352},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureDefenseButton" />
             <Property name="TooltipText" value="Increases target physical defense. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -121,7 +121,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureSlowButton" >
-            <Property name="Area" value="{{0,140},{0,50},{0,180},{0,90}}" />
+            <Property name="Area" value="{{0,356},{0,6},{0,408},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureSlowButton" />
             <Property name="TooltipText" value="Decrease target speed. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -139,7 +139,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureStrengthButton" >
-            <Property name="Area" value="{{0,180},{0,50},{0,220},{0,90}}" />
+            <Property name="Area" value="{{0,412},{0,6},{0,464},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureStrengthButton" />
             <Property name="TooltipText" value="Increase target strength. Target: allied creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -157,7 +157,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureWeakButton" >
-            <Property name="Area" value="{{0,220},{0,50},{0,260},{0,90}}" />
+            <Property name="Area" value="{{0,468},{0,6},{0,520},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureWeakButton" />
             <Property name="TooltipText" value="Decrease target strength. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
@@ -175,7 +175,7 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="SpellEyeEvilButton" >
-            <Property name="Area" value="{{0,260},{0,50},{0,300},{0,90}}" />
+            <Property name="Area" value="{{0,20},{0,62},{0,72},{0,114}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SpellEyeEvilButton" />
             <Property name="TooltipText" value="Temporary gives vision on tiles without vision. Target: any tile" />
             <Property name="InheritsAlpha" value="False" />

--- a/gui/WindowTabSpells.layout
+++ b/gui/WindowTabSpells.layout
@@ -8,14 +8,18 @@
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
+        <!-- Two rows of 40x40, the same shape the rooms tab uses: one row of 60s
+             ran to x=700 and the last buttons fell off the right edge of the tab,
+             which is only window width - 200 wide, at anything close to the
+             minimum window size. -->
         <Window type="OD/GameTabButton" name="SummonWorkerButton" >
-            <Property name="Area" value="{{0,100},{0,25},{0,160},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,10},{0,140},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SummonWorkerButton" />
             <Property name="TooltipText" value="Summon a worker" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SummonWorkerButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -27,13 +31,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CallToWarButton" >
-            <Property name="Area" value="{{0,160},{0,25},{0,220},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,10},{0,180},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CallToWarButton" />
             <Property name="TooltipText" value="Casts a spell that calls available creatures" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CallToWarButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -45,13 +49,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHealButton" >
-            <Property name="Area" value="{{0,220},{0,25},{0,280},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,10},{0,220},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHealButton" />
             <Property name="TooltipText" value="Casts a spell that heals owned creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHealButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -63,13 +67,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureExplosionButton" >
-            <Property name="Area" value="{{0,280},{0,25},{0,340},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,10},{0,260},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
             <Property name="TooltipText" value="Casts a spell that damages enemy creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureExplosionButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -81,13 +85,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHasteButton" >
-            <Property name="Area" value="{{0,340},{0,25},{0,400},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,10},{0,300},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHasteButton" />
             <Property name="TooltipText" value="Increases, target speed. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHasteButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -99,13 +103,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureDefenseButton" >
-            <Property name="Area" value="{{0,400},{0,25},{0,460},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,50},{0,140},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureDefenseButton" />
             <Property name="TooltipText" value="Increases target physical defense. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureDefenseButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -117,13 +121,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureSlowButton" >
-            <Property name="Area" value="{{0,460},{0,25},{0,520},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,50},{0,180},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureSlowButton" />
             <Property name="TooltipText" value="Decrease target speed. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureSlowButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -135,13 +139,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureStrengthButton" >
-            <Property name="Area" value="{{0,520},{0,25},{0,580},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,50},{0,220},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureStrengthButton" />
             <Property name="TooltipText" value="Increase target strength. Target: allied creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureStrengthButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -153,13 +157,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureWeakButton" >
-            <Property name="Area" value="{{0,580},{0,25},{0,640},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,50},{0,260},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureWeakButton" />
             <Property name="TooltipText" value="Decrease target strength. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureWeakButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -171,13 +175,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="SpellEyeEvilButton" >
-            <Property name="Area" value="{{0,640},{0,25},{0,700},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,50},{0,300},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SpellEyeEvilButton" />
             <Property name="TooltipText" value="Temporary gives vision on tiles without vision. Target: any tile" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SpellEyeEvilButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />

--- a/gui/WindowTabTraps.layout
+++ b/gui/WindowTabTraps.layout
@@ -3,40 +3,40 @@
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Traps" >
         <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-        <Property name="Text" value="[image-size='w:32 h:32'][image='OpenDungeonsIcons/WorkshopButton']" />
+        <Property name="Text" value="[image-size='w:40 h:40'][image='OpenDungeonsIcons/WorkshopButton']" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
-        <Property name="TooltipText" value="Traps" />
+        <Property name="TooltipText" value="Workshop" />
         <Window type="OD/GameTabButton" name="DestroyTrapButton" >
-            <Property name="Area" value="{{0,20},{0,25},{0,80},{0,85}}" />
+            <Property name="Area" value="{{0,20},{0,6},{0,72},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/DestroyTrapButton" />
             <Property name="TooltipText" value="Destroy a trap (returns half its price)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="CannonButton" >
-            <Property name="Area" value="{{0,100},{0,25},{0,160},{0,85}}" />
+            <Property name="Area" value="{{0,76},{0,6},{0,128},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CannonButton" />
             <Property name="TooltipText" value="Build a cannon" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="SpikeTrapButton" >
-            <Property name="Area" value="{{0,160},{0,25},{0,220},{0,85}}" />
+            <Property name="Area" value="{{0,132},{0,6},{0,184},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SpikeTrapButton" />
             <Property name="TooltipText" value="Build a spike trap" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="BoulderTrapButton" >
-            <Property name="Area" value="{{0,220},{0,25},{0,280},{0,85}}" />
+            <Property name="Area" value="{{0,188},{0,6},{0,240},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/BoulderTrapButton" />
             <Property name="TooltipText" value="Build a boulder trap" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WoodenDoorTrapButton" >
-            <Property name="Area" value="{{0,280},{0,25},{0,340},{0,85}}" />
+            <Property name="Area" value="{{0,244},{0,6},{0,296},{0,58}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WoodenDoorTrapButton" />
             <Property name="TooltipText" value="Build a wooden door" />
             <Property name="InheritsAlpha" value="False" />

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,49 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$taskClippingPatch = Join-Path $PSScriptRoot 'patches/cegui-ogre-clipping.patch'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskClippingPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Restoring CEGUI Ogre rendering clip regions'
+    & git -C "$taskRoot\src\cegui" apply $taskClippingPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI clipping patch failed' }
+}
+$ErrorActionPreference = 'Stop'
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/ogre-multiwindow-settings.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\ogre" apply --recount --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying OGRE multi-window settings compatibility fixes'
+    & git -C "$taskRoot\src\ogre" apply --recount $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'OGRE compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/patches/cegui-ogre-clipping.patch
+++ b/scripts/win32/patches/cegui-ogre-clipping.patch
@@ -1,0 +1,11 @@
+diff --git a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
++++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+@@ -211,6 +211,6 @@
+             d_renderSystem._setViewport(currentViewport);
+ #else
+             d_renderSystem.setScissorTest(
+-                false, d_clipRect.left(), d_clipRect.top(),
++                i->clip, d_clipRect.left(), d_clipRect.top(),
+                          d_clipRect.right(), d_clipRect.bottom());
+ #endif

--- a/scripts/win32/patches/ogre-multiwindow-settings.patch
+++ b/scripts/win32/patches/ogre-multiwindow-settings.patch
@@ -1,0 +1,362 @@
+diff --git a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+index 361ff64..f7c6444 100644
+--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
++++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+@@ -126,6 +126,8 @@ namespace Ogre {
+ 
+         void initConfigOptions() override;
+ 
++        void setConfigOption(const String &name, const String &value) override;
++
+         RenderSystemCapabilities* createRenderSystemCapabilities() const override;
+ 
+         void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+index 8b9b623..294afa8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+@@ -74,6 +74,15 @@ namespace Ogre {
+         */
+         GLSLProgram* getActiveProgram(void);
+ 
++        /// Destroy all linked programs in the current OpenGL context.
++        void destroyAllPrograms();
++
++        /// Forget program-pipeline objects owned by a context that is being destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
++        /// Return the context currently selected by the render system.
++        GL3PlusContext* getCurrentContext() const;
++
+         /** Populate a list of uniforms based on an OpenGL program object.
+         */
+         void extractUniformsFromProgram(
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+index 65fec8d..a1b50e7 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+@@ -90,9 +90,12 @@ namespace Ogre
+         */
+         void activate(void) override;
+ 
++        /// Forget the context-local pipeline before its OpenGL context is destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
+     protected:
+-        /// GL handle for pipeline object.
+-        GLuint mGLProgramPipelineHandle;
++        /// GL program-pipeline objects are context-local even when shader programs are shared.
++        std::map<GL3PlusContext*, GLuint> mGLProgramPipelineHandles;
+ 
+         /// Compiles and links the separate programs.
+         void compileAndLink(void) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+index da255e6..9c6271e 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+@@ -62,6 +62,31 @@ namespace Ogre {
+ 
+     GLSLProgramManager::~GLSLProgramManager(void) {}
+ 
++    void GLSLProgramManager::destroyAllPrograms()
++    {
++        for (auto & program : mPrograms)
++        {
++            delete program.second;
++        }
++        mPrograms.clear();
++        mActiveProgram = NULL;
++    }
++
++    void GLSLProgramManager::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        for (auto & program : mPrograms)
++        {
++            if (auto separableProgram = dynamic_cast<GLSLSeparableProgram*>(program.second))
++                separableProgram->notifyContextDestroyed(context);
++        }
++        mActiveProgram = NULL;
++    }
++
++    GL3PlusContext* GLSLProgramManager::getCurrentContext() const
++    {
++        return mRenderSystem->_getCurrentContext();
++    }
++
+     GL3PlusStateCacheManager* GLSLProgramManager::getStateCacheManager()
+     {
+         return mRenderSystem->_getStateCacheManager();
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+index f22f44f..278f7e8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+@@ -45,14 +45,32 @@ namespace Ogre
+ 
+     GLSLSeparableProgram::~GLSLSeparableProgram()
+     {
+-        OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &mGLProgramPipelineHandle));
++        notifyContextDestroyed(GLSLProgramManager::getSingleton().getCurrentContext());
++        mGLProgramPipelineHandles.clear();
+     }
+ 
+     void GLSLSeparableProgram::compileAndLink()
+     {
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        OgreAssert(context, "cannot create a program pipeline without an active OpenGL context");
++
++        if (!mLinked)
++        {
++            auto currentPipeline = mGLProgramPipelineHandles.find(context);
++            if (currentPipeline != mGLProgramPipelineHandles.end())
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &currentPipeline->second));
++            mGLProgramPipelineHandles.clear();
++        }
++
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline != mGLProgramPipelineHandles.end())
++            return;
++
+         // Ensure no monolithic programs are in use.
+         OGRE_CHECK_GL_ERROR(glUseProgram(0));
+-        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &mGLProgramPipelineHandle));
++        GLuint pipelineHandle = 0;
++        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &pipelineHandle));
+ 
+         mLinked = true;
+ 
+@@ -61,51 +79,69 @@ namespace Ogre
+             if(!s) continue;
+ 
+             if(!s->linkSeparable())
+-        {
++            {
+                 mLinked = false;
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipelineHandle));
+                 return;
+             }
+         }
+ 
+-            GLenum ogre2gltype[GPT_COUNT] = {
+-                GL_VERTEX_SHADER_BIT,
+-                GL_FRAGMENT_SHADER_BIT,
+-                GL_GEOMETRY_SHADER_BIT,
+-                GL_TESS_EVALUATION_SHADER_BIT,
+-                GL_TESS_CONTROL_SHADER_BIT,
+-                GL_COMPUTE_SHADER_BIT
+-            };
++        GLenum ogre2gltype[GPT_COUNT] = {
++            GL_VERTEX_SHADER_BIT,
++            GL_FRAGMENT_SHADER_BIT,
++            GL_GEOMETRY_SHADER_BIT,
++            GL_TESS_EVALUATION_SHADER_BIT,
++            GL_TESS_CONTROL_SHADER_BIT,
++            GL_COMPUTE_SHADER_BIT
++        };
+ 
+-            for (auto s : mShaders)
+-            {
++        for (auto s : mShaders)
++        {
+             if(!s) continue;
+ 
+-                OGRE_CHECK_GL_ERROR(glUseProgramStages(mGLProgramPipelineHandle, ogre2gltype[s->getType()],
+-                                                       s->getGLProgramHandle()));
+-            }
++            OGRE_CHECK_GL_ERROR(glUseProgramStages(pipelineHandle, ogre2gltype[s->getType()],
++                                                   s->getGLProgramHandle()));
++        }
+ 
+-            // Validate pipeline
+-            OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(mGLProgramPipelineHandle));
+-            logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), mGLProgramPipelineHandle );
++        // Validate pipeline
++        OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(pipelineHandle));
++        logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), pipelineHandle );
+ 
+-            //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
+-            //                glObjectLabel(GL_PROGRAM_PIPELINE, mGLProgramPipelineHandle, 0,
+-            //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
+-        }
++        mGLProgramPipelineHandles[context] = pipelineHandle;
++
++        //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
++        //                glObjectLabel(GL_PROGRAM_PIPELINE, pipelineHandle, 0,
++        //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
++    }
+ 
+     void GLSLSeparableProgram::activate(void)
+     {
+-        if (!mLinked)
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (!mLinked || pipeline == mGLProgramPipelineHandles.end())
+         {
+             compileAndLink();
++            pipeline = mGLProgramPipelineHandles.find(context);
+         }
+ 
+-        if (mLinked)
++        if (mLinked && pipeline != mGLProgramPipelineHandles.end())
+         {
+-            GLSLProgramManager::getSingleton().getStateCacheManager()->bindGLProgramPipeline(mGLProgramPipelineHandle);
++            programManager.getStateCacheManager()->bindGLProgramPipeline(pipeline->second);
+         }
+     }
+ 
++    void GLSLSeparableProgram::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline == mGLProgramPipelineHandles.end())
++            return;
++
++        if (GLSLProgramManager::getSingleton().getCurrentContext() == context)
++            OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipeline->second));
++        mGLProgramPipelineHandles.erase(pipeline);
++    }
++
+     void GLSLSeparableProgram::updateUniforms(GpuProgramParametersSharedPtr params,
+                                               uint16 mask, GpuProgramType fromProgType)
+     {
+diff --git a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+index 5695b7f..07e3aa1 100644
+--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
++++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+@@ -34,6 +34,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
+ #include "OgreStringConverter.h"
+ #include "OgreGL3PlusTextureManager.h"
+ #include "OgreGL3PlusHardwareBuffer.h"
++#include "OgreHighLevelGpuProgramManager.h"
+ #include "OgreGLSLShader.h"
+ #include "OgreGpuProgramManager.h"
+ #include "OgreException.h"
+@@ -214,6 +215,78 @@ namespace Ogre {
+         mOptions[opt.name] = opt;
+     }
+ 
++    void GL3PlusRenderSystem::setConfigOption(const String &name, const String &value)
++    {
++        const bool separateShadersChanged = name == "Separate Shader Objects"
++            && mGLInitialised && mSeparateShaderObjectsEnabled != StringConverter::parseBool(value);
++
++        GLRenderSystemCommon::setConfigOption(name, value);
++        if (!mGLInitialised)
++            return;
++
++        if (separateShadersChanged)
++        {
++            std::vector<ResourcePtr> loadedPrograms;
++            ResourceManager::ResourceMapIterator resources =
++                HighLevelGpuProgramManager::getSingleton().getResourceIterator();
++            while (resources.hasMoreElements())
++            {
++                ResourcePtr program = resources.getNext();
++                if (program->isLoaded())
++                    loadedPrograms.push_back(program);
++            }
++            for (int programType = 0; programType < GPT_COUNT; ++programType)
++            {
++                GpuProgramType type = static_cast<GpuProgramType>(programType);
++                if (mCurrentShader[type])
++                    unbindGpuProgram(type);
++            }
++            OGRE_CHECK_GL_ERROR(glUseProgram(0));
++            mStateCacheManager->bindGLProgramPipeline(0);
++            mProgramManager->destroyAllPrograms();
++            for (ResourcePtr & program : loadedPrograms)
++                program->unload();
++
++            mSeparateShaderObjectsEnabled = StringConverter::parseBool(value);
++            if (mSeparateShaderObjectsEnabled)
++                mCurrentCapabilities->setCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            else
++                mCurrentCapabilities->unsetCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            for (ResourcePtr & program : loadedPrograms)
++                program->load();
++        }
++        else if (name == "Reversed Z-Buffer")
++        {
++            const bool clipControlSupported = hasMinGLVersion(4, 5)
++                || checkExtension("GL_ARB_clip_control");
++            mIsReverseDepthBufferEnabled = StringConverter::parseBool(value)
++                && clipControlSupported;
++            if (clipControlSupported)
++            {
++                OGRE_CHECK_GL_ERROR(glClipControl(GL_LOWER_LEFT,
++                    mIsReverseDepthBufferEnabled ? GL_ZERO_TO_ONE : GL_NEGATIVE_ONE_TO_ONE));
++            }
++        }
++        else if (name == "Debug Layer" && getCapabilities()->hasCapability(RSC_DEBUG))
++        {
++            const bool debugEnabled = StringConverter::parseBool(value);
++            if (debugEnabled)
++            {
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT));
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(&GLDebugCallback, NULL));
++                OGRE_CHECK_GL_ERROR(glDebugMessageControlARB(GL_DEBUG_SOURCE_API, GL_DONT_CARE,
++                    GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_FALSE));
++            }
++            else
++            {
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(NULL, NULL));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT));
++            }
++        }
++    }
++
+     RenderSystemCapabilities* GL3PlusRenderSystem::createRenderSystemCapabilities() const
+     {
+         RenderSystemCapabilities* rsc = OGRE_NEW RenderSystemCapabilities();
+@@ -1398,6 +1471,7 @@ namespace Ogre {
+ 
+     void GL3PlusRenderSystem::_unregisterContext(GL3PlusContext *context)
+     {
++        mProgramManager->notifyContextDestroyed(context);
+         static_cast<GL3PlusHardwareBufferManager*>(HardwareBufferManager::getSingletonPtr())->notifyContextDestroyed(context);
+ 
+         for(auto & rt : mRenderTargets)
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+index 70e89c2..8f8178c 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+@@ -327,7 +327,8 @@ namespace Ogre {
+                         mHasPixelFormatARB = true;
+                     else if (ext == "WGL_ARB_multisample")
+                         mHasMultisample = true;
+-                    else if (ext == "WGL_EXT_framebuffer_sRGB")
++                    else if (ext == "WGL_EXT_framebuffer_sRGB"
++                             || ext == "WGL_ARB_framebuffer_sRGB")
+                         mHasHardwareGamma = true;
+                 }
+             }
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+index c4269f8..f46ddff 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+@@ -551,11 +551,8 @@ namespace Ogre {
+ 
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_TOPMOST, mLeft, mTop, width, height,
+-                    SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+-
++                    SWP_FRAMECHANGED | SWP_NOACTIVATE);
++                windowMovedOrResized();
+             }
+             else
+             {               
+@@ -584,9 +581,6 @@ namespace Ogre {
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_NOTOPMOST, left, top, winWidth, winHeight,
+                     SWP_DRAWFRAME | SWP_FRAMECHANGED | SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+                 windowMovedOrResized();
+ 
+             }

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -65,6 +65,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <exception>
 
 void ODApplication::startGame(boost::program_options::variables_map& options)
 {
@@ -80,10 +81,20 @@ void ODApplication::startGame(boost::program_options::variables_map& options)
     logMgr.setLevel(resMgr.getLogLevel());
 
 
-    if(resMgr.isServerMode())
-        startServer();
-    else
-        startClient();
+    try
+    {
+        if(resMgr.isServerMode())
+            startServer();
+        else
+            startClient();
+    }
+    catch(const std::exception& error)
+    {
+        // Preserve the exception before the log manager is destroyed and main
+        // displays its Windows error dialog.
+        OD_LOG_ERR("Unhandled exception: " + std::string(error.what()));
+        throw;
+    }
 }
 
 void ODApplication::startServer()
@@ -161,7 +172,7 @@ void ODApplication::startClient()
         std::stringstream ss(videoMode);
         // Ignore the x in the middle
         char ignore;
-        ss >> w >> ignore >> h >> h;
+        ss >> w >> ignore >> h;
 
         w = std::max(w, MIN_WIDTH);
         h = std::max(h, MIN_HEIGHT);
@@ -210,11 +221,7 @@ void ODApplication::startClient()
     
     ogreRoot.initialise(false);
 
-    Ogre::NameValuePairList misc;
-    misc["FSAA"] = "0";
-    misc["vsync"] = "true";
-
-    // You can also later load these from config or allow command-line override
+    Ogre::NameValuePairList misc = ogreRoot.getRenderSystem()->getRenderWindowDescription().miscParams;
 
     OD_LOG_INF("Creating window: with resolution " + Helper::toString(w) + " " + Helper::toString(h));
     
@@ -235,7 +242,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system
@@ -333,6 +340,7 @@ void ODApplication::startClient()
     Ogre::MaterialManager::getSingleton().removeListener(sgListener);
     delete sgListener;
     Ogre::RTShader::ShaderGenerator::destroy();
+    frameListener.prepareRenderWindowShutdown();
     ogreRoot.destroyRenderTarget(renderWindow);
 }
 

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -80,6 +80,7 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mSwivelDegrees(0.0),
     mTranslateVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mTranslateVectorAccel(Ogre::Vector3(0.0, 0.0, 0.0)),
+    mTranslateMaxSpeedFactor(Ogre::Vector2(1.0, 1.0)),
     mRotateLocalVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mSceneManager(sceneManager),
     mViewport(nullptr)
@@ -241,6 +242,30 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
     OD_LOG_INF("Creating viewport...");
 }
 
+void CameraManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    Ogre::Viewport* previousViewport = mViewport;
+    Ogre::RenderTarget* previousTarget = previousViewport->getTarget();
+    Ogre::Viewport* viewport = renderWindow->addViewport(mActiveCamera,
+        previousViewport->getZOrder(), previousViewport->getLeft(), previousViewport->getTop(),
+        previousViewport->getWidth(), previousViewport->getHeight());
+    viewport->setBackgroundColour(previousViewport->getBackgroundColour());
+    viewport->setClearEveryFrame(previousViewport->getClearEveryFrame(), previousViewport->getClearBuffers());
+    viewport->setMaterialScheme(previousViewport->getMaterialScheme());
+    viewport->setOverlaysEnabled(previousViewport->getOverlaysEnabled());
+    viewport->setSkiesEnabled(previousViewport->getSkiesEnabled());
+    viewport->setShadowsEnabled(previousViewport->getShadowsEnabled());
+    viewport->setVisibilityMask(previousViewport->getVisibilityMask());
+
+    mViewport = viewport;
+    previousTarget->removeViewport(previousViewport->getZOrder());
+    if(viewport->getActualHeight() > 0)
+    {
+        mActiveCamera->setAspectRatio(static_cast<Ogre::Real>(viewport->getActualWidth())
+            / static_cast<Ogre::Real>(viewport->getActualHeight()));
+    }
+}
+
 const Ogre::Vector3& CameraManager::getActiveCameraPosition() const
 {
     return getActiveCameraNode()->getPosition();
@@ -285,6 +310,18 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     mTranslateVector *= static_cast<Ogre::Real>(std::max(0.0f, speed - (0.75f + (speed / mMoveSpeed))
                         * mMoveSpeedAcceleration * frameTime));
     mTranslateVector += mTranslateVectorAccel * static_cast<Ogre::Real>(frameTime * 2.0f);
+
+    const Ogre::Real maxMoveSpeedX = mMoveSpeed * mTranslateMaxSpeedFactor.x;
+    if(mTranslateVector.x > maxMoveSpeedX)
+        mTranslateVector.x = maxMoveSpeedX;
+    else if(mTranslateVector.x < -maxMoveSpeedX)
+        mTranslateVector.x = -maxMoveSpeedX;
+
+    const Ogre::Real maxMoveSpeedY = mMoveSpeed * mTranslateMaxSpeedFactor.y;
+    if(mTranslateVector.y > maxMoveSpeedY)
+        mTranslateVector.y = maxMoveSpeedY;
+    else if(mTranslateVector.y < -maxMoveSpeedY)
+        mTranslateVector.y = -maxMoveSpeedY;
 
     // If we have sped up to more than the maximum moveSpeed then rescale the
     // vector to that length. We use the squaredLength() in this calculation
@@ -615,54 +652,70 @@ void CameraManager::move(const Direction direction, double aux)
     Ogre::Real currentPitch = getActiveCameraNode()->getOrientation().getPitch().valueDegrees();
     currentPitch = std::fmod(currentPitch, 90.0f);
 
+    const bool scaledPan = aux > 0.0;
+    const Ogre::Real maxSpeedFactor = scaledPan ?
+        static_cast<Ogre::Real>(std::min(aux, 1.0)) : 1.0f;
+    const auto applyPanAcceleration = [this, scaledPan](Ogre::Real& acceleration, Ogre::Real direction)
+    {
+        const Ogre::Real newAcceleration = direction * mMoveSpeedAcceleration;
+        if(scaledPan)
+            acceleration = newAcceleration;
+        else
+            acceleration += newAcceleration;
+    };
+
     switch (direction)
     {
     case moveRight:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopRight:
         if(mTranslateVectorAccel.x >= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveLeft:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopLeft:
         if(mTranslateVectorAccel.x <= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveBackward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopBackward:
         if(mTranslateVectorAccel.y <= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveForward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopForward:
         if(mTranslateVectorAccel.y >= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveUp:

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -163,6 +163,9 @@ public:
     Ogre::Viewport* getViewport()
     { return mViewport; }
 
+    //! \brief Move the main camera viewport to another render window.
+    void setRenderWindow(Ogre::RenderWindow* renderWindow);
+
     void resetHCSNodes(int nodeValue)
     {
         mXHCS.resetNodes(nodeValue);
@@ -244,6 +247,9 @@ private:
     //! \brief Carry out the acceleration/deceleration calculations on the camera translation.
     Ogre::Vector3   mTranslateVector;
     Ogre::Vector3   mTranslateVectorAccel;
+
+    //! \brief Maximum pan speed per axis, used to scale mouse-edge scrolling.
+    Ogre::Vector2   mTranslateMaxSpeedFactor;
 
     //! \brief The X-axis rotation vector, tilting the point of view (look down or up).
     Ogre::Vector3   mRotateLocalVector;

--- a/source/game/SkillManager.cpp
+++ b/source/game/SkillManager.cpp
@@ -735,3 +735,36 @@ void SkillManager::connectGuiButtons(GameEditorModeBase* mode, CEGUI::Window* ro
         skill->connectGuiButtons(mode, rootWindow, playerSelection);
     }
 }
+
+std::string SkillManager::getSelectedButton(const PlayerSelection& playerSelection)
+{
+    SkillFamily family;
+    uint32_t type;
+    switch(playerSelection.getCurrentAction())
+    {
+        case SelectedAction::buildRoom:
+            family = SkillFamily::rooms;
+            type = static_cast<uint32_t>(playerSelection.getNewRoomType());
+            break;
+        case SelectedAction::buildTrap:
+            family = SkillFamily::traps;
+            type = static_cast<uint32_t>(playerSelection.getNewTrapType());
+            break;
+        case SelectedAction::castSpell:
+            family = SkillFamily::spells;
+            type = static_cast<uint32_t>(playerSelection.getNewSpellType());
+            break;
+        case SelectedAction::destroyRoom:
+            return Gui::BUTTON_DESTROY_ROOM;
+        case SelectedAction::destroyTrap:
+            return Gui::BUTTON_DESTROY_TRAP;
+        default:
+            return "";
+    }
+
+    const std::vector<SkillType>& skills = getSkillManager().mSkillsFamily.at(static_cast<uint32_t>(family));
+    if(type >= skills.size() || skills[type] == SkillType::nullSkillType)
+        return "";
+    const SkillDef* skill = getSkillManager().mSkills.at(static_cast<uint32_t>(skills[type]));
+    return skill->getGuiPath() + skill->mButtonName;
+}

--- a/source/game/SkillManager.h
+++ b/source/game/SkillManager.h
@@ -101,6 +101,9 @@ public:
 
     static void connectGuiButtons(GameEditorModeBase* mode, CEGUI::Window* rootWindow, PlayerSelection& playerSelection);
 
+    //! Return the action-bar button corresponding to the current room, trap or spell.
+    static std::string getSelectedButton(const PlayerSelection& playerSelection);
+
 private:
     //! \brief Allowed skills
     std::vector<const SkillDef*> mSkills;

--- a/source/gamemap/MiniMap.cpp
+++ b/source/gamemap/MiniMap.cpp
@@ -23,6 +23,54 @@
 #include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 
+#include <CEGUI/BasicImage.h>
+#include <CEGUI/ImageManager.h>
+#include <CEGUI/Window.h>
+#include <cmath>
+
+namespace
+{
+class CircularMiniMapImage : public CEGUI::BasicImage
+{
+public:
+    explicit CircularMiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name) {}
+    explicit CircularMiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes) {}
+
+    void render(CEGUI::GeometryBuffer& buffer, const CEGUI::Rectf& area,
+        const CEGUI::Rectf* clip, const CEGUI::ColourRect& colours) const override
+    {
+        if(area.getWidth() <= 0.0f || area.getHeight() <= 0.0f)
+            return;
+        // Clip the existing texture, preserving its coordinates and all renderer choices.
+        const float radiusX = area.getWidth() * 0.5f;
+        const float radiusY = area.getHeight() * 0.5f;
+        const float centerX = area.left() + radiusX;
+        for(float y = area.top(); y < area.bottom(); y += 1.0f)
+        {
+            const float nextY = std::min(y + 1.0f, area.bottom());
+            const float dy = ((y + nextY) * 0.5f - area.top() - radiusY) / radiusY;
+            const float halfWidth = radiusX * std::sqrt(std::max(0.0f, 1.0f - dy * dy));
+            CEGUI::Rectf strip(centerX - halfWidth, y, centerX + halfWidth, nextY);
+            if(clip != nullptr)
+                strip = strip.getIntersection(*clip);
+            if(strip.getWidth() > 0.0f && strip.getHeight() > 0.0f)
+                CEGUI::BasicImage::render(buffer, area, &strip, colours);
+        }
+    }
+};
+}
+
+CEGUI::BasicImage& MiniMap::createMiniMapImage(CEGUI::Window* miniMapWindow)
+{
+    CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
+    const bool circular = miniMapWindow->isUserStringDefined("Circular") &&
+        miniMapWindow->getUserString("Circular") == "true";
+    if(circular && !images.isImageTypeAvailable("CircularMiniMap"))
+        images.addImageType<CircularMiniMapImage>("CircularMiniMap");
+    return static_cast<CEGUI::BasicImage&>(images.create(
+        circular ? "CircularMiniMap" : "BasicImage", "MiniMapImageset"));
+}
+
 namespace MiniMapTypes
 {
 static const std::string MINIMAP_CAMERA = "MiniMapCamera";

--- a/source/gamemap/MiniMap.h
+++ b/source/gamemap/MiniMap.h
@@ -22,7 +22,8 @@
 
 namespace CEGUI
 {
-class Window;
+    class Window;
+    class BasicImage;
 }
 
 class MiniMap
@@ -41,6 +42,7 @@ public:
 
     //! \brief This function will create the minimap according to user preferences
     static MiniMap* createMiniMap(CEGUI::Window* miniMapWindow);
+    static CEGUI::BasicImage& createMiniMapImage(CEGUI::Window* miniMapWindow);
 
     // Returns the list of all possible minimap types
     static const std::vector<std::string>& getMiniMapTypes();

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -95,7 +95,7 @@ MiniMapCamera::MiniMapCamera(CEGUI::Window* miniMapWindow) :
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
         CEGUI::Size<float>(static_cast<float>(TEXTURE_SIZE), static_cast<float>(TEXTURE_SIZE))));
 

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -146,8 +146,9 @@ Ogre::Vector2 MiniMapCamera::camera_2dPositionFromClick(int xx, int yy)
     Ogre::Real sin = Ogre::Math::Sin(angle);
 
     // Compute tile clicked
-    Ogre::Real diffX = ((xx - mTopLeftCornerX) / mWidth - 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
-    Ogre::Real diffY = ((mTopLeftCornerY - yy) / mHeight + 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
+    Ogre::Real diffX = ((xx - mTopLeftCornerX) / displaySize.d_width - 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
+    Ogre::Real diffY = ((mTopLeftCornerY - yy) / displaySize.d_height + 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
 
     Ogre::Vector2 pos(diffX * cos - diffY * sin + mCurCamPosX, diffX * sin + diffY * cos + mCurCamPosY);
     OD_LOG_INF("Clicked minimap pos=" + Helper::toString(pos.x) + ", " + Helper::toString(pos.y));

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -123,6 +123,7 @@ MiniMapCamera::~MiniMapCamera()
     rt->removeAllListeners();
     Ogre::SceneManager* sceneManager = RenderManager::getSingleton().getSceneManager();
     sceneManager->destroyCamera(mMiniMapCam);
+    sceneManager->destroySceneNode(mMiniMapCamNode);
     Ogre::String mm("miniMapOgreTexture");
     Ogre::TextureManager::getSingletonPtr()->remove(mm,Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     CEGUI::ImageManager::getSingletonPtr()->destroy("MiniMapImageset");
@@ -131,6 +132,8 @@ MiniMapCamera::~MiniMapCamera()
 
 Ogre::Vector2 MiniMapCamera::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     if(mCurCamPosX == -1)
         return Ogre::Vector2::ZERO;
 

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -68,7 +68,7 @@ MiniMapDrawn::MiniMapDrawn(CEGUI::Window* miniMapWindow) :
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
                                       CEGUI::Size<float>(
                                           static_cast<float>(mWidth), static_cast<float>(mHeight)

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -100,8 +100,9 @@ Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
     mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Real mm, nn, oo, pp;
     // Compute move and normalise
-    mm = (xx - mTopLeftCornerX) / static_cast<double>(mWidth) - 0.5;
-    nn = (yy - mTopLeftCornerY) / static_cast<double>(mHeight) - 0.5;
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
+    mm = (xx - mTopLeftCornerX) / static_cast<double>(displaySize.d_width) - 0.5;
+    nn = (yy - mTopLeftCornerY) / static_cast<double>(displaySize.d_height) - 0.5;
     // Applying rotation
     oo = nn * mSinRotation + mm * mCosRotation;
     pp = nn * mCosRotation - mm * mSinRotation;

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -96,6 +96,8 @@ MiniMapDrawn::~MiniMapDrawn()
 
 Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Real mm, nn, oo, pp;
     // Compute move and normalise
     mm = (xx - mTopLeftCornerX) / static_cast<double>(mWidth) - 0.5;

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -407,7 +407,7 @@ MiniMapDrawnFull::MiniMapDrawnFull(CEGUI::Window* miniMapWindow) :
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
                                       CEGUI::Size<float>(
                                           static_cast<float>(mWidth), static_cast<float>(mHeight)

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -454,13 +454,14 @@ Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
     mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
     mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Vector2 v(0, 0);
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
     Ogre::Real gainX = static_cast<Ogre::Real>(mGameMap.getMapSizeX())
-        / static_cast<Ogre::Real>(mWidth);
+        / displaySize.d_width;
     Ogre::Real gainY = static_cast<Ogre::Real>(mGameMap.getMapSizeY())
-        / static_cast<Ogre::Real>(mHeight);
+        / displaySize.d_height;
 
     v.x = round(static_cast<Ogre::Real>(xx - mTopLeftCornerX) * gainX);
-    v.y = round(static_cast<Ogre::Real>(mHeight - yy + mTopLeftCornerY) * gainY);
+    v.y = round(static_cast<Ogre::Real>(displaySize.d_height - yy + mTopLeftCornerY) * gainY);
 
     return v;
 }

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -451,6 +451,8 @@ MiniMapDrawnFull::~MiniMapDrawnFull()
 
 Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Vector2 v(0, 0);
     Ogre::Real gainX = static_cast<Ogre::Real>(mGameMap.getMapSizeX())
         / static_cast<Ogre::Real>(mWidth);

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -122,7 +122,7 @@ EditorMode::EditorMode(ModeManager* modeManager):
     mPortalWaveRefreshing(false),
     mMouseX(0),
     mMouseY(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mModifiedMapBit(false)
 {
 

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -29,6 +29,7 @@
 #include "rooms/RoomType.h"
 #include "traps/TrapType.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/MakeUnique.h"
 
 #include <Ogre.h>
@@ -94,6 +95,7 @@ GameEditorModeBase::GameEditorModeBase(ModeManager* modeManager, ModeManager::Mo
     mChatMessageDisplayTime(0),
     mChatMessageBoxDisplay(ChatMessageBoxDisplay::hide),
     mMiniMap(MiniMap::createMiniMap(rootWindow->getChild(Gui::MINIMAP))),
+    mMiniMapType(ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false)),
     mMainCullingManager( new CullingManager(mGameMap, CullingType::SHOW_MAIN_WINDOW)),
     mKeepReplayAtDisconnect(false),
     mCameraTilesIntersections(std::vector<Ogre::Vector3>(4, Ogre::Vector3::ZERO)),
@@ -192,6 +194,14 @@ bool GameEditorModeBase::onMinimapClick(const CEGUI::EventArgs& arg)
 
 void GameEditorModeBase::onFrameStarted(const Ogre::FrameEvent& evt)
 {
+    const std::string miniMapType = ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false);
+    if(miniMapType != mMiniMapType)
+    {
+        delete mMiniMap;
+        mMiniMap = nullptr;
+        mMiniMap = MiniMap::createMiniMap(mRootWindow->getChild(Gui::MINIMAP));
+        mMiniMapType = miniMapType;
+    }
     updateMessages(evt.timeSinceLastFrame);
     if(mMainCullingManager != nullptr)
     {
@@ -336,4 +346,3 @@ void GameEditorModeBase::leaveConsole()
     mCurrentInputMode = InputModeNormal;
     activate();
 }
-

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -267,7 +267,7 @@ void GameEditorModeBase::updateMessages(Ogre::Real update_time)
     for (auto it = mEventMessages.begin(); it != mEventMessages.end();)
     {
         EventMessage* event = *it;
-        if (event->isMessageTooOld(maxChatTimeDisplay))
+        if (shouldExpireEventMessages() && event->isMessageTooOld(maxChatTimeDisplay))
         {
             delete event;
             it = mEventMessages.erase(it);

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -183,6 +183,18 @@ bool GameEditorModeBase::onMinimapClick(const CEGUI::EventArgs& arg)
 {
     const CEGUI::MouseEventArgs& mouseEvt = static_cast<const CEGUI::MouseEventArgs&>(arg);
 
+    CEGUI::Window* mapWindow = mRootWindow->getChild(Gui::MINIMAP);
+    if(mapWindow->isUserStringDefined("Circular") && mapWindow->getUserString("Circular") == "true")
+    {
+        const CEGUI::Rectf area = mapWindow->getUnclippedOuterRect().get();
+        if(area.getWidth() <= 0.0f || area.getHeight() <= 0.0f)
+            return true;
+        const float x = 2.0f * (mouseEvt.position.d_x - area.left()) / area.getWidth() - 1.0f;
+        const float y = 2.0f * (mouseEvt.position.d_y - area.top()) / area.getHeight() - 1.0f;
+        if(x * x + y * y > 1.0f)
+            return true;
+    }
+
     ODFrameListener& frameListener = ODFrameListener::getSingleton();
 
     Ogre::Vector2 cc = mMiniMap->camera_2dPositionFromClick(static_cast<int>(mouseEvt.position.d_x),

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -108,7 +108,7 @@ public:
     void receiveChat(const ChatMessage& chat) override;
 
     //! \brief Receive and display some event text
-    void receiveEventShortNotice(EventMessage* event);
+    virtual void receiveEventShortNotice(EventMessage* event);
 
     //! \brief Called when the mode is activated.
     virtual void activate() override = 0;
@@ -137,6 +137,7 @@ protected:
 
     //! \brief Update the chat and event messages seen.
     void updateMessages(Ogre::Real update_time);
+    virtual bool shouldExpireEventMessages() const { return true; }
 
     //! \brief The main CEGUI window.
     CEGUI::Window* mRootWindow;

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -156,6 +156,7 @@ protected:
 
     //! \brief The minimap used in this mode
     MiniMap* mMiniMap;
+    std::string mMiniMapType;
 
     //! \brief Culling manager for the main map
     CullingManager* mMainCullingManager;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -37,6 +37,7 @@
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
 #include "render/TextRenderer.h"
+#include "rooms/Room.h"
 #include "rooms/RoomManager.h"
 #include "rooms/RoomType.h"
 #include "sound/MusicPlayer.h"
@@ -85,7 +86,6 @@ static double getAutoscrollIntensity(int mousePosition, int screenSize, bool min
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
-    mIsSpellCooldownDisplayed(false),
     mIndexEvent(0),
     mSettings(mRootWindow, modeManager->getGui()),
     mIsSkillWindowOpen(false),
@@ -102,6 +102,14 @@ GameMode::GameMode(ModeManager *modeManager):
     ODFrameListener::getSingleton().getCameraManager()->setDefaultView();
 
     CEGUI::Window* guiSheet = mRootWindow;
+
+    SkillManager::listAllSkills([this](const std::string&, const std::string& castButton,
+        const std::string&, SkillType)
+    {
+        mRootWindow->getChild(castButton)->setProperty("SelectionColour", "00FFFFFF");
+    });
+    guiSheet->getChild(Gui::BUTTON_DESTROY_ROOM)->setProperty("SelectionColour", "00FFFFFF");
+    guiSheet->getChild(Gui::BUTTON_DESTROY_TRAP)->setProperty("SelectionColour", "00FFFFFF");
 
     //Help window
     addEventConnection(
@@ -420,9 +428,6 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     textRenderer.moveText(ODApplication::POINTER_INFO_STRING,
                           static_cast<Ogre::Real>(mouseEvent.x + 30), static_cast<Ogre::Real>(mouseEvent.y));
 
-    // We notify current selection input
-    checkInputCommand();
-
     handleMouseWheel(toSFMLMouseWheel(arg));
 
     // Since this is a tile selection query we loop over the result set
@@ -432,6 +437,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     int tileX = Helper::round(inputManager.mKeeperHandPos.x);
     int tileY = Helper::round(inputManager.mKeeperHandPos.y);
+    inputManager.mXPos = tileX;
+    inputManager.mYPos = tileY;
     Tile* tileClicked = mGameMap->getTile(tileX, tileY);
     if(tileClicked == nullptr)
         return true;
@@ -573,21 +580,48 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     if(mGameMap->getGamePaused())
         return true;
 
-    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos,RenderManager::KEEPER_HAND_WORLD_Z))
+    // Cancelling an action does not require a valid world target.
+    if(id == OIS::MB_Right && mPlayerSelection.getCurrentAction() != SelectedAction::none)
+    {
+        inputManager.mRMouseDown = true;
+        inputManager.mLMouseDown = false;
+        mPlayerSelection.setCurrentAction(SelectedAction::none);
+        mActionFailureTime = 0.0f;
+        unselectAllTiles();
+        TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
         return true;
+    }
 
-    RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
+    if(ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos,RenderManager::KEEPER_HAND_WORLD_Z))
+    {
+        inputManager.mXPos = Helper::round(inputManager.mKeeperHandPos.x);
+        inputManager.mYPos = Helper::round(inputManager.mKeeperHandPos.y);
+        RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
+    }
+    else
+    {
+        inputManager.mXPos = -1;
+        inputManager.mYPos = -1;
+    }
 
     // The player should be able to move the mouse even if not clicking on a tile. Because of that, we set
     // mMMouseDown before checking which tile is clicked
     if (id == OIS::MB_Middle)
         inputManager.mMMouseDown = true;
 
-    int tileX = Helper::round(inputManager.mKeeperHandPos.x);
-    int tileY = Helper::round(inputManager.mKeeperHandPos.y);
-    Tile* tileClicked = mGameMap->getTile(tileX, tileY);
+    Tile* tileClicked = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
     if(tileClicked == nullptr)
+    {
+        if(id == OIS::MB_Left ||
+           (id == OIS::MB_Right && mGameMap->getLocalPlayer()->numObjectsInHand() > 0))
+        {
+            const InputCommandState previousState = inputManager.mCommandState;
+            inputManager.mCommandState = InputCommandState::validated;
+            displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
+            inputManager.mCommandState = previousState;
+        }
         return true;
+    }
 
     if (id == OIS::MB_Middle)
     {
@@ -637,24 +671,20 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
         inputManager.mLStartDragY = inputManager.mYPos;
         unselectAllTiles();
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
-        // If we have a currently selected action, we cancel it and don't try to slap or
-        // drop what we have in hand
-        if(mPlayerSelection.getCurrentAction() != SelectedAction::none)
-        {
-            mPlayerSelection.setCurrentAction(SelectedAction::none);
-            return true;
-        }
-
         if(mGameMap->getLocalPlayer()->numObjectsInHand() > 0)
         {
             // If we right clicked with the mouse over a valid map tile, try to drop what we have in hand on the map.
             Tile *curTile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
 
             if (curTile == nullptr)
+            {
+                displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
                 return true;
+            }
 
             if (mGameMap->getLocalPlayer()->isDropHandPossible(curTile))
             {
+                mActionFailureTime = 0.0f;
                 if(ODClient::getSingleton().isConnected())
                 {
                     // Send a message to the server telling it we want to drop the creature
@@ -666,6 +696,11 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
 
                 return true;
             }
+            const InputCommandState previousState = inputManager.mCommandState;
+            inputManager.mCommandState = InputCommandState::validated;
+            handlePlayerActionNone();
+            inputManager.mCommandState = previousState;
+            return true;
         }
         else
         {
@@ -770,7 +805,6 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
     CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseButtonUp(Gui::convertButton(id));
 
     InputManager& inputManager = mModeManager->getInputManager();
-    inputManager.mCommandState = InputCommandState::validated;
 
     // First check for the axis rotation release, as this
     // seems to be the most expected action the user wants to put at end
@@ -781,13 +815,6 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
         ODFrameListener::getSingleton().moveCamera(CameraManager::zeroRandomRotateX, 0.0);
         ODFrameListener::getSingleton().moveCamera(CameraManager::zeroRandomRotateY, 0.0);
     }
-
-    // If the mouse press was on a CEGUI window ignore it
-    if (inputManager.mMouseDownOnCEGUIWindow)
-        return true;
-
-    if (!isConnected())
-        return true;
 
     // Right mouse button up
     if (id == OIS::MB_Right)
@@ -800,10 +827,38 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
         return true;
 
     // Left mouse button up
+    const bool wasLeftMouseDown = inputManager.mLMouseDown;
     inputManager.mLMouseDown = false;
+    inputManager.mCommandState = InputCommandState::infoOnly;
+
+    // Only finish a world action that began on the map and was not cancelled.
+    if(!wasLeftMouseDown || inputManager.mMouseDownOnCEGUIWindow ||
+       isMouseDownOnCEGUIWindow() || !isConnected() || mGameMap->getGamePaused())
+    {
+        if(mPlayerSelection.getCurrentAction() == SelectedAction::selectTile)
+            mPlayerSelection.setCurrentAction(SelectedAction::none);
+        unselectAllTiles();
+        return true;
+    }
+
+    if(ODFrameListener::getSingleton().findWorldPositionFromMouse(arg,
+        inputManager.mKeeperHandPos, RenderManager::KEEPER_HAND_WORLD_Z))
+    {
+        inputManager.mXPos = Helper::round(inputManager.mKeeperHandPos.x);
+        inputManager.mYPos = Helper::round(inputManager.mKeeperHandPos.y);
+    }
+    else
+    {
+        inputManager.mXPos = -1;
+        inputManager.mYPos = -1;
+    }
 
     // We notify current selection input
+    inputManager.mCommandState = InputCommandState::validated;
     checkInputCommand();
+    if(mPlayerSelection.getCurrentAction() == SelectedAction::selectTile)
+        mPlayerSelection.setCurrentAction(SelectedAction::none);
+    inputManager.mCommandState = InputCommandState::infoOnly;
 
     return true;
 }
@@ -1173,7 +1228,7 @@ void GameMode::onFrameStarted(const Ogre::FrameEvent& evt)
     player->frameStarted(evt.timeSinceLastFrame);
 
     // After frameStarted, so that the countdown shown is the one just computed.
-    refreshSpellCooldownText();
+    refreshActionFeedback(evt.timeSinceLastFrame);
 
     if((mSkillCurrentCompletion.mProgressBar != nullptr) &&
        (mSkillCurrentCompletion.mCompletenessDisplayed < mSkillCurrentCompletion.mCompleteness))
@@ -1713,40 +1768,127 @@ void GameMode::refreshSpellButtonCoolDowns()
     });
 }
 
-void GameMode::refreshSpellCooldownText()
+std::string GameMode::getActionDescription() const
 {
-    // checkInputCommand() is what writes the text next to the pointer, and it only runs
-    // when the mouse moves or is clicked. Everything it displays is a function of where
-    // the pointer is, except the spell cooldown, which counts down on its own: holding
-    // the mouse still, over an enemy waiting to cast at it for instance, left the
-    // countdown frozen at whatever it read when the mouse last moved.
-    if(mPlayerSelection.getCurrentAction() != SelectedAction::castSpell)
+    switch(mPlayerSelection.getCurrentAction())
     {
-        mIsSpellCooldownDisplayed = false;
-        return;
+        case SelectedAction::buildRoom:
+            return "Build " + RoomManager::getRoomReadableName(mPlayerSelection.getNewRoomType()) +
+                ": left-drag to build; right-click to cancel.";
+        case SelectedAction::buildTrap:
+            return "Place " + TrapManager::getTrapReadableName(mPlayerSelection.getNewTrapType()) +
+                ": left-click or drag to place; right-click to cancel.";
+        case SelectedAction::destroyRoom:
+            return "Sell rooms: left-drag your room tiles; right-click to cancel.";
+        case SelectedAction::destroyTrap:
+            return "Sell traps: left-drag your trap tiles; right-click to cancel.";
+        case SelectedAction::selectTile:
+            return mDigSetBool ? "Mark for digging: drag walls, release to confirm; right-click to cancel." :
+                "Unmark digging: drag marked walls, release to confirm; right-click to cancel.";
+        case SelectedAction::castSpell:
+        {
+            std::string target;
+            switch(mPlayerSelection.getNewSpellType())
+            {
+                case SpellType::summonWorker:
+                    target = "left-click or drag claimed ground";
+                    break;
+                case SpellType::creatureHeal:
+                    target = "left-drag hurt creatures on claimed ground";
+                    break;
+                case SpellType::creatureExplosion:
+                    target = "left-drag enemies on claimed ground";
+                    break;
+                case SpellType::eyeEvil:
+                case SpellType::callToWar:
+                    target = "left-click a map tile";
+                    break;
+                case SpellType::creatureWeak:
+                case SpellType::creatureSlow:
+                    target = "left-click an enemy on claimed ground";
+                    break;
+                default:
+                    target = "left-click an allied creature on claimed ground";
+                    break;
+            }
+            return SpellManager::getSpellReadableName(mPlayerSelection.getNewSpellType()) +
+                ": " + target + "; right-click to cancel.";
+        }
+        default:
+            if(mGameMap->getLocalPlayer()->numObjectsInHand() > 0)
+                return "Place from hand: right-click valid ground to drop the first object.";
+            return "Explore / dig: left-click to pick up; left-drag walls to mark or unmark digging.";
     }
-
-    if(SpellManager::checkSpellCooldown(mGameMap, mPlayerSelection.getNewSpellType(), *this))
-    {
-        mIsSpellCooldownDisplayed = true;
-        return;
-    }
-
-    if(!mIsSpellCooldownDisplayed)
-        return;
-
-    // The cooldown has just run out. What belongs next to the pointer now is whatever
-    // the spell itself wants to display there, and only the spell knows that, so ask it
-    // once. Not while the mouse button is being released though: checkSpellCast() casts
-    // the spell in that state rather than describing it.
-    mIsSpellCooldownDisplayed = false;
-
-    const InputManager& inputManager = mModeManager->getInputManager();
-    if(inputManager.mCommandState == InputCommandState::validated)
-        return;
-
-    SpellManager::checkSpellCast(mGameMap, mPlayerSelection.getNewSpellType(), inputManager, *this);
 }
+
+void GameMode::refreshActionFeedback(float elapsed)
+{
+    mActionFailureTime = std::max(0.0f, mActionFailureTime - elapsed);
+    const std::string description = getActionDescription();
+    if(description != mActionDescription)
+    {
+        mActionDescription = description;
+        mActionTargetText.clear();
+        const std::string button = SkillManager::getSelectedButton(mPlayerSelection);
+        if(!mSelectedActionButton.empty())
+            mRootWindow->getChild(mSelectedActionButton)->setProperty("SelectionColour", "00FFFFFF");
+        mSelectedActionButton = button;
+        if(!button.empty())
+        {
+            mRootWindow->getChild(button)->setProperty("SelectionColour", "FFFFCC55");
+            mActionFailureTime = 0.0f;
+        }
+    }
+
+    InputManager& inputManager = mModeManager->getInputManager();
+    if(isMouseDownOnCEGUIWindow())
+    {
+        unselectAllTiles();
+        mActionTargetText.clear();
+        TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
+    }
+    else
+    {
+        // Recompute the tile when the camera moves under a stationary pointer, too.
+        const CEGUI::Sizef size = CEGUI::System::getSingleton().getDefaultGUIContext().getSurfaceSize();
+        OIS::MouseState mouseState;
+        mouseState.width = static_cast<int>(size.d_width);
+        mouseState.height = static_cast<int>(size.d_height);
+        const OIS::MouseEvent mouseEvent(nullptr, mouseState);
+        if(ODFrameListener::getSingleton().findWorldPositionFromMouse(mouseEvent,
+            inputManager.mKeeperHandPos, RenderManager::KEEPER_HAND_WORLD_Z))
+        {
+            inputManager.mXPos = Helper::round(inputManager.mKeeperHandPos.x);
+            inputManager.mYPos = Helper::round(inputManager.mKeeperHandPos.y);
+        }
+        else
+        {
+            inputManager.mXPos = -1;
+            inputManager.mYPos = -1;
+        }
+        if(!inputManager.mLMouseDown)
+        {
+            inputManager.mLStartDragX = inputManager.mXPos;
+            inputManager.mLStartDragY = inputManager.mYPos;
+        }
+        // A release leaves validated in the input manager: a frame must never repeat it.
+        const InputCommandState previousState = inputManager.mCommandState;
+        inputManager.mCommandState = inputManager.mLMouseDown ? InputCommandState::building : InputCommandState::infoOnly;
+        if(mGameMap->getGamePaused())
+        {
+            unselectAllTiles();
+            displayText(Ogre::ColourValue::Red, "The game is paused.");
+        }
+        else
+            checkInputCommand();
+        inputManager.mCommandState = previousState;
+    }
+
+    CEGUI::Window* feedback = mRootWindow->getChild("ActionFeedback");
+    const std::string detail = mActionFailureTime > 0.0f ? "Cannot complete: " + mActionFailure : mActionTargetText;
+    feedback->setText(mActionDescription + (detail.empty() ? "" : "\n" + detail));
+}
+
 
 void GameMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2)
 {
@@ -1759,33 +1901,50 @@ void GameMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2
 
 void GameMode::selectTiles(const std::vector<Tile*> tiles)
 {
-    unselectAllTiles();
+    mPreviewTiles = tiles;
+}
 
+void GameMode::updateSelectedTiles()
+{
+    if(!mActionTargetValid)
+        mPreviewTiles.clear();
+    if(mPreviewTiles == mSelectedTiles)
+        return;
     Player* player = mGameMap->getLocalPlayer();
-    for(Tile* tile : tiles)
-    {
+    for(Tile* tile : mSelectedTiles)
+        tile->setSelected(false, player);
+    for(Tile* tile : mPreviewTiles)
         tile->setSelected(true, player);
-    }
+    mSelectedTiles = mPreviewTiles;
 }
 
 void GameMode::unselectAllTiles()
 {
     Player* player = mGameMap->getLocalPlayer();
-    // Compute selected tiles
-    for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
-    {
-        for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
-        {
-            mGameMap->getTile(ii, jj)->setSelected(false, player);
-        }
-    }
+    for(Tile* tile : mSelectedTiles)
+        tile->setSelected(false, player);
+    mSelectedTiles.clear();
+    mPreviewTiles.clear();
 }
 
 void GameMode::displayText(const Ogre::ColourValue& txtColour, const std::string& txt)
 {
+    mActionTargetValid = txtColour != Ogre::ColourValue::Red;
+    mActionTargetText = (mActionTargetValid ? "Ready: " : "Unavailable: ") + txt;
+    if(mModeManager->getInputManager().mCommandState == InputCommandState::validated)
+    {
+        if(mActionTargetValid)
+            mActionFailureTime = 0.0f;
+        else
+        {
+            mActionFailure = txt;
+            mActionFailureTime = 3.0f;
+        }
+    }
     TextRenderer& textRenderer = TextRenderer::getSingleton();
-    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, txtColour);
-    textRenderer.setText(ODApplication::POINTER_INFO_STRING, txt);
+    textRenderer.setColor(ODApplication::POINTER_INFO_STRING,
+        mActionTargetValid ? Ogre::ColourValue(0.5f, 1.0f, 0.5f) : Ogre::ColourValue(1.0f, 0.45f, 0.35f));
+    textRenderer.setText(ODApplication::POINTER_INFO_STRING, mActionTargetText);
 }
 
 void GameMode::checkInputCommand()
@@ -1793,62 +1952,110 @@ void GameMode::checkInputCommand()
     // In the gamemode, by default, we select tiles
     const InputManager& inputManager = mModeManager->getInputManager();
 
+    mPreviewTiles.clear();
+    mActionTargetValid = false;
+    mActionTargetText.clear();
+    if(mPlayerSelection.getCurrentAction() != SelectedAction::none &&
+       mGameMap->getTile(inputManager.mXPos, inputManager.mYPos) == nullptr)
+    {
+        displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
+        unselectAllTiles();
+        return;
+    }
+
     switch(mPlayerSelection.getCurrentAction())
     {
         case SelectedAction::none:
             handlePlayerActionNone();
-            return;
+            break;
         case SelectedAction::selectTile:
             handlePlayerActionSelectTile();
-            return;
+            break;
         case SelectedAction::buildRoom:
             RoomManager::checkBuildRoom(mGameMap, mPlayerSelection.getNewRoomType(), inputManager, *this);
-            return;
+            break;
         case SelectedAction::destroyRoom:
             RoomManager::checkSellRoomTiles(mGameMap, inputManager, *this);
-            return;
+            break;
         case SelectedAction::castSpell:
             SpellManager::checkSpellCast(mGameMap, mPlayerSelection.getNewSpellType(), inputManager, *this);
-            return;
+            break;
         case SelectedAction::buildTrap:
             TrapManager::checkBuildTrap(mGameMap, mPlayerSelection.getNewTrapType(), inputManager, *this);
-            return;
+            break;
         case SelectedAction::destroyTrap:
             TrapManager::checkSellTrapTiles(mGameMap, inputManager, *this);
-            return;
+            break;
         default:
-            return;
+            break;
     }
+    if(inputManager.mCommandState != InputCommandState::validated)
+        updateSelectedTiles();
+    else
+        unselectAllTiles();
 }
 
 void GameMode::handlePlayerActionNone()
 {
     const InputManager& inputManager = mModeManager->getInputManager();
-    // We only display the selection cursor on the hovered tile
-    if(inputManager.mCommandState == InputCommandState::validated)
+    Player* player = mGameMap->getLocalPlayer();
+    if(player->numObjectsInHand() == 0)
     {
-        unselectAllTiles();
+        TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
         return;
     }
 
-    // selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-    //     inputManager.mYPos);
+    Tile* tile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tile == nullptr)
+        displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
+    else if(player->isDropHandPossible(tile))
+    {
+        displayText(Ogre::ColourValue::White, "Right-click to place the first object in hand.");
+        selectTiles({tile});
+    }
+    else if(tile->isFullTile())
+        displayText(Ogre::ColourValue::Red, "Dig out this tile before dropping an object.");
+    else if(!player->getSeat()->hasVisionOnTile(tile))
+        displayText(Ogre::ColourValue::Red, "You cannot drop objects outside your vision.");
+    else if(tile->getCoveringRoom() != nullptr && tile->getCoveringRoom()->getType() == RoomType::arena &&
+            player->getObjectsInHand().front()->getObjectType() == GameEntityType::creature)
+        displayText(Ogre::ColourValue::Red, "The arena has no available place for this creature.");
+    else
+        displayText(Ogre::ColourValue::Red, "This object needs ground claimed by you or an ally.");
 }
 
 void GameMode::handlePlayerActionSelectTile()
 {
     const InputManager& inputManager = mModeManager->getInputManager();
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Player* player = mGameMap->getLocalPlayer();
+    std::vector<Tile*> tiles = mGameMap->rectangularRegion(inputManager.mXPos, inputManager.mYPos,
+        inputManager.mLStartDragX, inputManager.mLStartDragY);
+    std::vector<Tile*> diggableTiles;
+    for(Tile* tile : tiles)
     {
-        selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        if(mDigSetBool ? tile->isDiggable(player->getSeat()) : tile->getMarkedForDigging(player))
+            diggableTiles.push_back(tile);
+    }
+    if(diggableTiles.empty())
+    {
+        Tile* tile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+        if(!mDigSetBool)
+            displayText(Ogre::ColourValue::Red, "No marked walls in this selection.");
+        else if(tile != nullptr && !tile->isFullTile())
+            displayText(Ogre::ColourValue::Red, "This ground is already dug out.");
+        else if(tile != nullptr && tile->isClaimed() && !tile->isClaimedForSeat(player->getSeat()))
+            displayText(Ogre::ColourValue::Red, "You cannot dig an enemy's claimed wall.");
+        else
+            displayText(Ogre::ColourValue::Red, "This wall cannot be dug out.");
+        if(inputManager.mCommandState == InputCommandState::validated)
+            mPlayerSelection.setCurrentAction(SelectedAction::none);
         return;
     }
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    displayText(Ogre::ColourValue::White, mDigSetBool ? "Release to mark selected walls for digging." :
+        "Release to remove the digging marks.");
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
-        selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
-            inputManager.mLStartDragY);
+        selectTiles(diggableTiles);
         return;
     }
 
@@ -2013,4 +2220,3 @@ void GameMode::buildPlayerSettingsWindow()
 
     getModeManager().getGui().registerWindowHierarchy(tmpWin);
 }
-

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -70,12 +70,24 @@ const std::string TEXT_SEAT_ID_PREFIX = "TextSeat";
 const std::string TEXT_SEAT_PLAYER_NICKNAME_PREFIX = "TextSeatPlayerNick";
 const std::string TEXT_SEAT_TEAM_ID_PREFIX = "TextSeatTeam";
 
+const double AUTOSCROLL_EDGE_RATIO = 0.02;
+
+static double getAutoscrollIntensity(int mousePosition, int screenSize, bool minimumEdge)
+{
+    if(screenSize <= 1)
+        return 0.0;
+
+    const double edgeSize = AUTOSCROLL_EDGE_RATIO * screenSize;
+    const int distanceFromEdge = minimumEdge ? mousePosition : screenSize - 1 - mousePosition;
+    return std::max(0.0, std::min(1.0, (edgeSize - distanceFromEdge) / edgeSize));
+}
+
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
     mIsSpellCooldownDisplayed(false),
     mIndexEvent(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mIsSkillWindowOpen(false),
     mCurrentSkillType(SkillType::nullSkillType),
     mCurrentSkillProgress(0.0),
@@ -375,23 +387,29 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        if (arg.state.X.abs <= 0.02 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft);
+        const bool mouseOverGui = isMouseWheelOnCEGUIWindow();
+        const double leftIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
+        const double rightIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
+        const double topIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
+        const double bottomIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
+
+        if (leftIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopLeft);
 
-        if (arg.state.X.abs >= 0.98 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight);
+        if (rightIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight, rightIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopRight);
 
-        if (arg.state.Y.abs <= 0.02 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward);
+        if (topIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward, topIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopForward);
 
-        if (arg.state.Y.abs >= 0.98 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward);
+        if (bottomIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward, bottomIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopBackward);            
     }
@@ -1992,7 +2010,7 @@ void GameMode::buildPlayerSettingsWindow()
         mSeatIds.push_back(seat->getId());
         offset += 15;
     }
+
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
 }
-
-
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -104,14 +104,6 @@ GameMode::GameMode(ModeManager *modeManager):
 
     CEGUI::Window* guiSheet = mRootWindow;
 
-    SkillManager::listAllSkills([this](const std::string&, const std::string& castButton,
-        const std::string&, SkillType)
-    {
-        mRootWindow->getChild(castButton)->setProperty("SelectionColour", "00FFFFFF");
-    });
-    guiSheet->getChild(Gui::BUTTON_DESTROY_ROOM)->setProperty("SelectionColour", "00FFFFFF");
-    guiSheet->getChild(Gui::BUTTON_DESTROY_TRAP)->setProperty("SelectionColour", "00FFFFFF");
-
     addEventConnection(guiSheet->getChild("PanelToggleButton")->subscribeEvent(
         CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(&GameMode::toggleControlPanel, this)));
     addEventConnection(guiSheet->getChild("EventsButton")->subscribeEvent(
@@ -521,8 +513,8 @@ bool GameMode::isMouseDownOnCEGUIWindow()
 
     CEGUI::String winName = currentWindow->getName();
 
-    // If the mouse press is on a CEGUI window, ignore it, except for the chat and event queues windows.
-    if (winName == "Root" || winName == "GameChatWindow" || winName == "GameChatText" || winName == "GameEventText")
+    // Passive chat passes through; the opened event surface owns its input.
+    if (winName == "Root" || winName == "GameChatWindow" || winName == "GameChatText")
         return false;
 
     return true;
@@ -591,7 +583,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
         inputManager.mRMouseDown = true;
         inputManager.mLMouseDown = false;
         mPlayerSelection.setCurrentAction(SelectedAction::none);
-        mActionFailureTime = 0.0f;
+
         unselectAllTiles();
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
         return true;
@@ -689,7 +681,6 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
 
             if (mGameMap->getLocalPlayer()->isDropHandPossible(curTile))
             {
-                mActionFailureTime = 0.0f;
                 if(ODClient::getSingleton().isConnected())
                 {
                     // Send a message to the server telling it we want to drop the creature
@@ -1801,83 +1792,21 @@ void GameMode::refreshSpellButtonCoolDowns()
     });
 }
 
-std::string GameMode::getActionDescription() const
-{
-    switch(mPlayerSelection.getCurrentAction())
-    {
-        case SelectedAction::buildRoom:
-            return "Build " + RoomManager::getRoomReadableName(mPlayerSelection.getNewRoomType()) +
-                ": left-drag to build; right-click to cancel.";
-        case SelectedAction::buildTrap:
-            return "Place " + TrapManager::getTrapReadableName(mPlayerSelection.getNewTrapType()) +
-                ": left-click or drag to place; right-click to cancel.";
-        case SelectedAction::destroyRoom:
-            return "Sell rooms: left-drag your room tiles; right-click to cancel.";
-        case SelectedAction::destroyTrap:
-            return "Sell traps: left-drag your trap tiles; right-click to cancel.";
-        case SelectedAction::selectTile:
-            return mDigSetBool ? "Mark for digging: drag walls, release to confirm; right-click to cancel." :
-                "Unmark digging: drag marked walls, release to confirm; right-click to cancel.";
-        case SelectedAction::castSpell:
-        {
-            std::string target;
-            switch(mPlayerSelection.getNewSpellType())
-            {
-                case SpellType::summonWorker:
-                    target = "left-click or drag claimed ground";
-                    break;
-                case SpellType::creatureHeal:
-                    target = "left-drag hurt creatures on claimed ground";
-                    break;
-                case SpellType::creatureExplosion:
-                    target = "left-drag enemies on claimed ground";
-                    break;
-                case SpellType::eyeEvil:
-                case SpellType::callToWar:
-                    target = "left-click a map tile";
-                    break;
-                case SpellType::creatureWeak:
-                case SpellType::creatureSlow:
-                    target = "left-click an enemy on claimed ground";
-                    break;
-                default:
-                    target = "left-click an allied creature on claimed ground";
-                    break;
-            }
-            return SpellManager::getSpellReadableName(mPlayerSelection.getNewSpellType()) +
-                ": " + target + "; right-click to cancel.";
-        }
-        default:
-            if(mGameMap->getLocalPlayer()->numObjectsInHand() > 0)
-                return "Place from hand: right-click valid ground to drop the first object.";
-            return "Explore / dig: left-click to pick up; left-drag walls to mark or unmark digging.";
-    }
-}
-
 void GameMode::refreshActionFeedback(float elapsed)
 {
-    mActionFailureTime = std::max(0.0f, mActionFailureTime - elapsed);
-    const std::string description = getActionDescription();
-    if(description != mActionDescription)
-    {
-        mActionDescription = description;
-        mActionTargetText.clear();
-        const std::string button = SkillManager::getSelectedButton(mPlayerSelection);
-        if(!mSelectedActionButton.empty())
-            mRootWindow->getChild(mSelectedActionButton)->setProperty("SelectionColour", "00FFFFFF");
-        mSelectedActionButton = button;
-        if(!button.empty())
-        {
-            mRootWindow->getChild(button)->setProperty("SelectionColour", "FFFFCC55");
-            mActionFailureTime = 0.0f;
-        }
-    }
-
     InputManager& inputManager = mModeManager->getInputManager();
     if(isMouseDownOnCEGUIWindow())
     {
         unselectAllTiles();
         mActionTargetText.clear();
+        CEGUI::Window* hover = CEGUI::System::getSingleton().getDefaultGUIContext().getWindowContainingMouse();
+        if(hover != nullptr)
+            mActionTargetText = hover->getTooltipText().c_str();
+        if(inputManager.mHighlightedCreature != nullptr)
+        {
+            inputManager.mHighlightedCreature->normalizeAmbient();
+            inputManager.mHighlightedCreature = nullptr;
+        }
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
     }
     else
@@ -1917,15 +1846,36 @@ void GameMode::refreshActionFeedback(float elapsed)
         inputManager.mCommandState = previousState;
     }
 
-    CEGUI::Window* feedback = mRootWindow->getChild("ActionFeedback");
-    const std::string detail = mActionFailureTime > 0.0f ? "Cannot complete: " + mActionFailure : mActionTargetText;
-    feedback->setText(mActionDescription + (detail.empty() ? "" : "\n" + detail));
+    mRootWindow->getChild("ContextInfo")->setText(mActionTargetText);
+    CEGUI::Window* icon = mRootWindow->getChild("HandActionIcon");
+    const bool overGui = isMouseDownOnCEGUIWindow();
+    Player* player = mGameMap->getLocalPlayer();
+    const bool active = mPlayerSelection.getCurrentAction() != SelectedAction::none;
+    const bool holding = player->numObjectsInHand() > 0;
+    const std::string button = SkillManager::getSelectedButton(mPlayerSelection);
+    const bool prohibited = !mActionTargetValid && (active || holding);
+    icon->setVisible(!overGui && (prohibited || !button.empty()));
+    if(icon->isVisible())
+    {
+        icon->setProperty("Image", prohibited ? "OpenDungeonsIcons/Prohibition" :
+            mRootWindow->getChild(button)->getProperty("NormalImage"));
+        const CEGUI::Vector2f pointer = CEGUI::System::getSingleton().getDefaultGUIContext().getMouseCursor().getPosition();
+        const float scale = icon->getPixelSize().d_width / 50.0f;
+        icon->setPosition(CEGUI::UVector2(CEGUI::UDim(0, pointer.d_x + 90.0f * scale),
+            CEGUI::UDim(0, pointer.d_y + 8.0f * scale)));
+    }
+    Tile* tile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    const bool digging = !overGui && !holding && !mGameMap->getGamePaused() && tile != nullptr &&
+        (mPlayerSelection.getCurrentAction() == SelectedAction::selectTile ||
+         (!active && !mPreviewTiles.empty() && tile->isDiggable(player->getSeat())));
+    RenderManager::getSingleton().rrSetHandPose(!overGui && !holding && (active || mActionTargetValid), digging);
+
 }
 
 
 void GameMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2)
 {
-    // Loop over the tiles in the rectangular selection region and set their setSelected flag accordingly.
+    // Collect the eligible region for the outlined world preview.
     std::vector<Tile*> affectedTiles = mGameMap->rectangularRegion(tileX1,
         tileY1, tileX2, tileY2);
 
@@ -1939,16 +1889,22 @@ void GameMode::selectTiles(const std::vector<Tile*> tiles)
 
 void GameMode::updateSelectedTiles()
 {
-    if(!mActionTargetValid)
+    const bool building = mPlayerSelection.getCurrentAction() == SelectedAction::buildRoom ||
+        mPlayerSelection.getCurrentAction() == SelectedAction::buildTrap;
+    if(!mActionTargetValid && !building)
         mPreviewTiles.clear();
+    const Ogre::ColourValue colour = mActionTargetValid ? Ogre::ColourValue(0.35f, 0.3f, 1.0f) :
+        Ogre::ColourValue(1.0f, 0.15f, 0.1f);
     if(mPreviewTiles == mSelectedTiles)
+    {
+        RenderManager::getSingleton().rrDrawTilePreview(mSelectedTiles, colour);
         return;
+    }
     Player* player = mGameMap->getLocalPlayer();
     for(Tile* tile : mSelectedTiles)
         tile->setSelected(false, player);
-    for(Tile* tile : mPreviewTiles)
-        tile->setSelected(true, player);
     mSelectedTiles = mPreviewTiles;
+    RenderManager::getSingleton().rrDrawTilePreview(mSelectedTiles, colour);
 }
 
 void GameMode::unselectAllTiles()
@@ -1958,26 +1914,16 @@ void GameMode::unselectAllTiles()
         tile->setSelected(false, player);
     mSelectedTiles.clear();
     mPreviewTiles.clear();
+    RenderManager::getSingleton().rrDrawTilePreview(mSelectedTiles, Ogre::ColourValue::White);
 }
 
 void GameMode::displayText(const Ogre::ColourValue& txtColour, const std::string& txt)
 {
+    // Callers supply both eligibility and context; do not discard the former with the old label.
     mActionTargetValid = txtColour != Ogre::ColourValue::Red;
-    mActionTargetText = (mActionTargetValid ? "Ready: " : "Unavailable: ") + txt;
-    if(mModeManager->getInputManager().mCommandState == InputCommandState::validated)
-    {
-        if(mActionTargetValid)
-            mActionFailureTime = 0.0f;
-        else
-        {
-            mActionFailure = txt;
-            mActionFailureTime = 3.0f;
-        }
-    }
-    TextRenderer& textRenderer = TextRenderer::getSingleton();
-    textRenderer.setColor(ODApplication::POINTER_INFO_STRING,
-        mActionTargetValid ? Ogre::ColourValue(0.5f, 1.0f, 0.5f) : Ogre::ColourValue(1.0f, 0.45f, 0.35f));
-    textRenderer.setText(ODApplication::POINTER_INFO_STRING, mActionTargetText);
+    mActionTargetText = txt;
+    mRootWindow->getChild("ContextInfo")->setText(txt);
+    TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
 }
 
 void GameMode::checkInputCommand()
@@ -2034,6 +1980,49 @@ void GameMode::handlePlayerActionNone()
     Player* player = mGameMap->getLocalPlayer();
     if(player->numObjectsInHand() == 0)
     {
+        Tile* tile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+        GameEntity* closest = nullptr;
+        double distance = 0.0;
+        if(tile != nullptr)
+        {
+            std::vector<GameEntity*> entities;
+            tile->fillWithEntities(entities, SelectionEntityWanted::any, player);
+            for(GameEntity* entity : entities)
+            {
+                if(!entity->tryPickup(player->getSeat()))
+                    continue;
+                const Ogre::Vector3& pos = entity->getPosition();
+                const double candidate = Pathfinding::squaredDistance(pos.x, inputManager.mKeeperHandPos.x,
+                    pos.y, inputManager.mKeeperHandPos.y);
+                if(closest == nullptr || candidate < distance)
+                {
+                    closest = entity;
+                    distance = candidate;
+                }
+            }
+            if(closest != nullptr)
+            {
+                Creature* creature = dynamic_cast<Creature*>(closest);
+                displayText(Ogre::ColourValue::White, creature != nullptr ?
+                    creature->getDefinition()->getClassName() : closest->getName());
+            }
+            else if(tile->isDiggable(player->getSeat()))
+            {
+                displayText(Ogre::ColourValue::White, tile->getMarkedForDigging(player) ?
+                    "Marked wall. Click or drag to remove digging marks." : "Wall. Click or drag to mark for digging.");
+                selectSquaredTiles(tile->getX(), tile->getY(), tile->getX(), tile->getY());
+            }
+        }
+        InputManager& mutableInput = mModeManager->getInputManager();
+        Creature* creature = dynamic_cast<Creature*>(closest);
+        if(mutableInput.mHighlightedCreature != creature)
+        {
+            if(mutableInput.mHighlightedCreature != nullptr)
+                mutableInput.mHighlightedCreature->normalizeAmbient();
+            mutableInput.mHighlightedCreature = creature;
+            if(creature != nullptr)
+                creature->maxAmbient();
+        }
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
         return;
     }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -2077,8 +2077,13 @@ void GameMode::handlePlayerActionNone()
             if(closest != nullptr)
             {
                 Creature* creature = dynamic_cast<Creature*>(closest);
-                displayText(Ogre::ColourValue::White, creature != nullptr ?
-                    creature->getDefinition()->getClassName() : closest->getName());
+                if(closest->getObjectType() == GameEntityType::chickenEntity)
+                    displayText(Ogre::ColourValue::White, "Chicken");
+                else if(closest->getObjectType() == GameEntityType::treasuryObject)
+                    displayText(Ogre::ColourValue::White, "Gold");
+                else
+                    displayText(Ogre::ColourValue::White, creature != nullptr ?
+                        creature->getDefinition()->getClassName() : closest->getName());
             }
             else if(tile->isDiggable(player->getSeat()))
             {

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -19,6 +19,7 @@
 
 #include "camera/CameraManager.h"
 #include "entities/Creature.h"
+#include "entities/CreatureDefinition.h"
 #include "entities/GameEntityType.h"
 #include "entities/Tile.h"
 #include "game/Player.h"
@@ -111,9 +112,19 @@ GameMode::GameMode(ModeManager *modeManager):
     guiSheet->getChild(Gui::BUTTON_DESTROY_ROOM)->setProperty("SelectionColour", "00FFFFFF");
     guiSheet->getChild(Gui::BUTTON_DESTROY_TRAP)->setProperty("SelectionColour", "00FFFFFF");
 
+    addEventConnection(guiSheet->getChild("PanelToggleButton")->subscribeEvent(
+        CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(&GameMode::toggleControlPanel, this)));
+    addEventConnection(guiSheet->getChild("EventsButton")->subscribeEvent(
+        CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber([this](const CEGUI::EventArgs&)
+        {
+            CEGUI::Window* events = mRootWindow->getChild("GameEventText");
+            events->setVisible(!events->isVisible());
+            return true;
+        })));
+
     //Help window
     addEventConnection(
-        guiSheet->getChild("HelpButton")->subscribeEvent(
+        guiSheet->getChild("GameOptionsWindow/HelpButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&GameMode::toggleHelpWindow, this)
         )
@@ -135,7 +146,7 @@ GameMode::GameMode(ModeManager *modeManager):
 
     //Player settings window
     addEventConnection(
-        guiSheet->getChild("PlayerSettingsButton")->subscribeEvent(
+        guiSheet->getChild("GameOptionsWindow/PlayerSettingsButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&GameMode::togglePlayerSettingsWindow, this)
         )
@@ -160,12 +171,6 @@ GameMode::GameMode(ModeManager *modeManager):
     );
 
     // The skill tree window
-    addEventConnection(
-        guiSheet->getChild("SkillButton")->subscribeEvent(
-            CEGUI::PushButton::EventClicked,
-            CEGUI::Event::Subscriber(&GameMode::toggleSkillWindow, this)
-        )
-    );
     addEventConnection(
         guiSheet->getChild("SkillTreeWindow")->subscribeEvent(
             CEGUI::FrameWindow::EventCloseClicked,
@@ -890,6 +895,10 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
 
     switch (arg.key)
     {
+    case OIS::KC_G:
+        toggleControlPanel();
+        break;
+
     case OIS::KC_F1:
         toggleHelpWindow();
         break;
@@ -1080,6 +1089,15 @@ bool GameMode::keyPressedChat(const OIS::KeyEvent &arg)
     return true;
 }
 
+bool GameMode::toggleControlPanel(const CEGUI::EventArgs&)
+{
+    CEGUI::Window* tabs = mRootWindow->getChild(Gui::MAIN_TABCONTROL);
+    CEGUI::Window* content = tabs->getChild("__auto_TabPane__");
+    content->setVisible(!content->isVisible());
+    tabs->setMousePassThroughEnabled(!content->isVisible());
+    return true;
+}
+
 void GameMode::refreshMainUI()
 {
     Seat* mySeat = mGameMap->getLocalPlayer()->getSeat();
@@ -1106,6 +1124,19 @@ void GameMode::refreshMainUI()
     tempSS << mySeat->getMana() << " " << (mySeat->getManaDelta() >= 0 ? "+" : "-")
             << mySeat->getManaDelta();
     widget->setText(tempSS.str());
+    unsigned int workers = 0;
+    unsigned int fighters = 0;
+    for(Creature* creature : mGameMap->getCreaturesBySeat(mySeat))
+    {
+        if(!creature->tryPickup(mySeat))
+            continue;
+        if(creature->getDefinition()->isWorker())
+            ++workers;
+        else
+            ++fighters;
+    }
+    guiSheet->getChild(Gui::BUTTON_CREATURE_WORKER + "/Count")->setText(Helper::toString(workers));
+    guiSheet->getChild(Gui::BUTTON_CREATURE_FIGHTER + "/Count")->setText(Helper::toString(fighters));
 }
 
 void GameMode::refreshPlayerGoals(const std::string& goalsDisplayString)
@@ -1327,6 +1358,7 @@ bool GameMode::toggleObjectivesWindow(const CEGUI::EventArgs& e)
 
 bool GameMode::showPlayerSettingsWindow(const CEGUI::EventArgs&)
 {
+    mRootWindow->getChild("GameOptionsWindow")->hide();
     // Before showing the player settings, we reset to the values in the seat. That's
     // because only the server can change them and the values in the Seat are the
     // ones that should be shown
@@ -1507,6 +1539,7 @@ bool GameMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)
 
 bool GameMode::showHelpWindow(const CEGUI::EventArgs&)
 {
+    mRootWindow->getChild("GameOptionsWindow")->hide();
     mRootWindow->getChild("GameHelpWindow")->show();
     return true;
 }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -65,6 +65,7 @@
 
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 #include <string>
 
@@ -82,6 +83,22 @@ static double getAutoscrollIntensity(int mousePosition, int screenSize, bool min
     const double edgeSize = AUTOSCROLL_EDGE_RATIO * screenSize;
     const int distanceFromEdge = minimumEdge ? mousePosition : screenSize - 1 - mousePosition;
     return std::max(0.0, std::min(1.0, (edgeSize - distanceFromEdge) / edgeSize));
+}
+
+static bool blocksEdgeScrolling(CEGUI::Window* window)
+{
+    if(window == nullptr || window->getName() == "Root")
+        return false;
+
+    // Fixed HUD surfaces must not cover the physical screen edges. Dialogs
+    // still own their input, as do clicks and wheel events over the HUD.
+    for(CEGUI::Window* parent = window; parent != nullptr; parent = parent->getParent())
+    {
+        if(parent->isUserStringDefined("AllowEdgeScrolling") &&
+           parent->getUserString("AllowEdgeScrolling") == "true")
+            return false;
+    }
+    return true;
 }
 
 GameMode::GameMode(ModeManager *modeManager):
@@ -110,9 +127,16 @@ GameMode::GameMode(ModeManager *modeManager):
         CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber([this](const CEGUI::EventArgs&)
         {
             CEGUI::Window* events = mRootWindow->getChild("GameEventText");
-            events->setVisible(!events->isVisible());
+            if(events->isVisible())
+                events->hide();
+            else
+                showEventMessages();
             return true;
         })));
+    addEventConnection(guiSheet->getChild("EventsButton")->subscribeEvent(
+        CEGUI::Window::EventMouseClick, CEGUI::Event::Subscriber(&GameMode::onEventMessagesClicked, this)));
+    guiSheet->getChild("GameEventText")->hide();
+    guiSheet->getChild("EventsButton")->setAlpha(1.0f);
 
     //Help window
     addEventConnection(
@@ -392,7 +416,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        const bool mouseOverGui = isMouseWheelOnCEGUIWindow();
+        const bool mouseOverGui = blocksEdgeScrolling(
+            CEGUI::System::getSingleton().getDefaultGUIContext().getWindowContainingMouse());
         const double leftIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
         const double rightIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
         const double topIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
@@ -1214,6 +1239,7 @@ void GameMode::handleHotkeys(OIS::KeyCode keycode)
 void GameMode::onFrameStarted(const Ogre::FrameEvent& evt)
 {
     GameEditorModeBase::onFrameStarted(evt);
+    updateEventMessageIndicator(evt.timeSinceLastFrame);
 
     refreshGuiSkill();
     refreshSpellButtonCoolDowns();
@@ -1479,6 +1505,9 @@ bool GameMode::showSkillFromOptions(const CEGUI::EventArgs& /*e*/)
 
 bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
 {
+    hideOptionsWindow();
+    showEventMessages();
+
     // We can save if launching in server mode only
     if(!ODServer::getSingleton().isConnected())
     {
@@ -1496,6 +1525,57 @@ bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
         ODClient::getSingleton().queueClientNotification(clientNotification);
     }
     return true;
+}
+
+void GameMode::receiveEventShortNotice(EventMessage* event)
+{
+    GameEditorModeBase::receiveEventShortNotice(event);
+    if(mRootWindow->getChild("GameEventText")->isVisible())
+        showEventMessages();
+    else
+    {
+        mUnreadEventMessages = true;
+        mEventMessageFlashTime = 0.0f;
+        updateEventMessageIndicator(0.0f);
+    }
+}
+
+void GameMode::showEventMessages()
+{
+    CEGUI::Window* events = mRootWindow->getChild("GameEventText");
+    events->show();
+    events->moveToFront();
+    mUnreadEventMessages = false;
+    updateEventMessageIndicator(0.0f);
+}
+
+bool GameMode::onEventMessagesClicked(const CEGUI::EventArgs& arg)
+{
+    const CEGUI::MouseEventArgs& mouse = static_cast<const CEGUI::MouseEventArgs&>(arg);
+    CEGUI::Window* events = mRootWindow->getChild("GameEventText");
+    if(mouse.button == CEGUI::RightButton && !mUnreadEventMessages)
+    {
+        // Read messages remain available until explicitly dismissed.
+        for(EventMessage* message : mEventMessages)
+            delete message;
+        mEventMessages.clear();
+        events->setText("");
+        events->hide();
+    }
+    return true;
+}
+
+void GameMode::updateEventMessageIndicator(float elapsed)
+{
+    CEGUI::Window* button = mRootWindow->getChild("EventsButton");
+    if(!mUnreadEventMessages)
+    {
+        mEventMessageFlashTime = 0.0f;
+        button->setAlpha(1.0f);
+        return;
+    }
+    mEventMessageFlashTime = std::fmod(mEventMessageFlashTime + elapsed, 1.0f);
+    button->setAlpha(mEventMessageFlashTime < 0.5f ? 0.4f : 1.0f);
 }
 
 bool GameMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -440,29 +440,6 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     if(tileClicked == nullptr)
         return true;
 
-    Creature* closestCreature = tileClicked->getClosestCreature(inputManager.mCreatureTypeForOutliner);
-
-
-    
-    
-    if(closestCreature != nullptr)
-    {
-        if(closestCreature != inputManager.mHighlightedCreature)
-        {
-            if(inputManager.mHighlightedCreature != nullptr)
-            {
-                inputManager.mHighlightedCreature->normalizeAmbient();
-            }
-            inputManager.mHighlightedCreature = closestCreature;
-            closestCreature->maxAmbient();
-        }
-    }
-    else if(inputManager.mHighlightedCreature != nullptr)
-    {
-        inputManager.mHighlightedCreature->normalizeAmbient();
-        inputManager.mHighlightedCreature = nullptr;
-
-    }
     inputManager.mXPos = tileClicked->getX();
     inputManager.mYPos = tileClicked->getY();
     if (!inputManager.mLMouseDown)
@@ -1832,6 +1809,23 @@ void GameMode::refreshActionFeedback(float elapsed)
         {
             inputManager.mLStartDragX = inputManager.mXPos;
             inputManager.mLStartDragY = inputManager.mYPos;
+        }
+        // Empty-hand hover uses the pickup target selected by handlePlayerActionNone.
+        // Other states must also follow camera movement beneath a stationary pointer.
+        if(mPlayerSelection.getCurrentAction() != SelectedAction::none ||
+           mGameMap->getLocalPlayer()->numObjectsInHand() > 0 || mGameMap->getGamePaused())
+        {
+            Tile* hoveredTile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+            Creature* creature = hoveredTile != nullptr ?
+                hoveredTile->getClosestCreature(inputManager.mCreatureTypeForOutliner) : nullptr;
+            if(inputManager.mHighlightedCreature != creature)
+            {
+                if(inputManager.mHighlightedCreature != nullptr)
+                    inputManager.mHighlightedCreature->normalizeAmbient();
+                inputManager.mHighlightedCreature = creature;
+                if(creature != nullptr)
+                    creature->maxAmbient();
+            }
         }
         // A release leaves validated in the input manager: a frame must never repeat it.
         const InputCommandState previousState = inputManager.mCommandState;

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -118,6 +118,7 @@ class GameMode final : public GameEditorModeBase, public InputCommand
 
     void onFrameStarted(const Ogre::FrameEvent& evt) override;
     void onFrameEnded(const Ogre::FrameEvent& evt) override;
+    void receiveEventShortNotice(EventMessage* event) override;
 
     //! \brief Called when the game mode is activated
     //! Used to call the corresponding Gui Sheet.
@@ -220,6 +221,13 @@ protected:
     virtual bool keyReleasedNormal  (const OIS::KeyEvent &arg);
 
 private:
+    bool shouldExpireEventMessages() const override { return false; }
+    void showEventMessages();
+    bool onEventMessagesClicked(const CEGUI::EventArgs& arg);
+    void updateEventMessageIndicator(float elapsed);
+    bool mUnreadEventMessages = false;
+    float mEventMessageFlashTime = 0.0f;
+
     //! \brief Whether the pending exit confirmation should leave to the desktop
     //! rather than back to the main menu. Set by the button that opened the
     //! confirmation popup.

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -159,6 +159,7 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     bool showOptionsWindow(const CEGUI::EventArgs& = {});
     bool hideOptionsWindow(const CEGUI::EventArgs& = {});
     bool toggleOptionsWindow(const CEGUI::EventArgs& = {});
+    bool toggleControlPanel(const CEGUI::EventArgs& = {});
 
     void toggleAllowTileDebugWindow(){ showTileDebugWindow = !showTileDebugWindow ;};
     //! \brief Refreshes the player current goals.

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -229,12 +229,8 @@ private:
     //! this value is based on the first marked flag tile selected.
     bool mDigSetBool;
 
-    std::string mActionDescription;
     std::string mActionTargetText;
-    std::string mActionFailure;
-    std::string mSelectedActionButton;
     bool mActionTargetValid = false;
-    float mActionFailureTime = 0.0f;
     std::vector<Tile*> mPreviewTiles;
     std::vector<Tile*> mSelectedTiles;
 
@@ -290,7 +286,6 @@ private:
     void checkInputCommand();
     void handlePlayerActionNone();
     void handlePlayerActionSelectTile();
-    std::string getActionDescription() const;
     void updateSelectedTiles();
 
     //! \brief Builds the player settings window

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -193,9 +193,8 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     //! \brief Called at each frame. Updates spell cooldowns.
     void refreshSpellButtonCoolDowns();
 
-    //! \brief Called at each frame. Keeps the countdown next to the mouse pointer ticking
-    //! while a spell that is still cooling down is selected.
-    void refreshSpellCooldownText();
+    //! Refresh the selected action, target preview and resource/cooldown feedback without executing it.
+    void refreshActionFeedback(float elapsed);
 
     Creature* getClosestCreature(Tile*);
     
@@ -229,9 +228,14 @@ private:
     //! this value is based on the first marked flag tile selected.
     bool mDigSetBool;
 
-    //! \brief Whether the text next to the mouse pointer is currently a spell cooldown
-    //! countdown, and thus whether it will need replacing once the cooldown runs out.
-    bool mIsSpellCooldownDisplayed;
+    std::string mActionDescription;
+    std::string mActionTargetText;
+    std::string mActionFailure;
+    std::string mSelectedActionButton;
+    bool mActionTargetValid = false;
+    float mActionFailureTime = 0.0f;
+    std::vector<Tile*> mPreviewTiles;
+    std::vector<Tile*> mSelectedTiles;
 
     //! \brief Index of the event in the game event queue (for zooming automatically)
     uint32_t mIndexEvent;
@@ -285,6 +289,8 @@ private:
     void checkInputCommand();
     void handlePlayerActionNone();
     void handlePlayerActionSelectTile();
+    std::string getActionDescription() const;
+    void updateSelectedTiles();
 
     //! \brief Builds the player settings window
     void buildPlayerSettingsWindow();

--- a/source/modes/InputCommand.cpp
+++ b/source/modes/InputCommand.cpp
@@ -1,0 +1,22 @@
+#include "modes/InputCommand.h"
+
+#include "entities/Tile.h"
+
+#include <OgreColourValue.h>
+
+void InputCommand::displayTileBuildFailure(const Tile* tile, Seat* seat)
+{
+    std::string reason;
+    if(tile == nullptr)
+        reason = "Point at a tile inside the map.";
+    else if(tile->isFullTile())
+        reason = "Dig out this tile before building.";
+    else if(tile->getIsBuilding())
+        reason = "A room or trap already occupies this tile.";
+    else if(!tile->isClaimedForSeat(seat))
+        reason = "Claim this ground before building.";
+    else
+        reason = "No buildable tiles in this selection.";
+
+    displayText(Ogre::ColourValue::Red, reason);
+}

--- a/source/modes/InputCommand.h
+++ b/source/modes/InputCommand.h
@@ -27,6 +27,7 @@ class ColourValue;
 }
 
 class Tile;
+class Seat;
 
 //! Abstract class used for spell manager clients (on client side)
 class InputCommand
@@ -39,6 +40,9 @@ public:
     virtual void unselectAllTiles() = 0;
     //! \brief Notify the InputCommand that we want to display the given text to the local player
     virtual void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) = 0;
+
+    //! Explain why an empty room/trap selection cannot be built on the hovered tile.
+    void displayTileBuildFailure(const Tile* tile, Seat* seat);
 };
 
 

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -29,6 +29,7 @@
 
 #include <OISInputManager.h>
 #include <OgreRenderWindow.h>
+#include <exception>
 
 InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager(nullptr),
@@ -52,7 +53,10 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mMouse(nullptr),
     mCurrentAMode(nullptr),
     mHighlightedCreature(nullptr),
-    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied)
+    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied),
+    mRenderWindow(renderWindow),
+    mMouseGrab(false),
+    mKeyboardGrab(false)
 #ifdef OD_USE_SFML_WINDOW
     ,
     mListener(Utils::make_unique<SFMLToOISListener>(mCurrentAMode, renderWindow->getWidth(), renderWindow->getHeight()))
@@ -67,17 +71,20 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
         mHotkeyLocation[i].qq = Ogre::Quaternion::IDENTITY;
     }
 
+    ConfigManager& config = ConfigManager::getSingleton();
+    createInputDevices(config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes",
+                       config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes");
+}
+
+void InputManager::createInputDevices(bool mouseGrab, bool keyboardGrab)
+{
 #ifndef OD_USE_SFML_WINDOW
 
     // Get the Window attribute for OIS.
     size_t windowHnd = 0;
-    renderWindow->getCustomAttribute("WINDOW", &windowHnd);
+    mRenderWindow->getCustomAttribute("WINDOW", &windowHnd);
     std::ostringstream windowHndStr;
     windowHndStr << windowHnd;
-
-    ConfigManager& config = ConfigManager::getSingleton();
-    bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
-    bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
 
     //setup parameter list for OIS
     OIS::ParamList paramList;
@@ -101,7 +108,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager = OIS::InputManager::createInputSystem(paramList);
 
     //setup Keyboard
-    auto oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
+    OIS::Keyboard* oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
 
     oisKeyboard->setTextTranslation(OIS::Keyboard::Unicode);
 
@@ -112,6 +119,11 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
 #else
     mKeyboard.reset(new Keyboard());
 #endif
+    mMouseGrab = mouseGrab;
+    mKeyboardGrab = keyboardGrab;
+    setWidthAndHeight(mRenderWindow->getWidth(), mRenderWindow->getHeight());
+    if(mCurrentAMode != nullptr)
+        setCurrentAMode(*mCurrentAMode);
 }
 
 template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
@@ -120,12 +132,79 @@ template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
 InputManager::~InputManager()
 {
     OD_LOG_INF("*** Destroying Input Manager ***");
-#ifndef OD_USE_SFML_WINDOW
-    mInputManager->destroyInputObject(mMouse);
-    mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+    destroyInputDevices();
+}
 
-    OIS::InputManager::destroyInputSystem(mInputManager);
+void InputManager::destroyInputDevices()
+{
+#ifndef OD_USE_SFML_WINDOW
+    if(mInputManager != nullptr)
+    {
+        if(mMouse != nullptr)
+            mInputManager->destroyInputObject(mMouse);
+        if(mKeyboard != nullptr)
+            mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+        OIS::InputManager::destroyInputSystem(mInputManager);
+    }
     mInputManager = nullptr;
+    mMouse = nullptr;
+#endif
+    mKeyboard.reset();
+}
+
+void InputManager::refreshSettings()
+{
+    // Called before capturing input, never from inside an OIS callback.
+    ConfigManager& config = ConfigManager::getSingleton();
+    const bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
+    const bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
+    if(mouseGrab == mMouseGrab && keyboardGrab == mKeyboardGrab)
+        return;
+
+    const bool previousMouseGrab = mMouseGrab;
+    const bool previousKeyboardGrab = mKeyboardGrab;
+    destroyInputDevices();
+    try
+    {
+        createInputDevices(mouseGrab, keyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply input capture settings: " + std::string(error.what()));
+        destroyInputDevices();
+        config.setInputValue(Config::MOUSE_GRAB, previousMouseGrab ? "Yes" : "No");
+        config.setInputValue(Config::KEYBOARD_GRAB, previousKeyboardGrab ? "Yes" : "No");
+        config.saveUserConfig();
+        createInputDevices(previousMouseGrab, previousKeyboardGrab);
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+}
+
+bool InputManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    if(renderWindow == mRenderWindow)
+        return true;
+
+#ifdef OD_USE_SFML_WINDOW
+    return false;
+#else
+    Ogre::RenderWindow* previousWindow = mRenderWindow;
+    destroyInputDevices();
+    mRenderWindow = renderWindow;
+    try
+    {
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not move input to the new render window: " + std::string(error.what()));
+        destroyInputDevices();
+        mRenderWindow = previousWindow;
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+        return false;
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+    return true;
 #endif
 }
 

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -75,6 +75,8 @@ public:
     void setWidthAndHeight(int width, int height);
     void setCurrentAMode(AbstractApplicationMode& mode);
     void handleSFMLEvent(const sf::Event& evt);
+    void refreshSettings();
+    bool setRenderWindow(Ogre::RenderWindow* renderWindow);
 
     OIS::InputManager*  mInputManager;
 
@@ -104,6 +106,11 @@ public:
     
     private:
     AbstractApplicationMode* mCurrentAMode;
+    Ogre::RenderWindow* mRenderWindow;
+    bool mMouseGrab;
+    bool mKeyboardGrab;
+    void createInputDevices(bool mouseGrab, bool keyboardGrab);
+    void destroyInputDevices();
 #ifdef OD_USE_SFML_WINDOW
     std::unique_ptr<SFMLToOISListener> mListener;
 #endif

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -259,6 +259,8 @@ void MenuModeConfigureSeats::activate()
         offset += 30;
     }
 
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
+
     tmpWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers/LaunchGameButton");
     tmpWin->setEnabled(enabled);
 

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -71,7 +71,7 @@ public:
 
 MenuModeMain::MenuModeMain(ModeManager *modeManager):
     AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN),
-    mSettings(SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
+    mSettings(getModeManager().getGui().getGuiSheet(Gui::mainMenu), modeManager->getGui())
 {
     CEGUI::Window* rootWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);
     OD_ASSERT_TRUE(rootWin != nullptr);

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -154,6 +154,7 @@ void ModeManager::checkModeChange()
 void ModeManager::update(const Ogre::FrameEvent& evt)
 {
     checkModeChange();
+    mInputManager.refreshSettings();
 
     // We update the current mode
     AbstractApplicationMode* currentMode = getCurrentMode();

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -18,7 +18,9 @@
 #include "modes/SettingsWindow.h"
 
 #include "gamemap/MiniMap.h"
+#include "network/ODClient.h"
 #include "camera/CameraManager.h"
+#include "render/Gui.h"
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
 #include "utils/ConfigManager.h"
@@ -33,15 +35,22 @@
 #include <CEGUI/WindowManager.h>
 
 #include <OgreRoot.h>
+#include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreSceneManager.h>
 
 #include <SFML/Audio/Listener.hpp>
 
-SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
+#include <algorithm>
+#include <exception>
+#include <map>
+#include <sstream>
+
+SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow, Gui& gui):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
     mRootWindow(rootWindow),
-    dynamicShadowsChanged(false)
+    mGui(gui)
 {
     if (rootWindow == nullptr)
     {
@@ -140,14 +149,14 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     );
 
     addEventConnection(
-        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/DynamicShadowsCheckbox")->subscribeEvent(
-            CEGUI::ToggleButton::EventSelectStateChanged,
-            CEGUI::Event::Subscriber(&SettingsWindow::onTriggerDynamicShadows, this)
+        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/UIScaleCombobox")->subscribeEvent(
+            CEGUI::Combobox::EventListSelectionAccepted,
+            CEGUI::Event::Subscriber(&SettingsWindow::onUiScaleChanged, this)
         )
     );
-    
 
     initConfig();
+    mGui.registerWindowHierarchy(mApplyWindow);
 }
 
 SettingsWindow::~SettingsWindow()
@@ -290,7 +299,6 @@ void SettingsWindow::initConfig()
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
     dynamicShadowsCheckBox->setSelected( config.getUserValue(Config::Ctg::AUDIO,Config::SHADOWS,"",false) == "Yes");
-    dynamicShadowsChanged = false;
     Ogre::ConfigOptionMap::const_iterator it = options.find(Config::VIDEO_MODE);
     if (it != options.end())
     {
@@ -334,6 +342,32 @@ void SettingsWindow::initConfig()
         vsCheckBox->setSelected((vsync.currentValue == "Yes"));
     }
 
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    uiScaleCb->setReadOnly(true);
+    uiScaleCb->resetList();
+    int configuredUiScale = 100;
+    std::istringstream uiScaleParser(config.getGameValue(Config::UI_SCALE, "100", false));
+    if(!(uiScaleParser >> configuredUiScale))
+        configuredUiScale = 100;
+    configuredUiScale = std::max(static_cast<int>(Gui::MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<int>(Gui::MAX_UI_SCALE_PERCENT), configuredUiScale));
+    configuredUiScale = (configuredUiScale + 5) / 10 * 10;
+    for(uint32_t uiScale = Gui::MIN_UI_SCALE_PERCENT;
+        uiScale <= Gui::MAX_UI_SCALE_PERCENT; uiScale += 10)
+    {
+        CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(
+            Helper::toString(uiScale) + "%", uiScale);
+        item->setSelectionBrushImage(selImg);
+        uiScaleCb->addItem(item);
+        if(static_cast<int>(uiScale) == configuredUiScale)
+        {
+            uiScaleCb->setItemSelectState(item, true);
+            uiScaleCb->setText(item->getText());
+        }
+    }
+    mGui.setUserScalePercent(static_cast<float>(configuredUiScale));
+
     //! First of all, clear up the previously created windows.
     CEGUI::WindowManager& winMgr = CEGUI::WindowManager::getSingleton();
     CEGUI::Window* parentWindow = mSettingsWindow->getChild("MainTabControl/Video/VideoSP/");
@@ -366,15 +400,20 @@ void SettingsWindow::initConfig()
         if (config.immutable || config.possibleValues.empty())
             continue;
 
+        // OGRE may repeat colour depths for different fullscreen refresh rates.
+        std::sort(config.possibleValues.begin(), config.possibleValues.end());
+        config.possibleValues.erase(std::unique(config.possibleValues.begin(), config.possibleValues.end()),
+                                   config.possibleValues.end());
+
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));
-        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 155 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
+        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 34));
         videoCbText->setText(optionName + ": ");
         videoCbText->setProperty("FrameEnabled", "False");
         videoCbText->setProperty("BackgroundEnabled", "False");
 
         CEGUI::Combobox* videoCb = static_cast<CEGUI::Combobox*>(videoTab->createChild("OD/Combobox", optionName));
-        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 160 + offset), CEGUI::UDim(0.5, -20),
+        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.5, -20),
                          CEGUI::UDim(0, config.possibleValues.size() * 17 + 30));
         videoCb->setReadOnly(true);
         videoCb->setSortingEnabled(true);
@@ -398,11 +437,13 @@ void SettingsWindow::initConfig()
             }
             ++cbIndex;
         }
-        offset += 30;
+        offset += 40;
     }
+
+    mGui.registerWindowHierarchy(mSettingsWindow);
 }
 
-void SettingsWindow::saveConfig()
+bool SettingsWindow::saveConfig()
 {
     Ogre::Root* ogreRoot = Ogre::Root::getSingletonPtr();
     ConfigManager& config = ConfigManager::getSingleton();
@@ -412,6 +453,7 @@ void SettingsWindow::saveConfig()
     CEGUI::Editbox* usernameEb = static_cast<CEGUI::Editbox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/NicknameEdit"));
     config.setGameValue(Config::NICKNAME, usernameEb->getText().c_str());
+    ODClient::getSingleton().requestNicknameChange(usernameEb->getText().c_str());
 
     CEGUI::Combobox* keeperVoiceCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/KeeperVoice"));
@@ -456,6 +498,12 @@ void SettingsWindow::saveConfig()
             mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     config.setAudioValue(Config::MUSIC_VOLUME, Helper::toString(volumeSlider->getCurrentValue()));
 
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* uiScaleItem = uiScaleCb->getSelectedItem();
+    if(uiScaleItem != nullptr)
+        config.setGameValue(Config::UI_SCALE, Helper::toString(uiScaleItem->getID()));
+
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
     config.setAudioValue(Config::SHADOWS, dynamicShadowsCheckBox->isSelected() ? "Yes" : "No");
@@ -463,98 +511,136 @@ void SettingsWindow::saveConfig()
     // Video
     Ogre::RenderSystem* renderer = ogreRoot->getRenderSystem();
 
-    // Changing Ogre renderer needs a restart to allow to load shaders and requested stuff
     CEGUI::Combobox* rdrCb = static_cast<CEGUI::Combobox*>(
     mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/RendererCombobox"));
     std::string rendererName = rdrCb->getSelectedItem()->getText().c_str();
-    if (rendererName != renderer->getName() || dynamicShadowsChanged)
+    if (rendererName != renderer->getName())
     {
-        renderer = ogreRoot->getRenderSystemByName(rendererName);
-        if (renderer == nullptr)
-        {
-            const Ogre::RenderSystemList& renderers = ogreRoot->getAvailableRenderers();
-            if (renderers.empty())
-            {
-                OD_LOG_ERR("No valid renderer found while searching for " + std::string(rdrCb->getSelectedItem()->getText().c_str()));
-                return;
-            }
-            renderer = *renderers.begin();
-            OD_LOG_WRN("Wanted renderer : " + std::string(rdrCb->getSelectedItem()->getText().c_str()) + " not found. Using the first available: " + renderer->getName());
-        }
-
-        config.setVideoValue(Config::RENDERER, renderer->getName());
-        config.saveUserConfig();
-
-        // If render changed, we need to restart game.
-        // Note that we do not change values according to the others inputs. The reason
-        // is that we don't know if the given values are acceptable for the selected renderer
-        if(rendererName != renderer->getName())
-            OD_LOG_INF("Changed Ogre renderer to " + rendererName + ". We need to restart");
-        else
-            OD_LOG_INF("Changed Ogre dynamic shadows. We need to restart.");
-        exit(0);
+        OD_LOG_ERR("Cannot replace the active renderer while the game is running: " + rendererName);
+        return false;
     }
 
-    
     config.setVideoValue(Config::RENDERER, renderer->getName());
 
-    // Set renderer-dependent options now we know it didn't change.
     CEGUI::ToggleButton* fsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/FullscreenCheckbox"));
-    renderer->setConfigOption(Config::FULL_SCREEN, (fsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::FULL_SCREEN, fsCheckBox->isSelected() ? "Yes" : "No");
-
     CEGUI::Combobox* resCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/ResolutionCombobox"));
-    renderer->setConfigOption(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-    config.setVideoValue(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-
-    // Stores the renderer dependent options
     CEGUI::ToggleButton* vsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/VSyncCheckbox"));
-    renderer->setConfigOption(Config::VSYNC, (vsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::VSYNC, fsCheckBox->isSelected() ? "Yes" : "No");
 
-    // Save renderer dependent settings and apply them.
+    std::map<std::string, std::string> selectedVideoOptions;
+    selectedVideoOptions[Config::FULL_SCREEN] = fsCheckBox->isSelected() ? "Yes" : "No";
+    selectedVideoOptions[Config::VIDEO_MODE] = resCb->getSelectedItem()->getText().c_str();
+    selectedVideoOptions[Config::VSYNC] = vsCheckBox->isSelected() ? "Yes" : "No";
     for (CEGUI::Window* combo : mCustomVideoComboBoxes)
-    {
-        std::string optionName = combo->getName().c_str();
-        std::string optionValue = combo->getText().c_str();
-        renderer->setConfigOption(optionName, optionValue);
-        config.setVideoValue(optionName, optionValue);
-    }
+        selectedVideoOptions[combo->getName().c_str()] = combo->getText().c_str();
 
-    config.saveUserConfig();
-
-    // Apply config
-
-    // Video
-    Ogre::RenderWindow* win = ogreRoot->getAutoCreatedWindow();
-    if(win == nullptr)
+    const Ogre::ConfigOptionMap initialRendererOptions = renderer->getConfigOptions();
+    std::map<std::string, std::string> previousRendererOptions;
+    std::map<std::string, std::string> previousVideoConfig;
+    bool resizeRenderWindow = false;
+    bool recreateRenderWindow = false;
+    for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
     {
-        OD_LOG_WRN("Changing window options when using sfml is not implemented yet! Please restart for the changes to have an effect.");
-    }
-    else
-    {
-        std::vector<std::string> resVtr = Helper::split(resCb->getSelectedItem()->getText().c_str(), 'x');
-        if (resVtr.size() == 2)
+        Ogre::ConfigOptionMap::const_iterator previous = initialRendererOptions.find(selected.first);
+        if(previous == initialRendererOptions.end())
+            continue;
+        previousRendererOptions[selected.first] = previous->second.currentValue;
+        previousVideoConfig[selected.first] = config.getVideoValue(
+            selected.first, previous->second.currentValue, false);
+        if(previous->second.currentValue == selected.second)
+            continue;
+        if(selected.first == Config::FULL_SCREEN || selected.first == Config::VIDEO_MODE)
         {
-            uint32_t width = static_cast<uint32_t>(Helper::toInt(resVtr[0]));
-            uint32_t height = static_cast<uint32_t>(Helper::toInt(resVtr[1]));
-            win->setFullscreen(fsCheckBox->isSelected(), width, height);
-
-            // In windowed mode, the window needs resizing through other means
-            // NOTE: Doesn't work when the window is maximized on certain Composers.
-            if (!fsCheckBox->isSelected())
-              win->resize(width, height);
+            resizeRenderWindow = true;
+            continue;
+        }
+        if(selected.first != Config::VSYNC && selected.first != "VSync Interval"
+            && selected.first != "Reversed Z-Buffer"
+            && selected.first != "Separate Shader Objects" && selected.first != "Debug Layer")
+        {
+            recreateRenderWindow = true;
         }
     }
+
+    ODFrameListener& frameListener = ODFrameListener::getSingleton();
+    try
+    {
+        renderer->setConfigOption(Config::FULL_SCREEN, selectedVideoOptions[Config::FULL_SCREEN]);
+        renderer->setConfigOption(Config::VIDEO_MODE, selectedVideoOptions[Config::VIDEO_MODE]);
+        renderer->setConfigOption(Config::VSYNC, selectedVideoOptions[Config::VSYNC]);
+        for (CEGUI::Window* combo : mCustomVideoComboBoxes)
+            renderer->setConfigOption(combo->getName().c_str(), combo->getText().c_str());
+
+        for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
+            config.setVideoValue(selected.first, selected.second);
+        config.saveUserConfig();
+
+        const Ogre::SceneManager::CameraList& cameras = RenderManager::getSingleton().getSceneManager()->getCameras();
+        for(const std::pair<const Ogre::String, Ogre::Camera*>& camera : cameras)
+            camera.second->setAspectRatio(camera.second->getAspectRatio());
+
+        if(recreateRenderWindow)
+        {
+            frameListener.requestRenderWindowRecreation(previousRendererOptions, previousVideoConfig);
+        }
+        else
+        {
+            Ogre::RenderWindow* window = frameListener.getRenderWindow();
+            if(resizeRenderWindow)
+            {
+                const std::vector<std::string> resolution = Helper::split(
+                    selectedVideoOptions[Config::VIDEO_MODE], 'x');
+                if(resolution.size() != 2)
+                    throw std::runtime_error("invalid video mode: " + selectedVideoOptions[Config::VIDEO_MODE]);
+
+                const uint32_t width = static_cast<uint32_t>(Helper::toInt(resolution[0]));
+                const uint32_t height = static_cast<uint32_t>(Helper::toInt(resolution[1]));
+                const bool fullscreen = fsCheckBox->isSelected();
+                window->setFullscreen(fullscreen, width, height);
+                if(!fullscreen)
+                    window->resize(width, height);
+                window->windowMovedOrResized();
+                frameListener.windowResized(window);
+            }
+            window->setVSyncInterval(static_cast<unsigned int>(Helper::toInt(
+                config.getVideoValue("VSync Interval", "1", false))));
+            window->setVSyncEnabled(vsCheckBox->isSelected());
+        }
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        std::map<std::string, std::string>::const_iterator fullscreen =
+            previousRendererOptions.find(Config::FULL_SCREEN);
+        if(fullscreen != previousRendererOptions.end())
+            renderer->setConfigOption(fullscreen->first, fullscreen->second);
+        std::map<std::string, std::string>::const_iterator videoMode =
+            previousRendererOptions.find(Config::VIDEO_MODE);
+        if(videoMode != previousRendererOptions.end())
+            renderer->setConfigOption(videoMode->first, videoMode->second);
+        for(const std::pair<const std::string, std::string>& option : previousRendererOptions)
+        {
+            if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+                continue;
+            renderer->setConfigOption(option.first, option.second);
+        }
+        for(const std::pair<const std::string, std::string>& option : previousVideoConfig)
+            config.setVideoValue(option.first, option.second);
+        config.saveUserConfig();
+        initConfig();
+        return false;
+    }
+    RenderManager::getSingleton().setDynamicShadowsEnabled(dynamicShadowsCheckBox->isSelected());
+    return true;
 }
 
 void SettingsWindow::show()
 {
     if (mSettingsWindow)
     {
+        initConfig();
         // Input only allowed on this window when visible.
         mSettingsWindow->setModalState(true);
         mSettingsWindow->show();
@@ -623,8 +709,8 @@ bool SettingsWindow::onApplySettings(const CEGUI::EventArgs&)
         return true;
     }
 
-    saveConfig();
-    hide();
+    if(saveConfig())
+        hide();
     return true;
 }
 
@@ -650,6 +736,16 @@ bool SettingsWindow::onMusicVolumeChanged(const CEGUI::EventArgs&)
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     setMusicVolumeValue(volumeSlider->getCurrentValue());
+    return true;
+}
+
+bool SettingsWindow::onUiScaleChanged(const CEGUI::EventArgs&)
+{
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* selectedItem = uiScaleCb->getSelectedItem();
+    if(selectedItem != nullptr)
+        mGui.setUserScalePercent(static_cast<float>(selectedItem->getID()));
     return true;
 }
 
@@ -702,11 +798,6 @@ bool SettingsWindow::onLightFactorChanged(const CEGUI::EventArgs&)
     return true;
 }
 
-
-void SettingsWindow::onTriggerDynamicShadows(const CEGUI::EventArgs&)
-{
-    dynamicShadowsChanged = !dynamicShadowsChanged;
-}
 
 void SettingsWindow::setLightFactorValue(float lightFactor)
 {

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -25,6 +25,8 @@
 
 #include <vector>
 
+class Gui;
+
 //! \brief This class is creating a setting window gui child to the current gui context
 //! and populates its widgets with the current game, video, audio values.
 //! It also permits to change them.
@@ -34,7 +36,7 @@ public:
     //! \brief Settings window constructor
     //! \param rootWindow The main CEGUI window used as background to the current mode.
     //! Used to load and later show the settings window.
-    SettingsWindow(CEGUI::Window* rootWindow);
+    SettingsWindow(CEGUI::Window* rootWindow, Gui& gui);
 
     ~SettingsWindow();
 
@@ -52,7 +54,6 @@ public:
     //! \brief Called when pushing the cancel button on the settings window.
     bool onCancelSettings(const CEGUI::EventArgs& e = {});
 
-    void onTriggerDynamicShadows(const CEGUI::EventArgs& );
 private:
     //! \brief Vector of cegui event bindings to be cleared on exiting the mode
     std::vector<CEGUI::Event::Connection> mEventConnections;
@@ -66,6 +67,8 @@ private:
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
 
+    Gui& mGui;
+
     //! \brief The temporary video comboboxes and texts created depending on the video settings.
     std::vector<CEGUI::Window*> mCustomVideoComboBoxes;
     std::vector<CEGUI::Window*> mCustomVideoTexts;
@@ -73,8 +76,8 @@ private:
     //! \brief Set the different widget values according to current config.
     void initConfig();
 
-    //! \brief Save the config, potentially stopping the application if it needs to.
-    void saveConfig();
+    //! \brief Save and apply the config. Returns false if a selected value could not be applied.
+    bool saveConfig();
 
     //! \brief Adds an event binding to be cleared on exiting the mode.
     inline void addEventConnection(CEGUI::Event::Connection conn)
@@ -101,11 +104,13 @@ private:
     bool onLightFactorChanged(const CEGUI::EventArgs&);
     bool onPanSpeedChanged(const CEGUI::EventArgs&);
 
+    //! \brief Applies the selected UI scale immediately.
+    bool onUiScaleChanged(const CEGUI::EventArgs&);
+
     //! \brief Set the volume value in the ambient light factor setting text and slider.
     void setLightFactorValue(float lightFactor);
     void setPanSpeedValue(float panSpeedPercent);
 
-    bool dynamicShadowsChanged;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -127,6 +127,8 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "editorAskPortalWaveData";
         case ClientNotificationType::editorSetPortalWaveData:
             return "editorSetPortalWaveData";
+        case ClientNotificationType::changeNick:
+            return "changeNick";
         default:
             OD_LOG_ERR("Unknown enum for ClientNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -79,7 +79,10 @@ enum class ClientNotificationType
     editorAskCreateMapLight,
     editorSetCreatureLevel,
     editorAskPortalWaveData,
-    editorSetPortalWaveData
+    editorSetPortalWaveData,
+
+    // Append new messages to preserve existing network and replay identifiers.
+    changeNick
 };
 
 ODPacket& operator<<(ODPacket& os, const ClientNotificationType& nt);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -224,9 +224,17 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             ServerMode serverMode;
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
+            // Older servers and replays end this packet after the server mode.
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            setSupportsLiveNickname(liveNickname);
+
             ODPacket packSend;
             const std::string& nick = gameMap->getLocalPlayerNick();
             packSend << ClientNotificationType::setNick << nick;
+            if(liveNickname)
+                packSend << true;
             send(packSend);
 
             // We can proceed to configure seat level
@@ -289,6 +297,23 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
                 OD_ASSERT_TRUE(packetReceived >> nick >> id);
                 mode->addPlayer(nick, id);
                 addEventMessage(new EventMessage(nick + " is now connected."));
+            }
+            break;
+        }
+
+        case ServerNotificationType::playerNickChanged:
+        {
+            int32_t playerId;
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> playerId >> nickname);
+            for(Player* player : gameMap->getPlayers())
+            {
+                if(player->getId() != playerId)
+                    continue;
+                player->setNick(nickname);
+                if(player == getPlayer())
+                    gameMap->setLocalPlayerNick(nickname);
+                break;
             }
             break;
         }
@@ -1465,6 +1490,18 @@ bool ODClient::replay(const std::string& filename)
 void ODClient::queueClientNotification(ClientNotification* n)
 {
     mClientNotificationQueue.push_back(n);
+}
+
+void ODClient::requestNicknameChange(const std::string& nickname)
+{
+    if(getSource() != ODSource::network || getPlayer() == nullptr || getPlayer()->getNick() == nickname)
+        return;
+    if(!supportsLiveNickname())
+    {
+        OD_LOG_WRN("The connected server does not support changing the current player's nickname.");
+        return;
+    }
+    queueClientNotification(ClientNotificationType::changeNick, nickname);
 }
 
 void ODClient::disconnect(bool keepReplay)

--- a/source/network/ODClient.h
+++ b/source/network/ODClient.h
@@ -58,6 +58,8 @@ class ODClient: public Ogre::Singleton<ODClient>,
     //! \brief Adds a client notification to the client notification queue.
     void queueClientNotification(ClientNotification* n);
 
+    void requestNicknameChange(const std::string& nickname);
+
     /*! \brief Adds a client notification to the client notification queue.
      *  \param type The type of the notification
      *  \param args The arguments that are to be piped into the notification.

--- a/source/network/ODPacket.h
+++ b/source/network/ODPacket.h
@@ -122,6 +122,9 @@ class ODPacket
          */
         operator bool() const;
 
+        bool endOfPacket() const
+        { return mPacket.endOfPacket(); }
+
         /*! \brief Clears the packet. After calling Clear, the packet should
          * be empty.
          */
@@ -158,4 +161,3 @@ class ODPacket
 };
 
 #endif // ODPACKET_H
-

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -896,7 +896,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             clientSocket->setState("nick");
             // Tell the client to give us their nickname
             ODPacket packetSend;
-            packetSend << ServerNotificationType::pickNick << mServerMode;
+            packetSend << ServerNotificationType::pickNick << mServerMode << true;
             clientSocket->send(packetSend);
             break;
         }
@@ -909,6 +909,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // Pick nick
             std::string clientNick;
             OD_ASSERT_TRUE(packetReceived >> clientNick);
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            clientSocket->setSupportsLiveNickname(liveNickname);
 
             // NOTE : playerId 0 is reserved for inactive players and 1 is reserved for AI
             int32_t playerId = mUniqueNumberPlayer + Seat::PLAYER_ID_HUMAN_MIN;
@@ -962,6 +966,27 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             packetSend << ServerNotificationType::startGameMode << seatId << mServerMode;
             clientSocket->send(packetSend);
             mSeatsConfigured = true;
+            break;
+        }
+
+        case ClientNotificationType::changeNick:
+        {
+            if(mServerState != ServerState::StateGame || !clientSocket->supportsLiveNickname()
+                || clientSocket->getPlayer() == nullptr)
+                break;
+
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> nickname);
+            Player* player = clientSocket->getPlayer();
+            player->setNick(nickname);
+            const int32_t playerId = player->getId();
+            ODPacket packetSend;
+            packetSend << ServerNotificationType::playerNickChanged << playerId << nickname;
+            for(ODSocketClient* client : mSockClients)
+            {
+                if(client->supportsLiveNickname())
+                    client->send(packetSend);
+            }
             break;
         }
 

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -60,6 +60,7 @@ bool ODSocketClient::replay(const std::string& filename)
 
 void ODSocketClient::disconnect(bool keepReplay)
 {
+    mSupportsLiveNickname = false;
     mPendingTimestamp = -1;
     ODSource src = mSource;
     mSource = ODSource::none;

--- a/source/network/ODSocketClient.h
+++ b/source/network/ODSocketClient.h
@@ -50,7 +50,8 @@ class ODSocketClient
             mSource(ODSource::none),
             mPlayer(nullptr),
             mLastTurnAck(-1),
-            mPendingTimestamp(-1)
+            mPendingTimestamp(-1),
+            mSupportsLiveNickname(false)
         {}
 
         virtual ~ODSocketClient()
@@ -68,6 +69,8 @@ class ODSocketClient
 
         Player* getPlayer() { return mPlayer; }
         void setPlayer(Player* player) { mPlayer = player; }
+        bool supportsLiveNickname() const { return mSupportsLiveNickname; }
+        void setSupportsLiveNickname(bool supported) { mSupportsLiveNickname = supported; }
         int64_t getLastTurnAck() { return mLastTurnAck; }
         void setLastTurnAck(int64_t lastTurnAck) { mLastTurnAck = lastTurnAck; }
         const std::string& getState() {return mState;}
@@ -130,6 +133,7 @@ class ODSocketClient
         std::ofstream mReplayOutputStream;
         ODPacket mPendingPacket;
         int32_t mPendingTimestamp;
+        bool mSupportsLiveNickname;
 
         //! \brief the replay filename being written. Used to later optionally delete it
         //! if asked to.
@@ -137,4 +141,3 @@ class ODSocketClient
 };
 
 #endif // ODSOCKETCLIENT_H
-

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -140,6 +140,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "displayText";
         case ServerNotificationType::editorPortalWaveData:
             return "editorPortalWaveData";
+        case ServerNotificationType::playerNickChanged:
+            return "playerNickChanged";
         default:
             OD_LOG_ERR("Unknown enum for ServerNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -102,7 +102,10 @@ enum class ServerNotificationType
     //! \brief Answer to the editor asking what the waves of a wave portal are
     editorPortalWaveData,
 
-    exit
+    exit,
+
+    // Sent only to clients that negotiated live nickname changes.
+    playerNickChanged
 };
 
 ODPacket& operator<<(ODPacket& os, const ServerNotificationType& nt);

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -24,9 +24,11 @@
 
 #include "ODApplication.h"
 #include "sound/SoundEffectsManager.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 
 #include <CEGUI/CEGUI.h>
+#include <CEGUI/BasicImage.h>
 #include <CEGUI/RendererModules/Ogre/Renderer.h>
 #include <CEGUI/RendererModules/Ogre/ResourceProvider.h>
 #include <CEGUI/RendererModules/Ogre/ImageCodec.h>
@@ -34,10 +36,93 @@
 #include <CEGUI/System.h>
 #include <CEGUI/WindowManager.h>
 #include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/widgets/TabControl.h>
 #include <CEGUI/Event.h>
 
+#include <algorithm>
+#include <sstream>
+
+namespace
+{
+const float LAYOUT_DESIGN_WIDTH = 1024.0f;
+const float LAYOUT_DESIGN_HEIGHT = 768.0f;
+const float FONT_DESIGN_WIDTH = 800.0f;
+const float FONT_DESIGN_HEIGHT = 600.0f;
+
+void scaleDimension(CEGUI::UDim& dimension, float scale)
+{
+    dimension.d_offset *= scale;
+}
+
+CEGUI::URect scaleRect(const CEGUI::URect& rect, float scale)
+{
+    CEGUI::URect scaled(rect);
+    scaleDimension(scaled.d_min.d_x, scale);
+    scaleDimension(scaled.d_min.d_y, scale);
+    scaleDimension(scaled.d_max.d_x, scale);
+    scaleDimension(scaled.d_max.d_y, scale);
+    return scaled;
+}
+
+CEGUI::USize scaleSize(const CEGUI::USize& size, float scale)
+{
+    CEGUI::USize scaled(size);
+    scaleDimension(scaled.d_width, scale);
+    scaleDimension(scaled.d_height, scale);
+    return scaled;
+}
+
+bool shouldScaleImage(const CEGUI::String& ceguiName)
+{
+    const std::string name(ceguiName.c_str());
+    return name.compare(0, 17, "OpenDungeonsSkin/") == 0
+        || name.compare(0, 18, "OpenDungeonsIcons/") == 0
+        || name.compare(0, 17, "ODMainMenuButton/") == 0
+        || name.compare(0, 7, "ODLogo/") == 0;
+}
+
+std::string scaleFormattedImageSizes(const CEGUI::String& ceguiText, float scale)
+{
+    std::string text(ceguiText.c_str());
+    size_t tagStart = 0;
+    while((tagStart = text.find("[image-size='", tagStart)) != std::string::npos)
+    {
+        size_t tagEnd = text.find("']", tagStart);
+        if(tagEnd == std::string::npos)
+            break;
+
+        const char* dimensions[] = {"w:", "h:"};
+        for(const char* dimension : dimensions)
+        {
+            const size_t marker = text.find(dimension, tagStart);
+            if(marker == std::string::npos || marker >= tagEnd)
+                continue;
+
+            const size_t valueStart = marker + 2;
+            size_t valueEnd = valueStart;
+            while(valueEnd < tagEnd && ((text[valueEnd] >= '0' && text[valueEnd] <= '9') || text[valueEnd] == '.'))
+                ++valueEnd;
+
+            float value = 0.0f;
+            std::istringstream valueParser(text.substr(valueStart, valueEnd - valueStart));
+            if(!(valueParser >> value))
+                continue;
+
+            std::ostringstream scaledValue;
+            scaledValue << std::max(1, static_cast<int>(value * scale + 0.5f));
+            text.replace(valueStart, valueEnd - valueStart, scaledValue.str());
+            tagEnd = text.find("']", tagStart);
+        }
+
+        tagStart = tagEnd + 2;
+    }
+    return text;
+}
+}
+
 Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFileName, Ogre::RenderTarget &renderTarget)
-  : mSoundEffectsManager(soundEffectsManager)
+  : mUserScale(1.0f),
+    mSoundEffectsManager(soundEffectsManager)
 {
     OD_LOG_INF("*** Initializing CEGUI ***");
     CEGUI::OgreRenderer& renderer = CEGUI::OgreRenderer::create(renderTarget);
@@ -52,6 +137,15 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
     CEGUI::SchemeManager::getSingleton().createFromFile("ODSkin.scheme");
     OD_LOG_INF("CEGUI::SchemeManager created");
+
+    float configuredScalePercent = 100.0f;
+    std::istringstream scaleParser(ConfigManager::getSingleton().getGameValue(Config::UI_SCALE, "100", false));
+    if(!(scaleParser >> configuredScalePercent))
+        configuredScalePercent = 100.0f;
+    configuredScalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), configuredScalePercent));
+    mUserScale = configuredScalePercent / 100.0f;
+    updateResourceScaling(renderer.getDisplaySize());
 
     // We want Ogre overlays to be displayed in front of CEGUI. According to
     // http://cegui.org.uk/forum/viewtopic.php?f=10&t=5694
@@ -83,6 +177,17 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
     mSheets[loadSavedGameMenu] =  wmgr->loadLayoutFromFile("MenuLoad.layout");
     mSheets[console] = wmgr->loadLayoutFromFile("WindowConsole.layout");
 
+    mDisplaySizeChangedConnection = CEGUI::System::getSingleton().subscribeEvent(
+        CEGUI::System::EventDisplaySizeChanged,
+        CEGUI::Event::Subscriber(&Gui::onDisplaySizeChanged, this));
+    mWindowDestroyedConnection = wmgr->subscribeEvent(
+        CEGUI::WindowManager::EventWindowDestroyed,
+        CEGUI::Event::Subscriber(&Gui::onWindowDestroyed, this));
+
+    for(const auto& sheet : mSheets)
+        registerWindow(sheet.second);
+    applyScale(renderer.getDisplaySize());
+
     // Set the game version
     mSheets[mainMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
     mSheets[skirmishMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
@@ -103,6 +208,8 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
 Gui::~Gui()
 {
+    mDisplaySizeChangedConnection.disconnect();
+    mWindowDestroyedConnection.disconnect();
     //This also calls CEGUI::System::destroy();
     CEGUI::OgreRenderer::destroySystem();
 }
@@ -117,9 +224,134 @@ CEGUI::MouseButton Gui::convertButton(OIS::MouseButtonID buttonID)
 
 void Gui::loadGuiSheet(guiSheet newSheet)
 {
+    registerWindowHierarchy(mSheets[newSheet]);
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().setRootWindow(mSheets[newSheet]);
     // This shouldn't be needed, but the gui seems to not allways change when using hideGui without it.
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::registerWindowHierarchy(CEGUI::Window* window)
+{
+    if(window == nullptr)
+        return;
+
+    registerWindow(window);
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+void Gui::registerWindow(CEGUI::Window* window)
+{
+    if(!window->isAutoWindow() && mScaledWindows.find(window) == mScaledWindows.end())
+    {
+        WindowScaleData data;
+        data.area = window->getArea();
+        data.minSize = window->getMinSize();
+        data.maxSize = window->getMaxSize();
+        data.text = window->getText();
+        data.hasFormattedImageSize = std::string(data.text.c_str()).find("[image-size='") != std::string::npos;
+        data.hasTabHeight = false;
+
+        CEGUI::TabControl* tabControl = dynamic_cast<CEGUI::TabControl*>(window);
+        if(tabControl != nullptr)
+        {
+            data.tabHeight = tabControl->getTabHeight();
+            data.hasTabHeight = true;
+        }
+
+        mScaledWindows.insert(std::make_pair(window, data));
+    }
+
+    for(size_t i = 0; i < window->getChildCount(); ++i)
+        registerWindow(window->getChildAtIdx(i));
+}
+
+void Gui::setUserScalePercent(float scalePercent)
+{
+    if(scalePercent != scalePercent)
+        scalePercent = 100.0f;
+
+    scalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), scalePercent));
+    mUserScale = scalePercent / 100.0f;
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+bool Gui::onDisplaySizeChanged(const CEGUI::EventArgs& e)
+{
+    const CEGUI::DisplayEventArgs& displayEvent = static_cast<const CEGUI::DisplayEventArgs&>(e);
+    applyScale(displayEvent.size);
+    return true;
+}
+
+bool Gui::onWindowDestroyed(const CEGUI::EventArgs& e)
+{
+    const CEGUI::WindowEventArgs& windowEvent = static_cast<const CEGUI::WindowEventArgs&>(e);
+    mScaledWindows.erase(windowEvent.window);
+    return true;
+}
+
+void Gui::applyScale(const CEGUI::Sizef& displaySize)
+{
+    const float resolutionScale = std::min(displaySize.d_width / LAYOUT_DESIGN_WIDTH,
+        displaySize.d_height / LAYOUT_DESIGN_HEIGHT);
+    const float scale = resolutionScale * mUserScale;
+
+    updateResourceScaling(displaySize);
+
+    for(const auto& scaledWindow : mScaledWindows)
+        applyScale(scaledWindow.first, scaledWindow.second, scale);
+
+    CEGUI::System::getSingleton().getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale)
+{
+    window->setMinSize(scaleSize(data.minSize, scale));
+    window->setMaxSize(scaleSize(data.maxSize, scale));
+    window->setArea(scaleRect(data.area, scale));
+
+    if(data.hasFormattedImageSize)
+        window->setText(scaleFormattedImageSizes(data.text, scale));
+
+    if(data.hasTabHeight)
+    {
+        CEGUI::UDim tabHeight(data.tabHeight);
+        scaleDimension(tabHeight, scale);
+        static_cast<CEGUI::TabControl*>(window)->setTabHeight(tabHeight);
+    }
+}
+
+void Gui::updateResourceScaling(const CEGUI::Sizef& displaySize)
+{
+    const CEGUI::Sizef fontNativeResolution(FONT_DESIGN_WIDTH / mUserScale,
+        FONT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::FontManager::FontIterator font = CEGUI::FontManager::getSingleton().getIterator();
+    while(!font.isAtEnd())
+    {
+        font.getCurrentValue()->setNativeResolution(fontNativeResolution);
+        font.getCurrentValue()->setAutoScaled(CEGUI::ASM_Min);
+        ++font;
+    }
+
+    const CEGUI::Sizef imageNativeResolution(LAYOUT_DESIGN_WIDTH / mUserScale,
+        LAYOUT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::ImageManager::ImageIterator image = CEGUI::ImageManager::getSingleton().getIterator();
+    while(!image.isAtEnd())
+    {
+        if(shouldScaleImage(image.getCurrentKey()))
+        {
+            CEGUI::BasicImage* basicImage = dynamic_cast<CEGUI::BasicImage*>(image.getCurrentValue().first);
+            if(basicImage != nullptr)
+            {
+                basicImage->setNativeResolution(imageNativeResolution);
+                basicImage->setAutoScaled(CEGUI::ASM_Min);
+            }
+        }
+        ++image;
+    }
+
+    CEGUI::FontManager::getSingleton().notifyDisplaySizeChanged(displaySize);
+    CEGUI::ImageManager::getSingleton().notifyDisplaySizeChanged(displaySize);
 }
 
 CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)
@@ -129,7 +361,14 @@ CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)
     {
         return it->second;
     }
+
     return nullptr;
+}
+
+void Gui::setRenderTarget(Ogre::RenderTarget& renderTarget)
+{
+    static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingleton().getRenderer())
+        ->setDefaultRootRenderTarget(renderTarget);
 }
 
 bool Gui::playButtonClickSound(const CEGUI::EventArgs&)

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -40,6 +40,7 @@
 #include <CEGUI/Event.h>
 
 #include <algorithm>
+#include <cmath>
 #include <sstream>
 
 namespace
@@ -48,6 +49,36 @@ const float LAYOUT_DESIGN_WIDTH = 1024.0f;
 const float LAYOUT_DESIGN_HEIGHT = 768.0f;
 const float FONT_DESIGN_WIDTH = 800.0f;
 const float FONT_DESIGN_HEIGHT = 600.0f;
+
+void createHandFeedbackImage()
+{
+    // Original project artwork: the reference's prohibition shape, without copied assets.
+    const int size = 64;
+    std::vector<unsigned char> pixels(size * size * 4, 0);
+    for(int y = 0; y < size; ++y)
+    {
+        for(int x = 0; x < size; ++x)
+        {
+            const float dx = x + 0.5f - size * 0.5f;
+            const float dy = y + 0.5f - size * 0.5f;
+            const float radius = std::sqrt(dx * dx + dy * dy);
+            const float ring = std::min(28.0f - radius, radius - 21.0f);
+            const float slash = std::min(24.0f - radius, 3.5f - std::abs(dx - dy) * 0.70710678f);
+            const float coverage = std::max(0.0f, std::min(1.0f, std::max(ring, slash) + 0.5f));
+            const int i = (y * size + x) * 4;
+            pixels[i] = 210;
+            pixels[i + 1] = 32;
+            pixels[i + 2] = 48;
+            pixels[i + 3] = static_cast<unsigned char>(coverage * 255.0f);
+        }
+    }
+    CEGUI::Texture& texture = CEGUI::System::getSingleton().getRenderer()->createTexture("HandProhibition");
+    texture.loadFromMemory(pixels.data(), CEGUI::Sizef(size, size), CEGUI::Texture::PF_RGBA);
+    CEGUI::BasicImage& image = static_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingleton().create(
+        "BasicImage", "OpenDungeonsIcons/Prohibition"));
+    image.setTexture(&texture);
+    image.setArea(CEGUI::Rectf(0, 0, size, size));
+}
 
 void scaleDimension(CEGUI::UDim& dimension, float scale)
 {
@@ -137,6 +168,7 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
     CEGUI::SchemeManager::getSingleton().createFromFile("ODSkin.scheme");
     OD_LOG_INF("CEGUI::SchemeManager created");
+    createHandFeedbackImage();
 
     float configuredScalePercent = 100.0f;
     std::istringstream scaleParser(ConfigManager::getSingleton().getGameValue(Config::UI_SCALE, "100", false));

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -255,6 +255,7 @@ void Gui::registerWindow(CEGUI::Window* window)
         if(tabControl != nullptr)
         {
             data.tabHeight = tabControl->getTabHeight();
+            data.tabTextPadding = tabControl->getTabTextPadding();
             data.hasTabHeight = true;
         }
 
@@ -318,6 +319,9 @@ void Gui::applyScale(CEGUI::Window* window, const WindowScaleData& data, float s
         CEGUI::UDim tabHeight(data.tabHeight);
         scaleDimension(tabHeight, scale);
         static_cast<CEGUI::TabControl*>(window)->setTabHeight(tabHeight);
+        CEGUI::UDim tabTextPadding(data.tabTextPadding);
+        scaleDimension(tabTextPadding, scale);
+        static_cast<CEGUI::TabControl*>(window)->setTabTextPadding(tabTextPadding);
     }
 }
 
@@ -382,8 +386,8 @@ bool Gui::playButtonClickSound(const CEGUI::EventArgs&)
  */
 const std::string Gui::DISPLAY_GOLD = "HorizontalPipe/GoldDisplay";
 const std::string Gui::DISPLAY_MANA = "HorizontalPipe/ManaDisplay";
-const std::string Gui::DISPLAY_TERRITORY = "HorizontalPipe/TerritoryDisplay";
-const std::string Gui::DISPLAY_CREATURES = "HorizontalPipe/CreaturesDisplay";
+const std::string Gui::DISPLAY_TERRITORY = "PlayerSettingsWindow/TerritoryDisplay";
+const std::string Gui::DISPLAY_CREATURES = "PlayerSettingsWindow/CreaturesDisplay";
 const std::string Gui::MINIMAP = "MiniMap";
 const std::string Gui::OBJECTIVE_TEXT = "ObjectivesWindow/ObjectivesText";
 const std::string Gui::MAIN_TABCONTROL = "MainTabControl";

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -24,7 +24,9 @@
 #ifndef GUI_H_
 #define GUI_H_
 
+#include <CEGUI/Event.h>
 #include <CEGUI/InputEvent.h>
+#include <CEGUI/Window.h>
 
 #include <OISMouse.h>
 
@@ -84,6 +86,21 @@ public:
     static CEGUI::MouseButton convertButton (OIS::MouseButtonID buttonID);
 
     CEGUI::Window* getGuiSheet(guiSheet sheet);
+
+    //! \brief Move CEGUI rendering to another Ogre render target.
+    void setRenderTarget(Ogre::RenderTarget& renderTarget);
+
+    enum
+    {
+        MIN_UI_SCALE_PERCENT = 80,
+        MAX_UI_SCALE_PERCENT = 120
+    };
+
+    //! \brief Registers a window tree for resolution-independent scaling.
+    void registerWindowHierarchy(CEGUI::Window* window);
+
+    //! \brief Sets the user-selected UI scale and applies it immediately.
+    void setUserScalePercent(float scalePercent);
 
     // Access names of the GUI elements
     static const std::string ROOT;
@@ -152,9 +169,33 @@ public:
     bool playButtonClickSound(const CEGUI::EventArgs& e = {});
 
 private:
+    struct WindowScaleData
+    {
+        CEGUI::URect area;
+        CEGUI::USize minSize;
+        CEGUI::USize maxSize;
+        CEGUI::String text;
+        CEGUI::UDim tabHeight;
+        bool hasFormattedImageSize;
+        bool hasTabHeight;
+    };
+
     std::map<guiSheet, CEGUI::Window*> mSheets;
+    std::map<CEGUI::Window*, WindowScaleData> mScaledWindows;
+
+    float mUserScale;
+
+    CEGUI::Event::ScopedConnection mDisplaySizeChangedConnection;
+    CEGUI::Event::ScopedConnection mWindowDestroyedConnection;
 
     SoundEffectsManager* mSoundEffectsManager;
+
+    bool onDisplaySizeChanged(const CEGUI::EventArgs& e);
+    bool onWindowDestroyed(const CEGUI::EventArgs& e);
+    void registerWindow(CEGUI::Window* window);
+    void applyScale(const CEGUI::Sizef& displaySize);
+    void applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale);
+    void updateResourceScaling(const CEGUI::Sizef& displaySize);
 };
 
 #endif // GUI_H_

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -176,6 +176,7 @@ private:
         CEGUI::USize maxSize;
         CEGUI::String text;
         CEGUI::UDim tabHeight;
+        CEGUI::UDim tabTextPadding;
         bool hasFormattedImageSize;
         bool hasTabHeight;
     };

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -43,11 +43,13 @@
 #include "sound/MusicPlayer.h"
 #include "sound/SoundEffectsManager.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 #include "utils/MakeUnique.h"
 
 #include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreRenderSystem.h>
 #include <OgreRoot.h>
 #include <OgreSceneManager.h>
 #include <Overlay/OgreOverlaySystem.h>
@@ -59,6 +61,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <stdexcept>
 #include <iostream>
 
 #include <signal.h>
@@ -81,6 +84,9 @@ ODFrameListener::ODFrameListener(const std::string& mainSceneFileName, Ogre::Ren
     lastSecondFrameRenderingQueued(0),
     mInitialized(false),
     mWindow(renderWindow),
+    mPrimaryWindow(renderWindow),
+    mRenderWindowRecreationPending(false),
+    mRenderWindowSequence(0),
     mGui(gui),
     mRenderManager(RenderManager::getSingletonPtr()),
     mGameMap(Utils::make_unique<GameMap>(false)),
@@ -119,6 +125,12 @@ void ODFrameListener::windowResized(Ogre::RenderWindow* rw)
     int left, top;
     rw->getMetrics(width, height, left, top);
 
+    if(width == 0 || height == 0)
+        return;
+
+    Ogre::Camera* camera = mCameraManager.getActiveCamera();
+    camera->setAspectRatio(static_cast<Ogre::Real>(width) / static_cast<Ogre::Real>(height));
+
     mModeManager->getInputManager().setWidthAndHeight(width, height);
     //Notify CEGUI that the display size has changed.
     CEGUI::System::getSingleton().notifyDisplaySizeChanged(CEGUI::Size<float>(
@@ -148,6 +160,177 @@ ODFrameListener::~ODFrameListener()
 void ODFrameListener::requestExit()
 {
     mExitRequested = true;
+}
+
+void ODFrameListener::requestRenderWindowRecreation(
+    const std::map<std::string, std::string>& previousRendererOptions,
+    const std::map<std::string, std::string>& previousVideoConfig)
+{
+    mPreviousRendererOptions = previousRendererOptions;
+    mPreviousVideoConfig = previousVideoConfig;
+    mRenderWindowRecreationPending = true;
+}
+
+void ODFrameListener::restorePreviousVideoSettings()
+{
+    Ogre::RenderSystem* renderer = Ogre::Root::getSingleton().getRenderSystem();
+    std::map<std::string, std::string>::const_iterator fullscreen =
+        mPreviousRendererOptions.find(Config::FULL_SCREEN);
+    if(fullscreen != mPreviousRendererOptions.end())
+        renderer->setConfigOption(fullscreen->first, fullscreen->second);
+    std::map<std::string, std::string>::const_iterator videoMode =
+        mPreviousRendererOptions.find(Config::VIDEO_MODE);
+    if(videoMode != mPreviousRendererOptions.end())
+        renderer->setConfigOption(videoMode->first, videoMode->second);
+    for(const std::pair<const std::string, std::string>& option : mPreviousRendererOptions)
+    {
+        if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+            continue;
+        renderer->setConfigOption(option.first, option.second);
+    }
+
+    ConfigManager& config = ConfigManager::getSingleton();
+    for(const std::pair<const std::string, std::string>& option : mPreviousVideoConfig)
+        config.setVideoValue(option.first, option.second);
+    config.saveUserConfig();
+    mPreviousRendererOptions.clear();
+    mPreviousVideoConfig.clear();
+}
+
+void ODFrameListener::applyPendingRenderWindowRecreation()
+{
+    if(!mRenderWindowRecreationPending)
+        return;
+    mRenderWindowRecreationPending = false;
+
+    Ogre::Root& root = Ogre::Root::getSingleton();
+    Ogre::RenderSystem* renderer = root.getRenderSystem();
+    Ogre::RenderWindow* previousWindow = mWindow;
+    Ogre::RenderWindow* replacementWindow = nullptr;
+    unsigned int previousWidth = 0;
+    unsigned int previousHeight = 0;
+    int previousLeft = 0;
+    int previousTop = 0;
+    previousWindow->getMetrics(previousWidth, previousHeight, previousLeft, previousTop);
+    const bool previousWasFullScreen = previousWindow->isFullScreen();
+    bool guiMoved = false;
+    bool cameraMoved = false;
+    bool inputMoved = false;
+    bool listenerMoved = false;
+    bool windowRegistered = false;
+
+    try
+    {
+        Ogre::RenderWindowDescription description = renderer->getRenderWindowDescription();
+        description.name = "OpenDungeonsLiveSettings" + Helper::toString(++mRenderWindowSequence);
+        description.miscParams["title"] = mPrimaryWindow->getName();
+        description.miscParams["hidden"] = "true";
+        if(!description.useFullScreen && !previousWasFullScreen)
+        {
+            description.miscParams["left"] = Helper::toString(previousLeft);
+            description.miscParams["top"] = Helper::toString(previousTop);
+        }
+
+        replacementWindow = root.createRenderWindow(description);
+        replacementWindow->setAutoUpdated(false);
+        replacementWindow->setActive(false);
+        Ogre::WindowEventUtilities::_addRenderWindow(replacementWindow);
+        windowRegistered = true;
+
+        renderer->_setRenderTarget(replacementWindow);
+        mCameraManager.setRenderWindow(replacementWindow);
+        cameraMoved = true;
+        mRenderManager->setViewport(mCameraManager.getViewport());
+        mGui->setRenderTarget(*replacementWindow);
+        guiMoved = true;
+        if(!mModeManager->getInputManager().setRenderWindow(replacementWindow))
+            throw std::runtime_error("input initialization failed for the replacement window");
+        mModeManager->getInputManager().refreshSettings();
+        inputMoved = true;
+
+        Ogre::WindowEventUtilities::removeWindowEventListener(previousWindow, this);
+        Ogre::WindowEventUtilities::addWindowEventListener(replacementWindow, this);
+        listenerMoved = true;
+        mWindow = replacementWindow;
+
+        previousWindow->setAutoUpdated(false);
+        previousWindow->setActive(false);
+        previousWindow->setVisible(false);
+        if(previousWasFullScreen)
+        {
+            previousWindow->setFullscreen(false, previousWidth, previousHeight);
+            if(description.useFullScreen)
+            {
+                replacementWindow->setFullscreen(false, description.width, description.height);
+                replacementWindow->setFullscreen(true, description.width, description.height);
+            }
+        }
+        replacementWindow->setVisible(true);
+        replacementWindow->setActive(true);
+        replacementWindow->setAutoUpdated(true);
+        replacementWindow->windowMovedOrResized();
+        windowResized(replacementWindow);
+
+        if(previousWindow != mPrimaryWindow)
+        {
+            Ogre::WindowEventUtilities::_removeRenderWindow(previousWindow);
+            root.destroyRenderTarget(previousWindow);
+        }
+        mPreviousRendererOptions.clear();
+        mPreviousVideoConfig.clear();
+        OD_LOG_INF("Applied video settings without restarting the game");
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        renderer->_setRenderTarget(previousWindow);
+        if(listenerMoved)
+        {
+            Ogre::WindowEventUtilities::removeWindowEventListener(replacementWindow, this);
+            Ogre::WindowEventUtilities::addWindowEventListener(previousWindow, this);
+            mWindow = previousWindow;
+        }
+        if(inputMoved)
+            mModeManager->getInputManager().setRenderWindow(previousWindow);
+        if(guiMoved)
+            mGui->setRenderTarget(*previousWindow);
+        if(cameraMoved)
+        {
+            mCameraManager.setRenderWindow(previousWindow);
+            mRenderManager->setViewport(mCameraManager.getViewport());
+        }
+        if(replacementWindow != nullptr)
+        {
+            if(windowRegistered)
+                Ogre::WindowEventUtilities::_removeRenderWindow(replacementWindow);
+            root.destroyRenderTarget(replacementWindow);
+        }
+        if(previousWasFullScreen && !previousWindow->isFullScreen())
+            previousWindow->setFullscreen(true, previousWidth, previousHeight);
+        restorePreviousVideoSettings();
+        previousWindow->setVisible(true);
+        previousWindow->setActive(true);
+        previousWindow->setAutoUpdated(true);
+        windowResized(previousWindow);
+    }
+}
+
+void ODFrameListener::prepareRenderWindowShutdown()
+{
+    if(mInitialized)
+        exitApplication();
+    mModeManager.reset();
+
+    if(mWindow != mPrimaryWindow)
+    {
+        Ogre::WindowEventUtilities::_removeRenderWindow(mWindow);
+        Ogre::Root& root = Ogre::Root::getSingleton();
+        root.getRenderSystem()->_setRenderTarget(mPrimaryWindow);
+        mGui->setRenderTarget(*mPrimaryWindow);
+        root.destroyRenderTarget(mWindow);
+        mWindow = mPrimaryWindow;
+    }
+    Ogre::WindowEventUtilities::_removeRenderWindow(mPrimaryWindow);
 }
 
 void ODFrameListener::exitApplication()
@@ -193,6 +376,7 @@ bool ODFrameListener::frameRenderingQueued(const Ogre::FrameEvent& evt)
     CEGUI::System::getSingleton().getDefaultGUIContext().injectTimePulse(evt.timeSinceLastFrame);
 
     mModeManager->update(evt);
+    applyPendingRenderWindowRecreation();
 
     int64_t currentTurn = mGameMap->getTurnNumber();
 
@@ -466,4 +650,3 @@ void ODFrameListener::readMainScene(const std::string& fileName)
     OD_LOG_INF("Load main scene file: " + fileName);
     mMainScene->readSceneMenu(fileName);
 }
-

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -36,6 +36,7 @@
 #include <OgreWindowEventUtilities.h>
 
 #include <memory>
+#include <map>
 #include <vector>
 
 
@@ -152,6 +153,13 @@ public:
     inline Ogre::RenderWindow* getRenderWindow()
     { return mWindow; }
 
+    void requestRenderWindowRecreation(
+        const std::map<std::string, std::string>& previousRendererOptions,
+        const std::map<std::string, std::string>& previousVideoConfig);
+
+    //! \brief Release window-dependent objects before ODApplication destroys the primary window.
+    void prepareRenderWindowShutdown();
+
     inline bool getIsMainMenuCreated()
     { return mIsMainMenuCreated; }
 
@@ -215,6 +223,14 @@ private:
     //! \brief The Ogre render window reference. Don't delete it.
     Ogre::RenderWindow* mWindow;
 
+    //! \brief The first window owns the main OpenGL context and remains alive as an anchor.
+    Ogre::RenderWindow* mPrimaryWindow;
+
+    bool mRenderWindowRecreationPending;
+    uint32_t mRenderWindowSequence;
+    std::map<std::string, std::string> mPreviousRendererOptions;
+    std::map<std::string, std::string> mPreviousVideoConfig;
+
     //! \brief Foreign reference to gui.
     Gui*                 mGui;
 
@@ -240,6 +256,9 @@ private:
 
     //! \brief Actually exit application
     void exitApplication();
+
+    void applyPendingRenderWindowRecreation();
+    void restorePreviousVideoSettings();
 
     //! \brief Updates server-turn independent creature animation, audio, and overall rendering.
     void updateAnimations(Ogre::Real timeSinceLastFrame);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -2567,7 +2567,19 @@ void RenderManager::rrDrawTilePreview(const std::vector<Tile*>& tiles, const Ogr
     {
         const float x = static_cast<float>(tile->getX());
         const float y = static_cast<float>(tile->getY());
-        const float z = tile->isFullTile() ? 1.02f : 0.04f;
+        float z = 0.04f;
+        if(tile->isFullTile())
+        {
+            // Use the rendered wall, including the existing unrevealed tile
+            // representation, so the outline cannot sit inside a taller mesh.
+            Ogre::MovableObject* wall = tile->getFogOfWarMesh();
+            const std::string meshName = tile->getOgreNamePrefix() + tile->getName() + "_tileMesh";
+            if(mSceneManager->hasEntity(meshName))
+                wall = mSceneManager->getEntity(meshName);
+            if(wall == nullptr)
+                continue;
+            z = wall->getWorldBoundingBox(true).getMaximum().z + 0.02f;
+        }
         const Ogre::Vector3 corners[] = {{x-0.5f,y-0.5f,z}, {x+0.5f,y-0.5f,z},
             {x+0.5f,y+0.5f,z}, {x-0.5f,y+0.5f,z}};
         for(int i = 0; i < 4; ++i)

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -46,6 +46,10 @@
 
 
 #include <OgreBone.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+#include <OgreManualObject.h>
 #include <OgreCamera.h>
 #include <OgreCompositorManager.h>
 #include <OgreEntity.h>
@@ -93,6 +97,69 @@ const Ogre::Real RenderManager::DRAGGABLE_NODE_HEIGHT = 3.0f;
 
 const int PERLIN_NOISE_TEXTURE_SIZE =  4096;
 
+namespace
+{
+void createKeeperHandPoses(Ogre::Entity* hand)
+{
+    Ogre::Skeleton* skeleton = hand->getMesh()->getSkeleton().get();
+    const Ogre::Animation* pickup = skeleton->getAnimation("Pickup");
+    // Reuse the existing rig's closed fingers; the index stays extended when pointing.
+    for(const std::string pose : {"Point", "Dig"})
+    {
+        if(!skeleton->hasAnimation(pose))
+        {
+            Ogre::Animation* animation = skeleton->createAnimation(pose, 1.0f);
+            for(unsigned short b = 0; b < skeleton->getNumBones(); ++b)
+            {
+                const std::string& name = skeleton->getBone(b)->getName();
+                const bool finger = name.find("Middle") == 0 || name.find("Midlle") == 0 ||
+                    name.find("Ring") == 0 || name.find("Little") == 0 || name.find("Thumb") == 0 ||
+                    (pose == "Dig" && name.find("Index") == 0);
+                if(!finger || !pickup->hasNodeTrack(b))
+                    continue;
+                Ogre::TransformKeyFrame sampled(nullptr, 0);
+                pickup->getNodeTrack(b)->getInterpolatedKeyFrame(Ogre::TimeIndex(pickup->getLength() * 0.5f), &sampled);
+                Ogre::TransformKeyFrame* frame = animation->createNodeTrack(b)->createNodeKeyFrame(0);
+                frame->setRotation(sampled.getRotation());
+                frame->setTranslate(sampled.getTranslate());
+                frame->setScale(sampled.getScale());
+            }
+        }
+        if(!hand->hasAnimationState(pose))
+            hand->getAllAnimationStates()->createAnimationState(pose, 0, 1.0f);
+    }
+}
+
+void addPickaxePrism(Ogre::ManualObject* mesh, const std::vector<Ogre::Vector2>& points,
+    float depth, const Ogre::ColourValue& colour)
+{
+    // A small extruded polygon, in the hand rig's local units.
+    const unsigned int count = static_cast<unsigned int>(points.size());
+    for(unsigned int i = 1; i + 1 < count; ++i)
+    {
+        for(float z : {-depth, depth})
+        {
+            for(unsigned int corner : {0u, z < 0 ? i + 1 : i, z < 0 ? i : i + 1})
+            {
+                mesh->position(points[corner].x, points[corner].y, z);
+                mesh->colour(colour);
+            }
+        }
+    }
+    for(unsigned int i = 0; i < count; ++i)
+    {
+        const Ogre::Vector2& a = points[i];
+        const Ogre::Vector2& b = points[(i + 1) % count];
+        for(const Ogre::Vector3& vertex : {Ogre::Vector3(a.x,a.y,-depth), Ogre::Vector3(b.x,b.y,-depth),
+            Ogre::Vector3(b.x,b.y,depth), Ogre::Vector3(a.x,a.y,-depth),
+            Ogre::Vector3(b.x,b.y,depth), Ogre::Vector3(a.x,a.y,depth)})
+        {
+            mesh->position(vertex);
+            mesh->colour(Ogre::ColourValue(colour.r * 0.75f, colour.g * 0.75f, colour.b * 0.75f, colour.a));
+        }
+    }
+}
+}
 
 RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mHandLight(nullptr),
@@ -476,6 +543,8 @@ void RenderManager::preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
 
 void RenderManager::stopGameRenderer(GameMap*)
 {
+    rrDrawTilePreview({}, Ogre::ColourValue::White);
+    rrSetHandPose(false, false);
     // We do not remove the entities from mDummyEntities as it is a workaround avoiding a crash and removing
     // them can cause the crash to happen
 
@@ -521,6 +590,7 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
 
     // Create the nodes that will follow the mouse pointer.
     Ogre::Entity* keeperHandEnt = mSceneManager->createEntity("keeperHandEnt", "Keeperhand.mesh");
+    createKeeperHandPoses(keeperHandEnt);
     keeperHandEnt->setLightMask(0);
     keeperHandEnt->setCastShadows(false);
     mHandAnimationState = keeperHandEnt->getAnimationState("Idle");
@@ -536,6 +606,24 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
     Ogre::Overlay* handKeeperOverlay = overlayManager.create(keeperHandEnt->getName() + "_Ov");
     mHandKeeperNode = mSceneManager->createSceneNode(keeperHandEnt->getName() + "_node");
     mHandKeeperNode->attachObject(keeperHandEnt);
+    mHandPickaxe = mSceneManager->createManualObject("KeeperHandPickaxe");
+    mHandPickaxe->setCastShadows(false);
+    mHandPickaxe->setRenderQueueGroup(OD_RENDER_QUEUE_ID_GUI);
+    mHandPickaxe->begin("debug_draw", Ogre::RenderOperation::OT_TRIANGLE_LIST, "Graphics");
+    addPickaxePrism(mHandPickaxe, {{-0.006f,-0.065f}, {0.006f,-0.065f}, {0.006f,0.075f}, {-0.006f,0.075f}},
+        0.005f, Ogre::ColourValue(0.42f,0.28f,0.12f));
+    // Convex sections retain the curved head's hollow underside when triangulated.
+    addPickaxePrism(mHandPickaxe, {{-0.085f,0.043f}, {-0.042f,0.057f}, {-0.05f,0.073f}},
+        0.008f, Ogre::ColourValue(0.55f,0.57f,0.59f));
+    addPickaxePrism(mHandPickaxe, {{-0.042f,0.057f}, {0,0.065f}, {0,0.085f}, {-0.05f,0.073f}},
+        0.008f, Ogre::ColourValue(0.55f,0.57f,0.59f));
+    addPickaxePrism(mHandPickaxe, {{0,0.065f}, {0.042f,0.057f}, {0.05f,0.073f}, {0,0.085f}},
+        0.008f, Ogre::ColourValue(0.55f,0.57f,0.59f));
+    addPickaxePrism(mHandPickaxe, {{0.042f,0.057f}, {0.085f,0.043f}, {0.05f,0.073f}},
+        0.008f, Ogre::ColourValue(0.55f,0.57f,0.59f));
+    mHandPickaxe->end();
+    keeperHandEnt->attachObjectToBone("Hand2", mHandPickaxe, Ogre::Quaternion::IDENTITY, Ogre::Vector3(0,0.03f,0.01f));
+    mHandPickaxe->setVisible(false);
     mHandKeeperNode->setScale(Ogre::Vector3::UNIT_SCALE * KEEPER_HAND_POS_Z);
     mHandKeeperNode->setPosition(0.0f, 0.0f, -KEEPER_HAND_POS_Z);
     handKeeperOverlay->add3D(mHandKeeperNode);
@@ -753,7 +841,7 @@ void RenderManager::updateRenderAnimations(Ogre::Real timeSinceLastFrame)
         if(mHandAnimationState->hasEnded())
         {
             Ogre::Entity* ent = mSceneManager->getEntity("keeperHandEnt");
-            mHandAnimationState = setEntityAnimation(ent, "Idle", true);
+            mHandAnimationState = setEntityAnimation(ent, mHandPose, true);
         }
     }
 }
@@ -2449,6 +2537,63 @@ void RenderManager::moveWorldCoords(Ogre::Real x, Ogre::Real y)
     }
 }
 
+void RenderManager::rrSetHandPose(bool pointing, bool digging)
+{
+    mHandPose = digging ? "Dig" : (pointing ? "Point" : "Idle");
+    if(mHandAnimationState != nullptr && mHandAnimationState->getLoop() &&
+       mHandAnimationState->getAnimationName() != mHandPose)
+        mHandAnimationState = setEntityAnimation(mSceneManager->getEntity("keeperHandEnt"), mHandPose, true);
+    if(mHandPickaxe != nullptr)
+        mHandPickaxe->setVisible(digging && mHandKeeperHandVisibility == 0 &&
+            mHandAnimationState != nullptr && mHandAnimationState->getLoop());
+}
+
+void RenderManager::rrDrawTilePreview(const std::vector<Tile*>& tiles, const Ogre::ColourValue& colour)
+{
+    if(mTilePreview == nullptr)
+    {
+        if(tiles.empty())
+            return;
+        mTilePreview = mSceneManager->createManualObject("KeeperTilePreview");
+        mTilePreview->setDynamic(true);
+        mTilePreview->setCastShadows(false);
+        mSceneManager->getRootSceneNode()->createChildSceneNode("KeeperTilePreviewNode")->attachObject(mTilePreview);
+    }
+    mTilePreview->clear();
+    if(tiles.empty())
+        return;
+    mTilePreview->begin("debug_draw", Ogre::RenderOperation::OT_LINE_LIST, "Graphics");
+    for(Tile* tile : tiles)
+    {
+        const float x = static_cast<float>(tile->getX());
+        const float y = static_cast<float>(tile->getY());
+        const float z = tile->isFullTile() ? 1.02f : 0.04f;
+        const Ogre::Vector3 corners[] = {{x-0.5f,y-0.5f,z}, {x+0.5f,y-0.5f,z},
+            {x+0.5f,y+0.5f,z}, {x-0.5f,y+0.5f,z}};
+        for(int i = 0; i < 4; ++i)
+        {
+            mTilePreview->position(corners[i]);
+            mTilePreview->colour(colour);
+            mTilePreview->position(corners[(i+1)%4]);
+            mTilePreview->colour(colour);
+            if(tile->isFullTile())
+            {
+                const Ogre::Vector3 bottom(corners[i].x, corners[i].y, 0.04f);
+                const Ogre::Vector3 nextBottom(corners[(i+1)%4].x, corners[(i+1)%4].y, 0.04f);
+                mTilePreview->position(bottom);
+                mTilePreview->colour(colour);
+                mTilePreview->position(nextBottom);
+                mTilePreview->colour(colour);
+                mTilePreview->position(bottom);
+                mTilePreview->colour(colour);
+                mTilePreview->position(corners[i]);
+                mTilePreview->colour(colour);
+            }
+        }
+    }
+    mTilePreview->end();
+}
+
 void RenderManager::entitySlapped()
 {
     Ogre::Entity* ent = mSceneManager->getEntity("keeperHandEnt");
@@ -2500,6 +2645,8 @@ std::string RenderManager::rrBuildSkullFlagMaterial(const std::string& materialN
 
 void RenderManager::rrMinimapRendering(bool postRender)
 {
+    if(mTilePreview != nullptr)
+        mTilePreview->setVisible(postRender);
     if(mHandLight != nullptr)
         mHandLight->setVisible(postRender);
 

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -106,6 +106,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mHandLightNode(nullptr),
     mShadowCam(nullptr),
     mCurrentFOVy(0.0f),
+    mCurrentAspectRatio(0.0f),
     mFactorWidth(0.0f),
     mFactorHeight(0.0f),
     mCreatureTextOverlayDisplayed(false),
@@ -120,42 +121,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     // mShaderGenerator->setShaderCacheEnabled(true);
     
     mShaderGenerator->addSceneManager(mSceneManager); 
-    if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE);
-        // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
-        // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
-        // mSceneManager->setShadowFarDistance(100.0);
-        // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
-        // mSceneManager->setShadowTextureSelfShadow(true);
-        // donno if the below should be here -- paul424 :
-        auto myIter = Ogre::MaterialManager::getSingleton().getResourceIterator();
-        while(myIter.hasMoreElements())
-        {
-            auto myPointer = myIter.peekNextValue();
-            Ogre::SharedPtr<Ogre::Material> myCastPointer = std::dynamic_pointer_cast<Ogre::Material> (myPointer);
-            Ogre::Technique* technique;
-            technique = myCastPointer->getTechnique(0);
-
-            if( technique->getPass(technique->getNumPasses() - 1)->hasFragmentProgram())
-            {
-                if(technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->hasNamedParameters())
-                {
-                    const Ogre::GpuNamedConstants& gnc = technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->getConstantDefinitions();
-                    auto it = gnc.map.find("shadowingEnabled");
-                    if(it!=  gnc.map.end())
-                        technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->setNamedConstant("shadowingEnabled",true);
-                }
-            }
-            myIter.getNext();
-        }  
-        
-    }
-    else
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_NONE);
-
-    }
+    setDynamicShadowsEnabled(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS) == "Yes");
     ddd.setStatic(true);
     mSceneManager->addListener(&ddd);
     mSceneManager->addRenderQueueListener(overlaySystem);
@@ -210,6 +176,42 @@ void RenderManager::saveTexture(Ogre::TexturePtr texture, const std::string& fil
     pixelBuffer->unlock();
 }
 
+
+void RenderManager::setDynamicShadowsEnabled(bool enabled)
+{
+    // Custom shaders apply lighting and shadows in one pass; automatic
+    // illumination splitting removes their fragment programs on GL3Plus.
+    mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
+    // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
+    // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
+    // mSceneManager->setShadowFarDistance(100.0);
+    // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
+    // mSceneManager->setShadowTextureSelfShadow(true);
+
+    // Include material clones and techniques created since the game started.
+    Ogre::ResourceManager::ResourceMapIterator materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while(materials.hasMoreElements())
+    {
+        Ogre::MaterialPtr material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+        for(unsigned short techniqueIndex = 0; techniqueIndex < material->getNumTechniques(); ++techniqueIndex)
+        {
+            Ogre::Technique* technique = material->getTechnique(techniqueIndex);
+            for(unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex)
+            {
+                Ogre::Pass* pass = technique->getPass(passIndex);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters())
+                {
+                    const Ogre::GpuNamedConstants& constants = parameters->getConstantDefinitions();
+                    if(constants.map.find("shadowingEnabled") != constants.map.end())
+                        parameters->setNamedConstant("shadowingEnabled", enabled);
+                }
+            }
+        }
+    }
+}
 
 RenderManager::~RenderManager()
 {
@@ -2425,24 +2427,15 @@ std::string RenderManager::setMaterialOpacity(const std::string& materialName, f
 void RenderManager::moveCursor(float relX, float relY)
 {
     Ogre::Camera* cam = mViewport->getCamera();
-    if(cam->getFOVy() != mCurrentFOVy)
+    if(cam->getFOVy() != mCurrentFOVy || cam->getAspectRatio() != mCurrentAspectRatio)
     {
         mCurrentFOVy = cam->getFOVy();
+        mCurrentAspectRatio = cam->getAspectRatio();
         Ogre::Radian angle = cam->getFOVy() * 0.5f;
         Ogre::Real tan = Ogre::Math::Tan(angle);
-        Ogre::Real shortestSize = KEEPER_HAND_POS_Z * tan * 2.0f;
-        Ogre::Real width = mViewport->getActualWidth();
-        Ogre::Real height = mViewport->getActualHeight();
-        if(width > height)
-        {
-            mFactorHeight = shortestSize;
-            mFactorWidth = shortestSize * width / height;
-        }
-        else
-        {
-            mFactorWidth = shortestSize;
-            mFactorHeight = shortestSize * height / width;
-        }
+        // FOVy defines the vertical extent; keep the hand aligned after resizing.
+        mFactorHeight = KEEPER_HAND_POS_Z * tan * 2.0f;
+        mFactorWidth = mFactorHeight * mCurrentAspectRatio;
     }
 
     mHandKeeperNode->setPosition(mFactorWidth * (relX - 0.5f), mFactorHeight * (0.5f - relY), -KEEPER_HAND_POS_Z);

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -96,8 +96,12 @@ public:
     //! \brief setup the scene
     void createScene(Ogre::Viewport*);
 
+    void setViewport(Ogre::Viewport* viewport)
+    { mViewport = viewport; }
+
     //! \brief Sets/Updates the overall world lighting value with given factor.
     void setWorldAmbientLightingFactor(float lightFactor);
+    void setDynamicShadowsEnabled(bool enabled);
 
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);
@@ -274,6 +278,7 @@ private:
     Ogre::SceneNode* mHandLightNode2;
     Ogre::Camera* mShadowCam;
     Ogre::Radian mCurrentFOVy;
+    Ogre::Real mCurrentAspectRatio;
     Ogre::Real mFactorWidth;
     Ogre::Real mFactorHeight;
 

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -169,6 +169,8 @@ public:
         const std::string& particleScript);
     void rrEntityRemoveParticleEffect(GameEntity* entity, Ogre::ParticleSystem* particleSystem);
     void rrToggleHandSelectorVisibility();
+    void rrSetHandPose(bool pointing, bool digging);
+    void rrDrawTilePreview(const std::vector<Tile*>& tiles, const Ogre::ColourValue& colour);
 
     //! \brief Toggles the creatures text overlay
     void rrSetCreaturesTextOverlay(GameMap& gameMap, bool value);
@@ -264,6 +266,9 @@ private:
     Ogre::SceneNode* mMainMenuSceneNode;
 
     Ogre::AnimationState* mHandAnimationState;
+    std::string mHandPose = "Idle";
+    Ogre::ManualObject* mHandPickaxe = nullptr;
+    Ogre::ManualObject* mTilePreview = nullptr;
 
 
     Ogre::TexturePtr m_texture;

--- a/source/rooms/RoomBridge.cpp
+++ b/source/rooms/RoomBridge.cpp
@@ -40,21 +40,8 @@ void BridgeRoomFactory::checkBuildBridge(RoomType type, GameMap* gameMap, Seat* 
 
     int32_t pricePerTarget = RoomManager::costPerTile(type);
     int32_t playerGold = static_cast<int32_t>(seat->getGold());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    if(isEditor && inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        if(!isEditor)
-        {
-            if(playerGold < pricePerTarget)
-            {
-                std::string txt = formatBuildRoom(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::Red, txt);
-            }
-            else
-            {
-                std::string txt = formatBuildRoom(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::White, txt);
-            }
-        }
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
         return;
@@ -154,15 +141,23 @@ void BridgeRoomFactory::checkBuildBridge(RoomType type, GameMap* gameMap, Seat* 
         buildableTiles.insert(buildableTiles.end(), tmpTiles.begin(), tmpTiles.end());
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
         inputCommand.selectTiles(buildableTiles);
 
     if(buildableTiles.empty())
     {
         if(!isEditor)
         {
-            std::string txt = formatBuildRoom(type, 0);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
+            Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+            if(tile == nullptr)
+                inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
+            else if(tile->getHasBridge())
+                inputCommand.displayText(Ogre::ColourValue::Red, "A bridge already occupies this tile.");
+            else if(std::find(allowedTilesVisual.begin(), allowedTilesVisual.end(), tile->getTileVisual()) == allowedTilesVisual.end())
+                inputCommand.displayText(Ogre::ColourValue::Red, allowedTilesVisual.size() == 1 ?
+                    "A wooden bridge needs water." : "A stone bridge needs water or lava.");
+            else
+                inputCommand.displayText(Ogre::ColourValue::Red, "Connect the bridge to your claimed ground.");
         }
         return;
     }
@@ -173,7 +168,7 @@ void BridgeRoomFactory::checkBuildBridge(RoomType type, GameMap* gameMap, Seat* 
         if(playerGold < priceTotal)
         {
             std::string txt = formatBuildRoom(type, priceTotal);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
+            inputCommand.displayText(Ogre::ColourValue::Red, "Not enough gold. " + txt);
             return;
         }
 

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -57,33 +57,16 @@ void RoomFactory::checkBuildRoomDefault(GameMap* gameMap, RoomType type, const I
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = RoomManager::costPerTile(type);
     int32_t playerGold = static_cast<int32_t>(player->getSeat()->getGold());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        if(playerGold < pricePerTarget)
-        {
-            std::string txt = formatBuildRoom(type, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatBuildRoom(type, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
-        return;
-    }
-
     std::vector<Tile*> buildableTiles = gameMap->getBuildableTilesForPlayerInArea(inputManager.mXPos,
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY, player);
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
         inputCommand.selectTiles(buildableTiles);
 
     if(buildableTiles.empty())
     {
-        std::string txt = formatBuildRoom(type, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayTileBuildFailure(gameMap->getTile(inputManager.mXPos, inputManager.mYPos),
+            player->getSeat());
         return;
     }
 
@@ -91,7 +74,7 @@ void RoomFactory::checkBuildRoomDefault(GameMap* gameMap, RoomType type, const I
     if(playerGold < priceTotal)
     {
         std::string txt = formatBuildRoom(type, priceTotal);
-        inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough gold. " + txt);
         return;
     }
 
@@ -514,28 +497,6 @@ RoomType RoomManager::getRoomTypeFromRoomName(const std::string& name)
 void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
     Player* player = gameMap->getLocalPlayer();
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        // We do not differentiate between room and trap (because there is no way to know on client side).
-        // Note that price = 0 doesn't mean that the building is not a room
-        Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsRoom()) || (tile->getSeat() != player->getSeat()))
-        {
-            std::string txt = formatSellRoom(0);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-            inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
-            return;
-        }
-
-        uint32_t price = tile->getRefundPriceRoom();
-        std::string txt = formatSellRoom(price);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
-        std::vector<Tile*> tiles;
-        tiles.push_back(tile);
-        inputCommand.selectTiles(tiles);
-        return;
-    }
-
     std::vector<Tile*> sellTiles;
     std::vector<Tile*> tiles = gameMap->rectangularRegion(inputManager.mXPos,
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
@@ -545,6 +506,9 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
         if(!tile->getIsRoom())
             continue;
 
+        if(tile->getTileVisual() == TileVisual::portalRoom || tile->getTileVisual() == TileVisual::portalWaveRoom)
+            continue;
+
         if(tile->getSeat() != player->getSeat())
             continue;
 
@@ -552,11 +516,22 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
         priceTotal += tile->getRefundPriceRoom();
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(sellTiles.empty())
+    {
+        inputCommand.unselectAllTiles();
+        Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+        if(tile != nullptr && (tile->getTileVisual() == TileVisual::portalRoom || tile->getTileVisual() == TileVisual::portalWaveRoom))
+            inputCommand.displayText(Ogre::ColourValue::Red, "Portals cannot be sold.");
+        else
+            inputCommand.displayText(Ogre::ColourValue::Red, "Select a room owned by you to sell.");
+        return;
+    }
+
+    inputCommand.displayText(Ogre::ColourValue::White, formatSellRoom(priceTotal));
+
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectTiles(sellTiles);
-        std::string txt = formatSellRoom(priceTotal);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
         return;
     }
 

--- a/source/spells/SpellCallToWar.cpp
+++ b/source/spells/SpellCallToWar.cpp
@@ -107,31 +107,23 @@ void SpellCallToWar::checkSpellCast(GameMap* gameMap, const InputManager& inputM
 
     Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
     if(tile == nullptr)
-        return;
-
-    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    int32_t price = ConfigManager::getSingleton().getSpellConfigInt32("CallToWarPrice");
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        if(playerMana < price)
-        {
-            std::string txt = formatCastSpell(SpellType::callToWar, price);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::callToWar, price);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
+    int32_t price = ConfigManager::getSingleton().getSpellConfigInt32("CallToWarPrice");
+    if(playerMana < price)
     {
-        std::string txt = formatCastSpell(SpellType::callToWar, price);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::callToWar, price));
+        return;
+    }
+    inputCommand.displayText(Ogre::ColourValue::White, formatCastSpell(SpellType::callToWar, price));
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+    {
         std::vector<Tile*> tiles;
         tiles.push_back(tile);
         inputCommand.selectTiles(tiles);
@@ -185,4 +177,3 @@ Spell* SpellCallToWar::getSpellFromPacket(GameMap* gameMap, ODPacket &is)
     spell->importFromPacket(is);
     return spell;
 }
-

--- a/source/spells/SpellCreatureDefense.cpp
+++ b/source/spells/SpellCreatureDefense.cpp
@@ -78,28 +78,14 @@ void SpellCreatureDefense::checkSpellCast(GameMap* gameMap, const InputManager& 
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureDefensePrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tileSelected == nullptr)
     {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureDefense, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureDefense, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-    if(tileSelected == nullptr)
-        return;
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
@@ -111,8 +97,20 @@ void SpellCreatureDefense::checkSpellCast(GameMap* gameMap, const InputManager& 
 
     if(closestCreature == nullptr)
     {
-        std::string txt = formatCastSpell(SpellType::creatureDefense, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a living allied creature.");
+        return;
+    }
+
+    Tile* targetTile = closestCreature->getPositionTile();
+    if(targetTile == nullptr || !targetTile->isClaimedForSeat(player->getSeat()))
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "The creature must stand on your claimed ground.");
+        return;
+    }
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureDefense, pricePerTarget));
         return;
     }
 

--- a/source/spells/SpellCreatureExplosion.cpp
+++ b/source/spells/SpellCreatureExplosion.cpp
@@ -77,41 +77,38 @@ void SpellCreatureExplosion::checkSpellCast(GameMap* gameMap, const InputManager
     int32_t priceTotal = 0;
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureExplosionPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureExplosion, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureExplosion, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
-        return;
-    }
-
-    if(inputManager.mCommandState == InputCommandState::building)
-    {
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
-            inputManager.mLStartDragY);
-    }
-
     std::vector<GameEntity*> targets;
     gameMap->playerSelects(targets, inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY,
         SelectionTileAllowed::groundClaimedAllied, SelectionEntityWanted::creatureAliveEnemy, player);
 
     if(targets.empty())
     {
-        std::string txt = formatCastSpell(SpellType::creatureExplosion, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select an enemy creature on your claimed ground.");
         return;
     }
 
-    std::random_shuffle(targets.begin(), targets.end());
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureExplosion, pricePerTarget));
+        return;
+    }
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+    {
+        std::vector<Tile*> targetTiles;
+        for(GameEntity* target : targets)
+        {
+            Tile* tile = target->getPositionTile();
+            if(std::find(targetTiles.begin(), targetTiles.end(), tile) == targetTiles.end())
+                targetTiles.push_back(tile);
+        }
+        inputCommand.selectTiles(targetTiles);
+    }
+
+    // Preview must not consume random numbers or change which creatures a later click affects.
+    if(inputManager.mCommandState == InputCommandState::validated)
+        std::random_shuffle(targets.begin(), targets.end());
     std::vector<Creature*> creatures;
     for(GameEntity* target : targets)
     {

--- a/source/spells/SpellCreatureHaste.cpp
+++ b/source/spells/SpellCreatureHaste.cpp
@@ -77,28 +77,14 @@ void SpellCreatureHaste::checkSpellCast(GameMap* gameMap, const InputManager& in
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHastePrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tileSelected == nullptr)
     {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureHaste, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureHaste, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-    if(tileSelected == nullptr)
-        return;
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
@@ -110,8 +96,20 @@ void SpellCreatureHaste::checkSpellCast(GameMap* gameMap, const InputManager& in
 
     if(closestCreature == nullptr)
     {
-        std::string txt = formatCastSpell(SpellType::creatureHaste, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a living allied creature.");
+        return;
+    }
+
+    Tile* targetTile = closestCreature->getPositionTile();
+    if(targetTile == nullptr || !targetTile->isClaimedForSeat(player->getSeat()))
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "The creature must stand on your claimed ground.");
+        return;
+    }
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureHaste, pricePerTarget));
         return;
     }
 

--- a/source/spells/SpellCreatureHeal.cpp
+++ b/source/spells/SpellCreatureHeal.cpp
@@ -78,29 +78,6 @@ void SpellCreatureHeal::checkSpellCast(GameMap* gameMap, const InputManager& inp
     int32_t priceTotal = 0;
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHealPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureHeal, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureHeal, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
-        return;
-    }
-
-    if(inputManager.mCommandState == InputCommandState::building)
-    {
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
-            inputManager.mLStartDragY);
-    }
-
     std::vector<GameEntity*> targets;
     gameMap->playerSelects(targets, inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY,
         SelectionTileAllowed::groundClaimedAllied, SelectionEntityWanted::creatureAliveOwnedHurt, player);
@@ -113,12 +90,32 @@ void SpellCreatureHeal::checkSpellCast(GameMap* gameMap, const InputManager& inp
     }
     if(targets.empty())
     {
-        std::string txt = formatCastSpell(SpellType::creatureHeal, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a hurt owned creature or hurt prisoner on your claimed ground.");
         return;
     }
 
-    std::random_shuffle(targets.begin(), targets.end());
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureHeal, pricePerTarget));
+        return;
+    }
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+    {
+        std::vector<Tile*> targetTiles;
+        for(GameEntity* target : targets)
+        {
+            Tile* tile = target->getPositionTile();
+            if(std::find(targetTiles.begin(), targetTiles.end(), tile) == targetTiles.end())
+                targetTiles.push_back(tile);
+        }
+        inputCommand.selectTiles(targetTiles);
+    }
+
+    // Preview must not consume random numbers or change which creatures a later click affects.
+    if(inputManager.mCommandState == InputCommandState::validated)
+        std::random_shuffle(targets.begin(), targets.end());
     std::vector<Creature*> creatures;
     for(GameEntity* target : targets)
     {

--- a/source/spells/SpellCreatureSlow.cpp
+++ b/source/spells/SpellCreatureSlow.cpp
@@ -77,28 +77,14 @@ void SpellCreatureSlow::checkSpellCast(GameMap* gameMap, const InputManager& inp
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureSlowPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tileSelected == nullptr)
     {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureSlow, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureSlow, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-    if(tileSelected == nullptr)
-        return;
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
@@ -111,8 +97,20 @@ void SpellCreatureSlow::checkSpellCast(GameMap* gameMap, const InputManager& inp
 
     if(closestCreature == nullptr)
     {
-        std::string txt = formatCastSpell(SpellType::creatureSlow, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a living enemy creature.");
+        return;
+    }
+
+    Tile* targetTile = closestCreature->getPositionTile();
+    if(targetTile == nullptr || !targetTile->isClaimedForSeat(player->getSeat()))
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "The creature must stand on your claimed ground.");
+        return;
+    }
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureSlow, pricePerTarget));
         return;
     }
 

--- a/source/spells/SpellCreatureStrength.cpp
+++ b/source/spells/SpellCreatureStrength.cpp
@@ -77,28 +77,14 @@ void SpellCreatureStrength::checkSpellCast(GameMap* gameMap, const InputManager&
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureStrengthPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tileSelected == nullptr)
     {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureStrength, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureStrength, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-    if(tileSelected == nullptr)
-        return;
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
@@ -110,8 +96,20 @@ void SpellCreatureStrength::checkSpellCast(GameMap* gameMap, const InputManager&
 
     if(closestCreature == nullptr)
     {
-        std::string txt = formatCastSpell(SpellType::creatureStrength, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a living allied creature.");
+        return;
+    }
+
+    Tile* targetTile = closestCreature->getPositionTile();
+    if(targetTile == nullptr || !targetTile->isClaimedForSeat(player->getSeat()))
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "The creature must stand on your claimed ground.");
+        return;
+    }
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureStrength, pricePerTarget));
         return;
     }
 

--- a/source/spells/SpellCreatureWeak.cpp
+++ b/source/spells/SpellCreatureWeak.cpp
@@ -77,28 +77,14 @@ void SpellCreatureWeak::checkSpellCast(GameMap* gameMap, const InputManager& inp
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureWeakPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+    if(tileSelected == nullptr)
     {
-        if(playerMana < pricePerTarget)
-        {
-            std::string txt = formatCastSpell(SpellType::creatureWeak, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::creatureWeak, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    Tile* tileSelected = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-    if(tileSelected == nullptr)
-        return;
-
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
             inputManager.mYPos);
@@ -110,8 +96,20 @@ void SpellCreatureWeak::checkSpellCast(GameMap* gameMap, const InputManager& inp
 
     if(closestCreature == nullptr)
     {
-        std::string txt = formatCastSpell(SpellType::creatureWeak, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a living enemy creature.");
+        return;
+    }
+
+    Tile* targetTile = closestCreature->getPositionTile();
+    if(targetTile == nullptr || !targetTile->isClaimedForSeat(player->getSeat()))
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "The creature must stand on your claimed ground.");
+        return;
+    }
+    if(playerMana < pricePerTarget)
+    {
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::creatureWeak, pricePerTarget));
         return;
     }
 

--- a/source/spells/SpellEyeEvil.cpp
+++ b/source/spells/SpellEyeEvil.cpp
@@ -101,31 +101,23 @@ void SpellEyeEvil::checkSpellCast(GameMap* gameMap, const InputManager& inputMan
 
     Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
     if(tile == nullptr)
-        return;
-
-    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    int32_t price = ConfigManager::getSingleton().getSpellConfigInt32("EyeEvilPrice");
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        if(playerMana < price)
-        {
-            std::string txt = formatCastSpell(SpellType::eyeEvil, price);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::eyeEvil, price);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Point at a tile inside the map.");
         return;
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
+    int32_t price = ConfigManager::getSingleton().getSpellConfigInt32("EyeEvilPrice");
+    if(playerMana < price)
     {
-        std::string txt = formatCastSpell(SpellType::eyeEvil, price);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::eyeEvil, price));
+        return;
+    }
+    inputCommand.displayText(Ogre::ColourValue::White, formatCastSpell(SpellType::eyeEvil, price));
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+    {
         std::vector<Tile*> tiles;
         tiles.push_back(tile);
         inputCommand.selectTiles(tiles);
@@ -179,4 +171,3 @@ Spell* SpellEyeEvil::getSpellFromPacket(GameMap* gameMap, ODPacket &is)
     spell->importFromPacket(is);
     return spell;
 }
-

--- a/source/spells/SpellManager.cpp
+++ b/source/spells/SpellManager.cpp
@@ -123,8 +123,8 @@ bool SpellManager::checkSpellCooldown(GameMap* gameMap, SpellType type, InputCom
     if(cooldown <= 0)
         return false;
 
-    std::string errorStr = getSpellNameFromSpellType(type)
-        + " (" + Helper::toString(cooldown, 2)+ " s)";
+    std::string errorStr = getSpellReadableName(type)
+        + " is cooling down (" + Helper::toString(cooldown, 2) + " s remaining).";
 
     inputCommand.displayText(Ogre::ColourValue::Red, errorStr);
     return true;

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -76,26 +76,16 @@ void SpellSummonWorker::checkSpellCast(GameMap* gameMap, const InputManager& inp
     Player* player = gameMap->getLocalPlayer();
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
 
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        int32_t price = getNextWorkerPriceForPlayer(gameMap, player);
-        if(playerMana < price)
-        {
-            std::string txt = formatCastSpell(SpellType::summonWorker, price);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatCastSpell(SpellType::summonWorker, price);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
-        return;
-    }
-
     std::vector<GameEntity*> targets;
     gameMap->playerSelects(targets, inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
         inputManager.mLStartDragY, SelectionTileAllowed::groundClaimedAllied, SelectionEntityWanted::tiles, player);
+
+    if(targets.empty())
+    {
+        inputCommand.unselectAllTiles();
+        inputCommand.displayText(Ogre::ColourValue::Red, "Summon workers on your claimed ground.");
+        return;
+    }
 
     int32_t nbFreeWorkers = ConfigManager::getSingleton().getSpellConfigInt32("SummonWorkerNbFree");
     int32_t nbWorkers = player->getSeat()->getNumCreaturesWorkers();
@@ -136,10 +126,17 @@ void SpellSummonWorker::checkSpellCast(GameMap* gameMap, const InputManager& inp
         pricePerWorker *= 2;
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(tiles.empty())
     {
-        std::string txt = formatCastSpell(SpellType::summonWorker, priceTotal);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.unselectAllTiles();
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough mana. " +
+            formatCastSpell(SpellType::summonWorker, getNextWorkerPriceForPlayer(gameMap, player)));
+        return;
+    }
+    inputCommand.displayText(Ogre::ColourValue::White, formatCastSpell(SpellType::summonWorker, priceTotal));
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+    {
         inputCommand.selectTiles(tiles);
         return;
     }

--- a/source/tests/test_ODPacket.cpp
+++ b/source/tests/test_ODPacket.cpp
@@ -54,3 +54,32 @@ BOOST_AUTO_TEST_CASE(test_ODPacket)
 
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_optional_nickname_capability)
+{
+    // The original handshake must remain readable without an extension byte.
+    ODPacket legacy;
+    legacy << std::string("Keeper");
+    std::string nickname;
+    legacy >> nickname;
+    BOOST_REQUIRE(legacy);
+    BOOST_CHECK(legacy.endOfPacket());
+
+    // Updated peers append their capability after the unchanged nickname field.
+    ODPacket extended;
+    extended << std::string("Keeper") << true;
+    extended >> nickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK_EQUAL(nickname, "Keeper");
+    BOOST_REQUIRE(!extended.endOfPacket());
+    bool liveNickname = false;
+    extended >> liveNickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK(liveNickname);
+    BOOST_CHECK(extended.endOfPacket());
+
+    extended.clear();
+    BOOST_CHECK(extended.endOfPacket());
+    extended << false;
+    BOOST_CHECK(!extended.endOfPacket());
+}

--- a/source/traps/TrapDoor.cpp
+++ b/source/traps/TrapDoor.cpp
@@ -76,51 +76,29 @@ class TrapDoorFactory : public TrapFactory
 
         int32_t pricePerTarget = TrapManager::costPerTile(type);
         int32_t playerGold = static_cast<int32_t>(player->getSeat()->getGold());
-        if(inputManager.mCommandState == InputCommandState::infoOnly)
-        {
-            if(playerGold < pricePerTarget)
-            {
-                std::string txt = formatBuildTrap(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::Red, txt);
-            }
-            else
-            {
-                std::string txt = formatBuildTrap(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::White, txt);
-            }
-            inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-                inputManager.mYPos);
-            return;
-        }
+        if(inputManager.mCommandState != InputCommandState::validated)
+            inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos,
+                inputManager.mXPos, inputManager.mYPos);
 
-        if(inputManager.mCommandState == InputCommandState::building)
+        if(!tile->isBuildableUpon(player->getSeat()))
         {
-            std::vector<Tile*> tiles;
-            tiles.push_back(tile);
-            inputCommand.selectTiles(tiles);
-            if(!tile->isBuildableUpon(player->getSeat()) ||
-               !TrapDoor::canDoorBeOnTile(gameMap, tile))
-            {
-                inputCommand.displayText(Ogre::ColourValue::Red, "Cannot place door on this tile");
-            }
-            else if(playerGold < pricePerTarget)
-            {
-                std::string txt = formatBuildTrap(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::Red, txt);
-            }
-            else
-            {
-                std::string txt = formatBuildTrap(type, pricePerTarget);
-                inputCommand.displayText(Ogre::ColourValue::White, txt);
-            }
+            inputCommand.displayTileBuildFailure(tile, player->getSeat());
             return;
         }
-
-        if(!tile->isBuildableUpon(player->getSeat()) ||
-           !TrapDoor::canDoorBeOnTile(gameMap, tile))
+        if(!TrapDoor::canDoorBeOnTile(gameMap, tile))
         {
+            inputCommand.displayText(Ogre::ColourValue::Red, "A door needs walls on two opposite sides.");
             return;
         }
+        if(playerGold < pricePerTarget)
+        {
+            inputCommand.displayText(Ogre::ColourValue::Red,
+                "Not enough gold. " + formatBuildTrap(type, pricePerTarget));
+            return;
+        }
+        inputCommand.displayText(Ogre::ColourValue::White, formatBuildTrap(type, pricePerTarget));
+        if(inputManager.mCommandState != InputCommandState::validated)
+            return;
 
         ClientNotification *clientNotification = TrapManager::createTrapClientNotification(type);
         gameMap->tileToPacket(clientNotification->mPacket, tile);

--- a/source/traps/TrapManager.cpp
+++ b/source/traps/TrapManager.cpp
@@ -55,33 +55,16 @@ void TrapFactory::checkBuildTrapDefault(GameMap* gameMap, TrapType type, const I
     Player* player = gameMap->getLocalPlayer();
     int32_t pricePerTarget = TrapManager::costPerTile(type);
     int32_t playerGold = static_cast<int32_t>(player->getSeat()->getGold());
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        if(playerGold < pricePerTarget)
-        {
-            std::string txt = formatBuildTrap(type, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::Red, txt);
-        }
-        else
-        {
-            std::string txt = formatBuildTrap(type, pricePerTarget);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-        }
-        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-            inputManager.mYPos);
-        return;
-    }
-
     std::vector<Tile*> buildableTiles = gameMap->getBuildableTilesForPlayerInArea(inputManager.mXPos,
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY, player);
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(inputManager.mCommandState != InputCommandState::validated)
         inputCommand.selectTiles(buildableTiles);
 
     if(buildableTiles.empty())
     {
-        std::string txt = formatBuildTrap(type, 0);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        inputCommand.displayTileBuildFailure(gameMap->getTile(inputManager.mXPos, inputManager.mYPos),
+            player->getSeat());
         return;
     }
 
@@ -89,7 +72,7 @@ void TrapFactory::checkBuildTrapDefault(GameMap* gameMap, TrapType type, const I
     if(playerGold < priceTotal)
     {
         std::string txt = formatBuildTrap(type, priceTotal);
-        inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        inputCommand.displayText(Ogre::ColourValue::Red, "Not enough gold. " + txt);
         return;
     }
 
@@ -495,28 +478,6 @@ TrapType TrapManager::getTrapTypeFromTrapName(const std::string& name)
 void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
     Player* player = gameMap->getLocalPlayer();
-    if(inputManager.mCommandState == InputCommandState::infoOnly)
-    {
-        // We do not differentiate between Trap and trap (because there is no way to know on client side).
-        // Note that price = 0 doesn't mean that the building is not a Trap
-        Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsTrap()) || (tile->getSeat() != player->getSeat()))
-        {
-            std::string txt = formatSellTrap(0);
-            inputCommand.displayText(Ogre::ColourValue::White, txt);
-            inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
-            return;
-        }
-
-        uint32_t price = tile->getRefundPriceTrap();
-        std::string txt = formatSellTrap(price);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
-        std::vector<Tile*> tiles;
-        tiles.push_back(tile);
-        inputCommand.selectTiles(tiles);
-        return;
-    }
-
     std::vector<Tile*> sellTiles;
     std::vector<Tile*> tiles = gameMap->rectangularRegion(inputManager.mXPos,
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
@@ -533,11 +494,18 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
         priceTotal += tile->getRefundPriceTrap();
     }
 
-    if(inputManager.mCommandState == InputCommandState::building)
+    if(sellTiles.empty())
+    {
+        inputCommand.unselectAllTiles();
+        inputCommand.displayText(Ogre::ColourValue::Red, "Select a trap owned by you to sell.");
+        return;
+    }
+
+    inputCommand.displayText(Ogre::ColourValue::White, formatSellTrap(priceTotal));
+
+    if(inputManager.mCommandState != InputCommandState::validated)
     {
         inputCommand.selectTiles(sellTiles);
-        std::string txt = formatSellTrap(priceTotal);
-        inputCommand.displayText(Ogre::ColourValue::White, txt);
         return;
     }
 

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1963,4 +1963,5 @@ void ConfigManager::loadDefaultValuesForUserConfig(void)
     setGameValue("LightFactor",	"100");
     setGameValue("MinimapType",	"MiniMapDrawn");
     setGameValue("Nickname", "Player");
+    setGameValue("UI Scale", "100");
 }

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -68,6 +68,7 @@ const std::string NICKNAME = "Nickname";
 const std::string KEEPERVOICE = "KeeperVoice";
 const std::string MINIMAP_TYPE = "MinimapType";
 const std::string LIGHT_FACTOR = "LightFactor";
+const std::string UI_SCALE = "UI Scale";
 }
 
 typedef std::map<TileVisual,std::map<int,float>> HighMap;

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);


### PR DESCRIPTION
Use the existing entity descriptions for chicken and gold pickup targets so the contextual feedback displays readable names rather than implementation-oriented labels.

Related to #4; this addresses only the behavior described above and does not claim to resolve the entire issue.

Prerequisite contributions: #70. This is one bug fix in the existing dependency stack; GitHub's default upstream comparison also contains unmerged prerequisites. Review this contribution alone using the focused comparison below, merge prerequisites separately, and recheck or rebase the remaining diff before merging this PR; do not merge the cumulative stack as an aggregate contribution.

[Review only this fix](https://github.com/Rokk001/OpenDungeonsPlus/compare/ff920ab977ebe837fc9ec7d61ee9894764638f21...6ba96b283025ae0839844ef0a5e558e4021ddb24).

Validation: this publication preserves the existing functional fork checkpoint; only fork documentation was excluded. Git patch integrity was checked, and the combined published runtime, asset and build files match the current fork. Previously recorded Windows builds and focused checks concern the original integrated fork; these contribution branches were not separately rebuilt or run. Outstanding live, multiplayer and full-interface acceptance is not claimed by this PR.

Version remains 0.7.1 because no release is being made; usage and scope are described above, and private planning and agent rules are excluded.
