### PR TITLE
Add local room lighting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +660,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)

--- a/cmake/config/resources.cfg.in
+++ b/cmake/config/resources.cfg.in
@@ -12,6 +12,11 @@ FileSystem=models
 FileSystem=particles
 FileSystem=shaders
 
+# Internal shadow programs must also be visible to OGRE's global resource pool.
+# Keep Main in Graphics above for game shader includes with strict group lookup.
+[OgreInternal]
+FileSystem=@CMAKE_INSTALL_PREFIX@/share/OGRE/Media/RTShaderLib/../Main
+
 [GUI]
 FileSystem=gui
 FileSystem=gui/fonts

--- a/materials/scripts/Arena.material
+++ b/materials/scripts/Arena.material
@@ -24,6 +24,7 @@ fragment_program myArenaFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Arena.material
+++ b/materials/scripts/Arena.material
@@ -21,10 +21,12 @@ fragment_program myArenaFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/ChickenCoop.material
+++ b/materials/scripts/ChickenCoop.material
@@ -21,10 +21,12 @@ fragment_program myChickenCoopFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/ChickenCoop.material
+++ b/materials/scripts/ChickenCoop.material
@@ -24,6 +24,7 @@ fragment_program myChickenCoopFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Claimed.material
+++ b/materials/scripts/Claimed.material
@@ -24,6 +24,7 @@ fragment_program myClaimedTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour  
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Claimed.material
+++ b/materials/scripts/Claimed.material
@@ -21,10 +21,12 @@ fragment_program myClaimedTileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour  
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Claimed2.material
+++ b/materials/scripts/Claimed2.material
@@ -24,6 +24,7 @@ fragment_program myClaimed2TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Claimed2.material
+++ b/materials/scripts/Claimed2.material
@@ -21,10 +21,12 @@ fragment_program myClaimed2TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/Creatures/Adventurer.material
+++ b/materials/scripts/Creatures/Adventurer.material
@@ -21,10 +21,12 @@ fragment_program myAdventurerFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Adventurer.material
+++ b/materials/scripts/Creatures/Adventurer.material
@@ -24,6 +24,7 @@ fragment_program myAdventurerFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetBody.material
+++ b/materials/scripts/Creatures/CaveHornetBody.material
@@ -24,6 +24,7 @@ fragment_program myCaveHornetBodyFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetBody.material
+++ b/materials/scripts/Creatures/CaveHornetBody.material
@@ -21,10 +21,12 @@ fragment_program myCaveHornetBodyFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetWings.material
+++ b/materials/scripts/Creatures/CaveHornetWings.material
@@ -24,6 +24,7 @@ fragment_program myCaveHornetWingsFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/CaveHornetWings.material
+++ b/materials/scripts/Creatures/CaveHornetWings.material
@@ -21,10 +21,12 @@ fragment_program myCaveHornetWingsFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Cultist.material
+++ b/materials/scripts/Creatures/Cultist.material
@@ -21,10 +21,12 @@ fragment_program myCultistFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0  
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Cultist.material
+++ b/materials/scripts/Creatures/Cultist.material
@@ -24,6 +24,7 @@ fragment_program myCultistFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0  
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/DarkElf.material
+++ b/materials/scripts/Creatures/DarkElf.material
@@ -21,10 +21,12 @@ fragment_program myDarkElfFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/DarkElf.material
+++ b/materials/scripts/Creatures/DarkElf.material
@@ -24,6 +24,7 @@ fragment_program myDarkElfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Defender.material
+++ b/materials/scripts/Creatures/Defender.material
@@ -21,10 +21,12 @@ fragment_program myDefenderFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Defender.material
+++ b/materials/scripts/Creatures/Defender.material
@@ -24,6 +24,7 @@ fragment_program myDefenderFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dragon.material
+++ b/materials/scripts/Creatures/Dragon.material
@@ -24,6 +24,7 @@ fragment_program myDragonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dragon.material
+++ b/materials/scripts/Creatures/Dragon.material
@@ -21,10 +21,12 @@ fragment_program myDragonFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf1.material
+++ b/materials/scripts/Creatures/Dwarf1.material
@@ -24,6 +24,7 @@ fragment_program myDwarf1FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf1.material
+++ b/materials/scripts/Creatures/Dwarf1.material
@@ -21,10 +21,12 @@ fragment_program myDwarf1FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf2.material
+++ b/materials/scripts/Creatures/Dwarf2.material
@@ -24,6 +24,7 @@ fragment_program myDwarf2FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Dwarf2.material
+++ b/materials/scripts/Creatures/Dwarf2.material
@@ -21,10 +21,12 @@ fragment_program myDwarf2FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Elf.material
+++ b/materials/scripts/Creatures/Elf.material
@@ -24,6 +24,7 @@ fragment_program myElfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Elf.material
+++ b/materials/scripts/Creatures/Elf.material
@@ -21,10 +21,12 @@ fragment_program myElfFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Gnome.material
+++ b/materials/scripts/Creatures/Gnome.material
@@ -24,6 +24,7 @@ fragment_program myGnomeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Gnome.material
+++ b/materials/scripts/Creatures/Gnome.material
@@ -21,10 +21,12 @@ fragment_program myGnomeFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Goblin.material
+++ b/materials/scripts/Creatures/Goblin.material
@@ -24,6 +24,7 @@ fragment_program myGoblinFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Goblin.material
+++ b/materials/scripts/Creatures/Goblin.material
@@ -21,10 +21,12 @@ fragment_program myGoblinFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Knight.material
+++ b/materials/scripts/Creatures/Knight.material
@@ -21,10 +21,12 @@ fragment_program myKnightFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Knight.material
+++ b/materials/scripts/Creatures/Knight.material
@@ -24,6 +24,7 @@ fragment_program myKnightFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kobold.material
+++ b/materials/scripts/Creatures/Kobold.material
@@ -21,10 +21,12 @@ fragment_program myKoboldFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kobold.material
+++ b/materials/scripts/Creatures/Kobold.material
@@ -24,6 +24,7 @@ fragment_program myKoboldFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kreatur.material
+++ b/materials/scripts/Creatures/Kreatur.material
@@ -24,6 +24,7 @@ fragment_program myKreaturFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Kreatur.material
+++ b/materials/scripts/Creatures/Kreatur.material
@@ -21,10 +21,12 @@ fragment_program myKreaturFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/LavaSpawn.material
+++ b/materials/scripts/Creatures/LavaSpawn.material
@@ -24,6 +24,7 @@ fragment_program myLavaSpawnFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/LavaSpawn.material
+++ b/materials/scripts/Creatures/LavaSpawn.material
@@ -21,10 +21,12 @@ fragment_program myLavaSpawnFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Lizardman.material
+++ b/materials/scripts/Creatures/Lizardman.material
@@ -21,10 +21,12 @@ fragment_program myLizardmanFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Lizardman.material
+++ b/materials/scripts/Creatures/Lizardman.material
@@ -24,6 +24,7 @@ fragment_program myLizardmanFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Monk.material
+++ b/materials/scripts/Creatures/Monk.material
@@ -24,6 +24,7 @@ fragment_program myMonkFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Monk.material
+++ b/materials/scripts/Creatures/Monk.material
@@ -21,10 +21,12 @@ fragment_program myMonkFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/NatureMonster.material
+++ b/materials/scripts/Creatures/NatureMonster.material
@@ -24,6 +24,7 @@ fragment_program myNatureMonsterFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/NatureMonster.material
+++ b/materials/scripts/Creatures/NatureMonster.material
@@ -21,10 +21,12 @@ fragment_program myNatureMonsterFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Orc.material
+++ b/materials/scripts/Creatures/Orc.material
@@ -21,10 +21,12 @@ fragment_program myOrcFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Orc.material
+++ b/materials/scripts/Creatures/Orc.material
@@ -24,6 +24,7 @@ fragment_program myOrcFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/PitDemon.material
+++ b/materials/scripts/Creatures/PitDemon.material
@@ -17,10 +17,12 @@ fragment_program myPitDemonFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/PitDemon.material
+++ b/materials/scripts/Creatures/PitDemon.material
@@ -20,6 +20,7 @@ fragment_program myPitDemonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Rat.material
+++ b/materials/scripts/Creatures/Rat.material
@@ -24,6 +24,7 @@ fragment_program myRatFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Rat.material
+++ b/materials/scripts/Creatures/Rat.material
@@ -21,10 +21,12 @@ fragment_program myRatFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Roach.material
+++ b/materials/scripts/Creatures/Roach.material
@@ -24,6 +24,7 @@ fragment_program myRoachFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Roach.material
+++ b/materials/scripts/Creatures/Roach.material
@@ -21,10 +21,12 @@ fragment_program myRoachFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/RunelordDwarf.material
+++ b/materials/scripts/Creatures/RunelordDwarf.material
@@ -24,6 +24,7 @@ fragment_program myRunelordDwarfFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/RunelordDwarf.material
+++ b/materials/scripts/Creatures/RunelordDwarf.material
@@ -21,10 +21,12 @@ fragment_program myRunelordDwarfFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Scarab.material
+++ b/materials/scripts/Creatures/Scarab.material
@@ -21,10 +21,12 @@ fragment_program myScarabFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Scarab.material
+++ b/materials/scripts/Creatures/Scarab.material
@@ -24,6 +24,7 @@ fragment_program myScarabFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Slime.material
+++ b/materials/scripts/Creatures/Slime.material
@@ -24,6 +24,7 @@ fragment_program mySlimeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Slime.material
+++ b/materials/scripts/Creatures/Slime.material
@@ -21,10 +21,12 @@ fragment_program mySlimeFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Spider.material
+++ b/materials/scripts/Creatures/Spider.material
@@ -21,10 +21,12 @@ fragment_program mySpiderFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Spider.material
+++ b/materials/scripts/Creatures/Spider.material
@@ -24,6 +24,7 @@ fragment_program mySpiderFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleAlbine.material
+++ b/materials/scripts/Creatures/TentacleAlbine.material
@@ -21,10 +21,12 @@ fragment_program myTentacleAlbineFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleAlbine.material
+++ b/materials/scripts/Creatures/TentacleAlbine.material
@@ -24,6 +24,7 @@ fragment_program myTentacleAlbineFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleGreen.material
+++ b/materials/scripts/Creatures/TentacleGreen.material
@@ -24,6 +24,7 @@ fragment_program myTentacleGreenFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/TentacleGreen.material
+++ b/materials/scripts/Creatures/TentacleGreen.material
@@ -21,10 +21,12 @@ fragment_program myTentacleGreenFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Troll.material
+++ b/materials/scripts/Creatures/Troll.material
@@ -24,6 +24,7 @@ fragment_program myTrollFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Troll.material
+++ b/materials/scripts/Creatures/Troll.material
@@ -21,10 +21,12 @@ fragment_program myTrollFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wizard.material
+++ b/materials/scripts/Creatures/Wizard.material
@@ -21,10 +21,12 @@ fragment_program myWizardFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour 
-        param_named_auto lightDiffuseColour light_diffuse_colour 0
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wizard.material
+++ b/materials/scripts/Creatures/Wizard.material
@@ -24,6 +24,7 @@ fragment_program myWizardFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wyvern.material
+++ b/materials/scripts/Creatures/Wyvern.material
@@ -24,6 +24,7 @@ fragment_program myWyvernFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/Wyvern.material
+++ b/materials/scripts/Creatures/Wyvern.material
@@ -21,10 +21,12 @@ fragment_program myWyvernFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/undead Army.material
+++ b/materials/scripts/Creatures/undead Army.material
@@ -21,10 +21,12 @@ fragment_program myundeadFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0 
-        param_named_auto lightSpecularColour light_specular_colour 0 
-        param_named_auto lightPos light_position  0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Creatures/undead Army.material
+++ b/materials/scripts/Creatures/undead Army.material
@@ -24,6 +24,7 @@ fragment_program myundeadFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0 
         param_named_auto lightSpecularColour light_specular_colour 0 
         param_named_auto lightPos light_position  0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Crypt.material
+++ b/materials/scripts/Crypt.material
@@ -24,6 +24,7 @@ fragment_program myCryptFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Crypt.material
+++ b/materials/scripts/Crypt.material
@@ -21,10 +21,12 @@ fragment_program myCryptFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/DCW0000.material
+++ b/materials/scripts/DCW0000.material
@@ -21,10 +21,12 @@ fragment_program myDCW0000TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position 
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0000.material
+++ b/materials/scripts/DCW0000.material
@@ -24,6 +24,7 @@ fragment_program myDCW0000TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position 
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0100.material
+++ b/materials/scripts/DCW0100.material
@@ -21,10 +21,12 @@ fragment_program myDCW0100TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0100.material
+++ b/materials/scripts/DCW0100.material
@@ -24,6 +24,7 @@ fragment_program myDCW0100TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0101.material
+++ b/materials/scripts/DCW0101.material
@@ -21,10 +21,12 @@ fragment_program myDCW0101TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position  
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0101.material
+++ b/materials/scripts/DCW0101.material
@@ -24,6 +24,7 @@ fragment_program myDCW0101TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position  
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0110.material
+++ b/materials/scripts/DCW0110.material
@@ -25,6 +25,7 @@ fragment_program myDCW0110TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW0110.material
+++ b/materials/scripts/DCW0110.material
@@ -22,10 +22,12 @@ fragment_program myDCW0110TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW1110.material
+++ b/materials/scripts/DCW1110.material
@@ -21,10 +21,12 @@ fragment_program myDCW1110TileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW1110.material
+++ b/materials/scripts/DCW1110.material
@@ -24,6 +24,7 @@ fragment_program myDCW1110TileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0

--- a/materials/scripts/DCW1111.material
+++ b/materials/scripts/DCW1111.material
@@ -22,10 +22,12 @@ source DCW.frag
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0           

--- a/materials/scripts/DCW1111.material
+++ b/materials/scripts/DCW1111.material
@@ -25,6 +25,7 @@ source DCW.frag
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named seatColor  float4 1.0 1.0 1.0 1.0           

--- a/materials/scripts/Dirt.material
+++ b/materials/scripts/Dirt.material
@@ -10,6 +10,7 @@ vertex_program myDirtTileVertexShader glsl
         param_named_auto worldMatrix world_matrix
         param_named_auto projectionMatrix projection_matrix          
         param_named_auto viewMatrix view_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
     }
   
 }
@@ -23,8 +24,10 @@ fragment_program myDirtTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
+        param_named shadowingEnabled bool false
     }
 }
 
@@ -45,7 +48,8 @@ material Dirt //: RTSS/NormalMapping_MultiPass
             fragment_program_ref myDirtTileFragmentShader
             { 
                 param_named decalmap int 0
-                param_named normalmap int 1     
+                param_named normalmap int 1
+                param_named shadowmap int 2
             }            
             
             
@@ -58,6 +62,13 @@ material Dirt //: RTSS/NormalMapping_MultiPass
             texture_unit normalmap
             {
                 texture DirtNormal.png               
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
         }
 

--- a/materials/scripts/Dirt.material
+++ b/materials/scripts/Dirt.material
@@ -21,10 +21,12 @@ fragment_program myDirtTileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named shadowingEnabled bool false

--- a/materials/scripts/DirtInstanced.material
+++ b/materials/scripts/DirtInstanced.material
@@ -24,6 +24,7 @@ fragment_program myDirtInstancedTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named shadowingEnabled bool false         

--- a/materials/scripts/DirtInstanced.material
+++ b/materials/scripts/DirtInstanced.material
@@ -21,10 +21,12 @@ fragment_program myDirtInstancedTileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named shadowingEnabled bool false         

--- a/materials/scripts/Dojo.material
+++ b/materials/scripts/Dojo.material
@@ -21,10 +21,12 @@ fragment_program myDojoFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named shadowingEnabled bool false  
     }

--- a/materials/scripts/Dojo.material
+++ b/materials/scripts/Dojo.material
@@ -24,6 +24,7 @@ fragment_program myDojoFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named shadowingEnabled bool false  
     }

--- a/materials/scripts/Dormitory.material
+++ b/materials/scripts/Dormitory.material
@@ -24,6 +24,7 @@ fragment_program myDormitoryFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory.material
+++ b/materials/scripts/Dormitory.material
@@ -21,10 +21,12 @@ fragment_program myDormitoryFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1011.material
+++ b/materials/scripts/Dormitory1011.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1011.material
+++ b/materials/scripts/Dormitory1011.material
@@ -21,10 +21,12 @@ fragment_program myDormitory1011FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1100.material
+++ b/materials/scripts/Dormitory1100.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1100.material
+++ b/materials/scripts/Dormitory1100.material
@@ -21,10 +21,12 @@ fragment_program myDormitory1100FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1111.material
+++ b/materials/scripts/Dormitory1111.material
@@ -24,6 +24,7 @@ fragment_program myDormitory1111FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Dormitory1111.material
+++ b/materials/scripts/Dormitory1111.material
@@ -21,10 +21,12 @@ fragment_program myDormitory1111FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position   
         param_named shadowingEnabled bool false              
     }

--- a/materials/scripts/Farm.material
+++ b/materials/scripts/Farm.material
@@ -24,6 +24,7 @@ fragment_program myFarmFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm.material
+++ b/materials/scripts/Farm.material
@@ -21,10 +21,12 @@ fragment_program myFarmFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm0000.material
+++ b/materials/scripts/Farm0000.material
@@ -21,10 +21,12 @@ fragment_program myFarm0000FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm0000.material
+++ b/materials/scripts/Farm0000.material
@@ -24,6 +24,7 @@ fragment_program myFarm0000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1000.material
+++ b/materials/scripts/Farm1000.material
@@ -21,10 +21,12 @@ fragment_program myFarm1000FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1000.material
+++ b/materials/scripts/Farm1000.material
@@ -24,6 +24,7 @@ fragment_program myFarm1000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1010.material
+++ b/materials/scripts/Farm1010.material
@@ -21,10 +21,12 @@ fragment_program myFarm1010FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1010.material
+++ b/materials/scripts/Farm1010.material
@@ -24,6 +24,7 @@ fragment_program myFarm1010FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1011.material
+++ b/materials/scripts/Farm1011.material
@@ -21,10 +21,12 @@ fragment_program myFarm1011FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1011.material
+++ b/materials/scripts/Farm1011.material
@@ -24,6 +24,7 @@ fragment_program myFarm1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1100.material
+++ b/materials/scripts/Farm1100.material
@@ -24,6 +24,7 @@ fragment_program myFarm1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Farm1100.material
+++ b/materials/scripts/Farm1100.material
@@ -21,10 +21,12 @@ fragment_program myFarm1100FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Forge.material
+++ b/materials/scripts/Forge.material
@@ -24,6 +24,7 @@ fragment_program myForgeFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Forge.material
+++ b/materials/scripts/Forge.material
@@ -21,10 +21,12 @@ fragment_program myForgeFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Gold.material
+++ b/materials/scripts/Gold.material
@@ -9,6 +9,7 @@ vertex_program myVertexShader glsl
         param_named_auto projectionMatrix projection_matrix
         param_named_auto viewMatrix view_matrix
         param_named_auto worldMatrix world_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
         param_named height float 0.0
     }
   
@@ -23,8 +24,10 @@ fragment_program myFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
+        param_named shadowingEnabled bool false
     }
 }
 
@@ -47,6 +50,7 @@ material Gold //: RTSS/NormalMapping_MultiPass
             { 
                 param_named decalmap int 0
                 param_named normalmap int 1
+                param_named shadowmap int 2
             }
  
             texture_unit 
@@ -58,6 +62,13 @@ material Gold //: RTSS/NormalMapping_MultiPass
             {
                 texture GoldNormal.png
 
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
             
             

--- a/materials/scripts/Gold.material
+++ b/materials/scripts/Gold.material
@@ -21,10 +21,12 @@ fragment_program myFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named_auto diffuseSurface surface_diffuse_colour
         param_named shadowingEnabled bool false

--- a/materials/scripts/GoldGround.material
+++ b/materials/scripts/GoldGround.material
@@ -11,6 +11,7 @@ vertex_program myGoldGroundVertexShader glsl
         param_named_auto projectionMatrix projection_matrix
         param_named_auto viewMatrix view_matrix
         param_named_auto worldMatrix world_matrix
+        param_named_auto lightMatrix texture_viewproj_matrix 0
     }
   
 }
@@ -24,7 +25,9 @@ fragment_program myGoldGroundFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
+        param_named shadowingEnabled bool false
         
     }
 }
@@ -47,6 +50,7 @@ material GoldGround //: RTSS/NormalMapping_MultiPass
             { 
                 param_named decalmap int 0
                 param_named normalmap int 1
+                param_named shadowmap int 2
             }            
             
             
@@ -59,6 +63,13 @@ material GoldGround //: RTSS/NormalMapping_MultiPass
             texture_unit normalmap
             {
                 texture DirtNormal.png               
+            }
+            texture_unit shadowmap
+            {
+                content_type shadow
+                tex_address_mode border
+                tex_border_colour 1 1 1 1
+                filtering bilinear
             }
         }
 

--- a/materials/scripts/GoldGround.material
+++ b/materials/scripts/GoldGround.material
@@ -22,10 +22,12 @@ fragment_program myGoldGroundFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named shadowingEnabled bool false
         

--- a/materials/scripts/Library.material
+++ b/materials/scripts/Library.material
@@ -21,10 +21,12 @@ fragment_program myLibraryFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library.material
+++ b/materials/scripts/Library.material
@@ -24,6 +24,7 @@ fragment_program myLibraryFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0000.material
+++ b/materials/scripts/Library0000.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0000FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0000.material
+++ b/materials/scripts/Library0000.material
@@ -21,10 +21,12 @@ fragment_program myLibrary0000FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0001.material
+++ b/materials/scripts/Library0001.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0001FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0001.material
+++ b/materials/scripts/Library0001.material
@@ -21,10 +21,12 @@ fragment_program myLibrary0001FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0101.material
+++ b/materials/scripts/Library0101.material
@@ -24,6 +24,7 @@ fragment_program myLibrary0101FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library0101.material
+++ b/materials/scripts/Library0101.material
@@ -21,10 +21,12 @@ fragment_program myLibrary0101FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1011.material
+++ b/materials/scripts/Library1011.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1011FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1011.material
+++ b/materials/scripts/Library1011.material
@@ -21,10 +21,12 @@ fragment_program myLibrary1011FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1100.material
+++ b/materials/scripts/Library1100.material
@@ -21,10 +21,12 @@ fragment_program myLibrary1100FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1100.material
+++ b/materials/scripts/Library1100.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1100FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1111.material
+++ b/materials/scripts/Library1111.material
@@ -21,10 +21,12 @@ fragment_program myLibrary1111FragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Library1111.material
+++ b/materials/scripts/Library1111.material
@@ -24,6 +24,7 @@ fragment_program myLibrary1111FragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Prison.material
+++ b/materials/scripts/Prison.material
@@ -24,6 +24,7 @@ fragment_program myPrisonFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Prison.material
+++ b/materials/scripts/Prison.material
@@ -21,10 +21,12 @@ fragment_program myPrisonFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Rock.material
+++ b/materials/scripts/Rock.material
@@ -22,10 +22,12 @@ fragment_program myRockFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Rock.material
+++ b/materials/scripts/Rock.material
@@ -25,6 +25,7 @@ fragment_program myRockFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false                 
     }

--- a/materials/scripts/Steel.material
+++ b/materials/scripts/Steel.material
@@ -21,10 +21,12 @@ fragment_program mySteelFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Steel.material
+++ b/materials/scripts/Steel.material
@@ -24,6 +24,7 @@ fragment_program mySteelFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/StoneBridge.material
+++ b/materials/scripts/StoneBridge.material
@@ -20,10 +20,12 @@ fragment_program myStoneBridgeTileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/StoneBridge.material
+++ b/materials/scripts/StoneBridge.material
@@ -23,6 +23,7 @@ fragment_program myStoneBridgeTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/WoodBridge.material
+++ b/materials/scripts/WoodBridge.material
@@ -24,6 +24,7 @@ fragment_program myWoodBridgeTileFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/WoodBridge.material
+++ b/materials/scripts/WoodBridge.material
@@ -21,10 +21,12 @@ fragment_program myWoodBridgeTileFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position        
         param_named_auto diffuseSurface surface_diffuse_colour 
         param_named seatColor  float4 1.0 1.0 1.0 1.0 

--- a/materials/scripts/Workshop.material
+++ b/materials/scripts/Workshop.material
@@ -21,10 +21,12 @@ fragment_program myWorkshopFragmentShader glsl
     default_params
     {
         param_named_auto ambientLightColour ambient_light_colour
-        param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
-        param_named_auto lightSpecularColour light_specular_colour 0.0 
-        param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
-        param_named_auto lightAttenuation light_attenuation 0
+        param_named_auto lightDiffuseColour light_diffuse_colour_array 8
+        param_named_auto lightSpecularColour light_specular_colour_array 8
+        param_named_auto lightPos light_position_array 8
+        param_named_auto lightAttenuation light_attenuation_array 8
+        param_named_auto lightCount light_count
+        param_named_auto firstLightCastsShadows light_casts_shadows 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/materials/scripts/Workshop.material
+++ b/materials/scripts/Workshop.material
@@ -24,6 +24,7 @@ fragment_program myWorkshopFragmentShader glsl
         param_named_auto lightDiffuseColour light_diffuse_colour 0.0 
         param_named_auto lightSpecularColour light_specular_colour 0.0 
         param_named_auto lightPos light_position  0.0 0.0 0.0 0.0
+        param_named_auto lightAttenuation light_attenuation 0
         param_named_auto cameraPosition camera_position
         param_named shadowingEnabled bool false         
     }

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/shaders/ClaimedTile.frag
+++ b/shaders/ClaimedTile.frag
@@ -1,7 +1,7 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 
 uniform sampler2D decalmap;
@@ -11,9 +11,6 @@ uniform sampler2D shadowmap;
 
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec4 diffuseSurface;
 uniform vec4 seatColor;
@@ -39,27 +36,10 @@ void main (void)
     if(shadowingEnabled)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-        
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.05)

--- a/shaders/ClaimedTile.frag
+++ b/shaders/ClaimedTile.frag
@@ -1,4 +1,7 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -33,14 +36,8 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
-    if(shadowingEnabled){
-        // compute shadowmap
-        if(tmpVertexPos.z > 0.00001 ){
-            tmpVertexPos /= tmpVertexPos.w;
-            shadow = texture(shadowmap, tmpVertexPos.xy); 
-        }
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     // compute lightDir
     vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
@@ -62,7 +59,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 ) *shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.05)

--- a/shaders/ClaimedTile.vert
+++ b/shaders/ClaimedTile.vert
@@ -53,7 +53,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
-    vec4 P_prim = inverse(worldMatrix) * P4;
+    vec4 P_prim = inverse(worldMatrix) * vec4(P, 1.0);
     VertexPos = lightMatrix * P_prim;    
  
     out_UV0 = uv_0;

--- a/shaders/Creature.frag
+++ b/shaders/Creature.frag
@@ -1,16 +1,13 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec3 ambient;
 uniform bool shadowingEnabled;
@@ -37,26 +34,10 @@ void main (void)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb * ambient;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb * ambient;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/Creature.frag
+++ b/shaders/Creature.frag
@@ -1,5 +1,7 @@
 #version 330  core
-#define epsilon 0.00001
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
@@ -29,15 +31,10 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > epsilon ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
     // compute lightDir
@@ -59,7 +56,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb * ambient )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb * ambient;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/DCW.frag
+++ b/shaders/DCW.frag
@@ -1,4 +1,7 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -33,15 +36,10 @@ void main (void)
     
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > 0 ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     // compute lightDir
     vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
     
@@ -61,7 +59,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 ) * shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.00005)

--- a/shaders/DCW.frag
+++ b/shaders/DCW.frag
@@ -1,7 +1,7 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 
 uniform sampler2D decalmap;
@@ -10,9 +10,6 @@ uniform sampler2D crossmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec4 diffuseSurface;
 uniform vec4 seatColor;
@@ -40,26 +37,10 @@ void main (void)
     // compute shadowmap
     if(shadowingEnabled)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb ;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb;
     
     vec4 crossMap = texture(crossmap, out_UV2.st);   
     if(crossMap.r < 0.00005)

--- a/shaders/DCW.vert
+++ b/shaders/DCW.vert
@@ -52,7 +52,7 @@ void main() {
     
     FragPos = P;
     
-    vec4 P_prim = inverse(worldMatrix) * P4;
+    vec4 P_prim = inverse(worldMatrix) * vec4(P, 1.0);
     VertexPos = lightMatrix * P_prim;
  
  

--- a/shaders/DirtTile.frag
+++ b/shaders/DirtTile.frag
@@ -1,7 +1,7 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 
 uniform sampler2D decalmap;
@@ -9,9 +9,6 @@ uniform sampler2D normalmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec4 diffuseSurface;
 uniform bool shadowingEnabled;
@@ -36,26 +33,10 @@ void main (void)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
         
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/DirtTile.frag
+++ b/shaders/DirtTile.frag
@@ -1,8 +1,12 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
+uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
 uniform vec4 lightDiffuseColour; 
@@ -14,6 +18,7 @@ uniform bool shadowingEnabled;
 in vec2 out_UV0;
 in vec2 out_UV1;
 in vec3 FragPos;
+in vec4 VertexPos;
 in mat3 TBN;
  
 out vec4 color;
@@ -27,6 +32,8 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
         
     // compute lightDir
@@ -48,7 +55,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/DirtTile.vert
+++ b/shaders/DirtTile.vert
@@ -20,6 +20,7 @@ out vec2 out_UV0;
 out vec2 out_UV1;
 
 out vec3 FragPos;
+out vec4 VertexPos;
 
  
 out mat3 TBN;
@@ -52,6 +53,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
+    VertexPos = lightMatrix * vec4(P, 1.0);
  
     out_UV0 = uv_0;
     out_UV1 = uv_1;

--- a/shaders/DirtTileInstanced.frag
+++ b/shaders/DirtTileInstanced.frag
@@ -1,6 +1,6 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 
 uniform sampler2D decalmap;
@@ -8,9 +8,6 @@ uniform sampler2D normalmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec4 diffuseSurface;
 uniform bool shadowingEnabled;
@@ -45,26 +42,10 @@ void main (void)
 		}
     }
         
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb/2.0;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/DirtTileInstanced.frag
+++ b/shaders/DirtTileInstanced.frag
@@ -1,4 +1,6 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
@@ -62,7 +64,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     if(diffuseSurface  != vec4(1.0,1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);
     else

--- a/shaders/GoldDistortion.frag
+++ b/shaders/GoldDistortion.frag
@@ -1,8 +1,12 @@
 #version 330  core
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
+uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
 uniform vec4 lightDiffuseColour; 
@@ -14,6 +18,7 @@ uniform bool shadowingEnabled;
 in vec2 out_UV0;
 in vec2 out_UV1;
 in vec3 FragPos;
+in vec4 VertexPos;
 in mat3 TBN;
  
 out vec4 color;
@@ -46,7 +51,10 @@ void main (void)
     
     
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 );
+    vec4 shadow = vec4(1.0);
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     
     if(diffuseSurface.rgb != vec3(1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);

--- a/shaders/GoldDistortion.frag
+++ b/shaders/GoldDistortion.frag
@@ -1,7 +1,7 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 
 uniform sampler2D decalmap;
@@ -9,9 +9,6 @@ uniform sampler2D normalmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform vec4 diffuseSurface;
 uniform bool shadowingEnabled;
@@ -32,21 +29,6 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
     vec3 result;
     
     
@@ -54,7 +36,7 @@ void main (void)
     vec4 shadow = vec4(1.0);
     if(shadowingEnabled)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb;
     
     if(diffuseSurface.rgb != vec3(1.0,1.0,1.0))
         result =  lightingTerm * mix(texelColor, diffuseSurface.rgb,0.5);

--- a/shaders/GoldDistortion.vert
+++ b/shaders/GoldDistortion.vert
@@ -7,6 +7,7 @@
 uniform    mat4 projectionMatrix;
 uniform    mat4 viewMatrix;
 uniform    mat4 worldMatrix;
+uniform    mat4 lightMatrix;
 uniform    float height;
 layout (location = 0) in vec4 position;
 layout (location = 2)  in vec3 normal;
@@ -17,6 +18,7 @@ layout (location = 8) in vec2 uv_1;
 out vec2 out_UV0;
 out vec2 out_UV1; 
 out vec3 FragPos;
+out vec4 VertexPos;
  
 out mat3 TBN;
  
@@ -49,6 +51,7 @@ void main() {
  
     gl_Position = projectionMatrix * viewMatrix * vec4(P, 1.0);
     FragPos = P;
+    VertexPos = lightMatrix * vec4(P, 1.0);
  
     out_UV0 = uv_0;
     out_UV1 = uv_1;

--- a/shaders/LightAttenuation.glsl
+++ b/shaders/LightAttenuation.glsl
@@ -1,0 +1,14 @@
+uniform vec4 lightAttenuation;
+
+float getLightAttenuation(vec4 lightPosition, vec3 surfacePosition)
+{
+    // Directional lights have no distance falloff.
+    if(lightPosition.w == 0.0)
+        return 1.0;
+
+    float distance = length(lightPosition.xyz - surfacePosition);
+    if(distance > lightAttenuation.x)
+        return 0.0;
+
+    return 1.0 / dot(lightAttenuation.yzw, vec3(1.0, distance, distance * distance));
+}

--- a/shaders/LightAttenuation.glsl
+++ b/shaders/LightAttenuation.glsl
@@ -1,14 +1,12 @@
-uniform vec4 lightAttenuation;
-
-float getLightAttenuation(vec4 lightPosition, vec3 surfacePosition)
+float getLightAttenuation(vec4 lightPosition, vec3 surfacePosition, vec4 attenuation)
 {
     // Directional lights have no distance falloff.
     if(lightPosition.w == 0.0)
         return 1.0;
 
     float distance = length(lightPosition.xyz - surfacePosition);
-    if(distance > lightAttenuation.x)
+    if(distance > attenuation.x)
         return 0.0;
 
-    return 1.0 / dot(lightAttenuation.yzw, vec3(1.0, distance, distance * distance));
+    return 1.0 / dot(attenuation.yzw, vec3(1.0, distance, distance * distance));
 }

--- a/shaders/LocalLighting.glsl
+++ b/shaders/LocalLighting.glsl
@@ -1,0 +1,26 @@
+#include "LightAttenuation.glsl"
+
+// Match Ogre's default maximum number of lights per material pass.
+uniform float lightCount;
+uniform vec4 lightDiffuseColour[8];
+uniform vec4 lightSpecularColour[8];
+uniform vec4 lightPos[8];
+uniform vec4 lightAttenuation[8];
+uniform float firstLightCastsShadows;
+
+vec3 getLocalLighting(vec3 position, vec3 normal, vec3 camera, float shadow)
+{
+    vec3 lighting = vec3(0.0);
+    vec3 viewDirection = normalize(camera - position);
+    for(int i = 0; i < min(int(lightCount), 8); ++i)
+    {
+        vec3 lightDirection = normalize(lightPos[i].xyz - position * lightPos[i].w);
+        float diffuse = max(dot(lightDirection, normal), 0.0);
+        float specular = pow(max(dot(reflect(-lightDirection, normal), viewDirection), 0.0), 16.0);
+        // The existing single shadow texture belongs to the first shadow light.
+        float visibility = i == 0 && firstLightCastsShadows > 0.5 ? shadow : 1.0;
+        lighting += (diffuse * lightDiffuseColour[i].rgb + specular * lightSpecularColour[i].rgb)
+            * getLightAttenuation(lightPos[i], position, lightAttenuation[i]) * visibility;
+    }
+    return lighting;
+}

--- a/shaders/Room.frag
+++ b/shaders/Room.frag
@@ -1,16 +1,13 @@
 #version 330  core
 #extension GL_ARB_shading_language_include : enable
 #include "ShadowMapping.glsl"
-#include "LightAttenuation.glsl"
+#include "LocalLighting.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
 uniform sampler2D shadowmap;
 
 uniform vec4 ambientLightColour;
-uniform vec4 lightDiffuseColour; 
-uniform vec4 lightSpecularColour;
-uniform vec4 lightPos;
 uniform vec4 cameraPosition;
 uniform bool shadowingEnabled;
 in vec2 out_UV0;
@@ -36,26 +33,10 @@ void main (void)
         shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
-    // compute lightDir
-    vec3 lightDir =  normalize(lightPos.xyz - FragPos*lightPos.w);
-    
-    
-    // compute Specular
-    vec3 viewDirection =  normalize( cameraPosition.xyz - FragPos);
-    vec3 reflectedLightDirection =  normalize(reflect(-1.0*lightDir.xyz,Normal));
-    float spec =  max(dot(reflectedLightDirection, viewDirection ), 0.0) ;
-    spec = pow(spec,16);    
-    vec3 specular = spec * lightSpecularColour.rgb; 
-    
-    
-    // compute Diffuse
-    float diff = max(dot(lightDir,Normal), 0.0);
-    vec3 diffuse = diff * lightDiffuseColour.rgb;
-    
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
+    vec3 lightingTerm = getLocalLighting(FragPos, Normal, cameraPosition.xyz, shadow.r) + ambientLightColour.rgb;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/Room.frag
+++ b/shaders/Room.frag
@@ -1,5 +1,7 @@
 #version 330  core
-#define epsilon 0.00001
+#extension GL_ARB_shading_language_include : enable
+#include "ShadowMapping.glsl"
+#include "LightAttenuation.glsl"
 
 uniform sampler2D decalmap;
 uniform sampler2D normalmap;
@@ -28,15 +30,10 @@ void main (void)
     Normal =  normalize(TBN * Normal); 
     
     vec4 shadow = vec4(1.0, 1.0, 1.0,1.0);
-    vec4 tmpVertexPos = VertexPos;
     
     // compute shadowmap
-    if(shadowingEnabled){
-		if(tmpVertexPos.z > epsilon ){
-		    tmpVertexPos /= tmpVertexPos.w;
-		    shadow = texture(shadowmap, tmpVertexPos.xy); 
-		}
-    }
+    if(shadowingEnabled)
+        shadow = vec4(sampleShadow(shadowmap, VertexPos));
     
     
     // compute lightDir
@@ -58,7 +55,7 @@ void main (void)
     vec3 result;
         
     // precompute the lighting term
-    vec3 lightingTerm =  (diffuse + specular + ambientLightColour.rgb/2.0 )*shadow.rgb;
+    vec3 lightingTerm = (diffuse + specular) * getLightAttenuation(lightPos, FragPos) * shadow.rgb + ambientLightColour.rgb/2.0;
     vec3 texelColor = texture(decalmap, out_UV0.st).rgb;
     result =  lightingTerm * texelColor;
 

--- a/shaders/Room.vert
+++ b/shaders/Room.vert
@@ -52,5 +52,5 @@ void main() {
  
     out_UV0 = uv0;
     out_UV1 = uv1;
-    VertexPos = lightMatrix * position;
+    VertexPos = lightMatrix * inverse(worldMatrix) * vec4(P, 1.0);
 }  

--- a/shaders/ShadowMapping.glsl
+++ b/shaders/ShadowMapping.glsl
@@ -1,0 +1,14 @@
+// Shadow texture coordinates have biased X/Y and OpenGL clip-space Z.
+float sampleShadow(sampler2D shadowMap, vec4 lightPosition)
+{
+    if(lightPosition.w <= 0.0)
+        return 1.0;
+
+    vec3 shadowPosition = lightPosition.xyz / lightPosition.w;
+    shadowPosition.z = shadowPosition.z * 0.5 + 0.5;
+    if(any(lessThan(shadowPosition, vec3(0.0))) || any(greaterThan(shadowPosition, vec3(1.0))))
+        return 1.0;
+
+    // Allow one depth-buffer step for the 16-bit shadow texture.
+    return step(shadowPosition.z - 1.0 / 65535.0, texture(shadowMap, shadowPosition.xy).r);
+}

--- a/shaders/ShadowMapping.glsl
+++ b/shaders/ShadowMapping.glsl
@@ -9,6 +9,6 @@ float sampleShadow(sampler2D shadowMap, vec4 lightPosition)
     if(any(lessThan(shadowPosition, vec3(0.0))) || any(greaterThan(shadowPosition, vec3(1.0))))
         return 1.0;
 
-    // Allow one depth-buffer step for the 16-bit shadow texture.
-    return step(shadowPosition.z - 1.0 / 65535.0, texture(shadowMap, shadowPosition.xy).r);
+    // Allow one depth-buffer step for the 24-bit shadow texture.
+    return step(shadowPosition.z - 1.0 / 16777215.0, texture(shadowMap, shadowPosition.xy).r);
 }

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,7 +235,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -65,6 +65,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <exception>
 
 void ODApplication::startGame(boost::program_options::variables_map& options)
 {
@@ -80,10 +81,20 @@ void ODApplication::startGame(boost::program_options::variables_map& options)
     logMgr.setLevel(resMgr.getLogLevel());
 
 
-    if(resMgr.isServerMode())
-        startServer();
-    else
-        startClient();
+    try
+    {
+        if(resMgr.isServerMode())
+            startServer();
+        else
+            startClient();
+    }
+    catch(const std::exception& error)
+    {
+        // Preserve the exception before the log manager is destroyed and main
+        // displays its Windows error dialog.
+        OD_LOG_ERR("Unhandled exception: " + std::string(error.what()));
+        throw;
+    }
 }
 
 void ODApplication::startServer()

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -353,6 +353,14 @@ void TileContainer::clearTiles(NodeType nt)
             {
                 mTiles[ii][jj]->removeItselfFromContainer();
                 mTiles[ii][jj]->destroyMesh(nt);
+            }
+        }
+        // Mesh cleanup can inspect neighbouring tiles to update shared lights.
+        // Keep the complete tile grid alive until every mesh has been removed.
+        for (int ii = 0; ii < mMapSizeX; ++ii)
+        {
+            for (int jj = 0; jj < mMapSizeY; ++jj)
+            {
                 delete mTiles[ii][jj];
             }
             delete[] mTiles[ii];

--- a/source/render/GroundShadowCameraSetup.h
+++ b/source/render/GroundShadowCameraSetup.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 OpenDungeons Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef GROUNDSHADOWCAMERASETUP_H
+#define GROUNDSHADOWCAMERASETUP_H
+
+#include <OgreCamera.h>
+#include <OgreMovablePlane.h>
+#include <OgreShadowCameraSetupPlaneOptimal.h>
+
+// Fit point-light shadows to the visible dungeon floor, independently of the
+// main camera's near clip and the height of the hand light.
+class GroundShadowCameraSetup : public Ogre::ShadowCameraSetup
+{
+public:
+    GroundShadowCameraSetup() : mGroundPlane(Ogre::Vector3::UNIT_Z, 0.0f)
+    {
+    }
+
+    void getShadowCamera(const Ogre::SceneManager* scene, const Ogre::Camera* camera,
+        const Ogre::Viewport* viewport, const Ogre::Light* light, Ogre::Camera* shadowCamera,
+        size_t iteration) const override
+    {
+        Ogre::PlaneOptimalShadowCameraSetup setup(&mGroundPlane);
+        setup.getShadowCamera(scene, camera, viewport, light, shadowCamera, iteration);
+
+        // Ogre may use a separate default frustum to select shadow casters.
+        // It must cover the same projection; getViewMatrix() alone returns
+        // that old culling view instead of the shadow camera's own view.
+        Ogre::Frustum* cullingFrustum = shadowCamera->getCullingFrustum();
+        if(cullingFrustum != nullptr)
+        {
+            cullingFrustum->setCustomViewMatrix(true, shadowCamera->getViewMatrix(true));
+            cullingFrustum->setCustomProjectionMatrix(true, shadowCamera->getProjectionMatrix());
+        }
+    }
+
+private:
+    Ogre::MovablePlane mGroundPlane;
+};
+
+#endif

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -968,10 +968,72 @@ void RenderManager::setupFogMaterial(Ogre::TexturePtr myTexture)
 
 
 
+void RenderManager::rrRefreshRoomLight(const Tile& tile, bool removing)
+{
+    // Share a light across a small patch, rather than allocating one per tile.
+    const int patchSize = 3;
+    const int originX = tile.getX() / patchSize * patchSize;
+    const int originY = tile.getY() / patchSize * patchSize;
+    const std::string name = "RoomLight_" + Helper::toString(originX) + "_" + Helper::toString(originY);
+    Ogre::Vector3 position = Ogre::Vector3::ZERO;
+    int count = 0;
+    for(int x = originX; x < originX + patchSize; ++x)
+    {
+        for(int y = originY; y < originY + patchSize; ++y)
+        {
+            Tile* candidate = tile.getGameMap()->getTile(x, y);
+            if(candidate == nullptr || (removing && candidate == &tile) ||
+               candidate->getEntityNode() == nullptr || !candidate->getLocalPlayerHasVision())
+                continue;
+            TileVisual visual = candidate->getTileVisual();
+            if(visual < TileVisual::dungeonTempleRoom || visual >= TileVisual::countTileVisual)
+                continue;
+            position += Ogre::Vector3(static_cast<Ogre::Real>(x), static_cast<Ogre::Real>(y), 0.0f);
+            ++count;
+        }
+    }
+
+    if(count == 0)
+    {
+        if(mSceneManager->hasLight(name))
+        {
+            Ogre::Light* light = mSceneManager->getLight(name);
+            Ogre::SceneNode* node = light->getParentSceneNode();
+            node->detachObject(light);
+            mSceneManager->destroyLight(light);
+            mSceneManager->destroySceneNode(node);
+        }
+        return;
+    }
+
+    Ogre::Light* light;
+    if(mSceneManager->hasLight(name))
+        light = mSceneManager->getLight(name);
+    else
+    {
+        light = mSceneManager->createLight(name);
+        light->setType(Ogre::Light::LT_POINT);
+        light->setCastShadows(false);
+        // A local room fill complements the existing cursor and authored lights.
+        light->setAttenuation(6.0f, 1.0f, 0.09f, 0.032f);
+        light->setSpecularColour(Ogre::ColourValue::Black);
+        Ogre::SceneNode* node = mLightSceneNode->createChildSceneNode(name + "_node");
+        node->attachObject(light);
+    }
+    position /= static_cast<Ogre::Real>(count);
+    position.z = 3.0f;
+    light->getParentSceneNode()->setPosition(position);
+    const Ogre::Real density = static_cast<Ogre::Real>(count) / (patchSize * patchSize);
+    light->setDiffuseColour(Ogre::ColourValue(0.9f, 0.8f, 0.6f) * (0.55f * density));
+}
+
 void RenderManager::rrRefreshTile(Tile& tile, GameMap& draggableTileContainer, const Player& localPlayer, NodeType nt)
 {
     if (tile.getEntityNode() == nullptr)
         return;
+
+    if(nt == NodeType::MTILES_NODE)
+        rrRefreshRoomLight(tile);
 
     std::string tileName = tile.getOgreNamePrefix() + tile.getName();
     std::string meshName;
@@ -1236,6 +1298,9 @@ void RenderManager::rrDestroyTile(Tile& tile, NodeType nt)
 {
     if (tile.getEntityNode() == nullptr)
         return;
+
+    if(nt == NodeType::MTILES_NODE)
+        rrRefreshRoomLight(tile, true);
 
     std::string tileName = tile.getOgreNamePrefix() + tile.getName();
     std::string selectorName = tileName + "_selection_indicator";

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "render/RenderManager.h"
+#include "render/GroundShadowCameraSetup.h"
 
 #include "entities/Creature.h"
 #include "entities/CreatureDefinition.h"
@@ -71,6 +72,8 @@
 #include <Overlay/OgreOverlayManager.h>
 #include <Overlay/OgreOverlaySystem.h>
 #include <RTShaderSystem/OgreShaderGenerator.h>
+#include <RTShaderSystem/OgreShaderRenderState.h>
+#include <RTShaderSystem/OgreShaderExIntegratedPSSM3.h>
 
 #include <sstream>
 #include <string>
@@ -120,44 +123,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     // mShaderGenerator->setShaderCacheEnabled(true);
     
     mShaderGenerator->addSceneManager(mSceneManager); 
-    if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
-    {
-        // Custom shaders apply lighting and shadows in one pass; automatic
-        // illumination splitting removes their fragment programs on GL3Plus.
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
-        // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
-        // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
-        // mSceneManager->setShadowFarDistance(100.0);
-        // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
-        // mSceneManager->setShadowTextureSelfShadow(true);
-        // donno if the below should be here -- paul424 :
-        auto myIter = Ogre::MaterialManager::getSingleton().getResourceIterator();
-        while(myIter.hasMoreElements())
-        {
-            auto myPointer = myIter.peekNextValue();
-            Ogre::SharedPtr<Ogre::Material> myCastPointer = std::dynamic_pointer_cast<Ogre::Material> (myPointer);
-            Ogre::Technique* technique;
-            technique = myCastPointer->getTechnique(0);
-
-            if( technique->getPass(technique->getNumPasses() - 1)->hasFragmentProgram())
-            {
-                if(technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->hasNamedParameters())
-                {
-                    const Ogre::GpuNamedConstants& gnc = technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->getConstantDefinitions();
-                    auto it = gnc.map.find("shadowingEnabled");
-                    if(it!=  gnc.map.end())
-                        technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->setNamedConstant("shadowingEnabled",true);
-                }
-            }
-            myIter.getNext();
-        }  
-        
-    }
-    else
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_NONE);
-
-    }
+    setDynamicShadowsEnabled(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS) == "Yes");
     ddd.setStatic(true);
     mSceneManager->addListener(&ddd);
     mSceneManager->addRenderQueueListener(overlaySystem);
@@ -212,6 +178,77 @@ void RenderManager::saveTexture(Ogre::TexturePtr texture, const std::string& fil
     pixelBuffer->unlock();
 }
 
+
+void RenderManager::setDynamicShadowsEnabled(bool enabled)
+{
+    // Custom shaders apply lighting and shadows in one pass; automatic
+    // illumination splitting removes their fragment programs on GL3Plus.
+    mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
+    if(enabled)
+    {
+        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH16);
+        mSceneManager->setShadowCameraSetup(Ogre::ShadowCameraSetupPtr(new GroundShadowCameraSetup()));
+    }
+
+    // Fixed-function materials also need a receiver when Ogre generates their
+    // shaders: integrated shadows do not add a separate receiver pass.
+    Ogre::RTShader::RenderState* renderState =
+        mShaderGenerator->getRenderState(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+#if OGRE_VERSION_MAJOR >= 13
+    const Ogre::RTShader::SubRenderStateList& subStates = renderState->getSubRenderStates();
+#else
+    const Ogre::RTShader::SubRenderStateList& subStates = renderState->getTemplateSubRenderStateList();
+#endif
+    Ogre::RTShader::SubRenderState* shadowState = nullptr;
+    for(Ogre::RTShader::SubRenderState* subState : subStates)
+    {
+        if(subState->getType() == Ogre::RTShader::SRS_INTEGRATED_PSSM3)
+            shadowState = subState;
+    }
+    if(enabled && shadowState == nullptr)
+        renderState->addTemplateSubRenderState(mShaderGenerator->createSubRenderState(Ogre::RTShader::SRS_INTEGRATED_PSSM3));
+    else if(!enabled && shadowState != nullptr)
+    {
+#if OGRE_VERSION_MAJOR >= 13
+        renderState->removeSubRenderState(shadowState);
+#else
+        renderState->removeTemplateSubRenderState(shadowState);
+#endif
+    }
+    mShaderGenerator->invalidateScheme(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+
+    // Include material clones and techniques created since the game started.
+    Ogre::ResourceManager::ResourceMapIterator materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while(materials.hasMoreElements())
+    {
+        Ogre::MaterialPtr material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+        for(unsigned short techniqueIndex = 0; techniqueIndex < material->getNumTechniques(); ++techniqueIndex)
+        {
+            Ogre::Technique* technique = material->getTechnique(techniqueIndex);
+            for(unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex)
+            {
+                Ogre::Pass* pass = technique->getPass(passIndex);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters())
+                {
+                    const Ogre::GpuNamedConstants& constants = parameters->getConstantDefinitions();
+                    if(constants.map.find("shadowingEnabled") != constants.map.end())
+                    {
+                        bool hasShadowTexture = false;
+                        for(unsigned short unit = 0; unit < pass->getNumTextureUnitStates(); ++unit)
+                        {
+                            if(pass->getTextureUnitState(unit)->getContentType() == Ogre::TextureUnitState::CONTENT_SHADOW)
+                                hasShadowTexture = true;
+                        }
+                        parameters->setNamedConstant("shadowingEnabled", enabled && hasShadowTexture);
+                    }
+                }
+            }
+        }
+    }
+}
 
 RenderManager::~RenderManager()
 {

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -122,7 +122,9 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mShaderGenerator->addSceneManager(mSceneManager); 
     if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
     {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE);
+        // Custom shaders apply lighting and shadows in one pass; automatic
+        // illumination splitting removes their fragment programs on GL3Plus.
+        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED);
         // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
         // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
         // mSceneManager->setShadowFarDistance(100.0);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -186,7 +186,7 @@ void RenderManager::setDynamicShadowsEnabled(bool enabled)
     mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
     if(enabled)
     {
-        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH16);
+        mSceneManager->setShadowTexturePixelFormat(Ogre::PF_DEPTH24_STENCIL8);
         mSceneManager->setShadowCameraSetup(Ogre::ShadowCameraSetupPtr(new GroundShadowCameraSetup()));
     }
 

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -98,6 +98,7 @@ public:
 
     //! \brief Sets/Updates the overall world lighting value with given factor.
     void setWorldAmbientLightingFactor(float lightFactor);
+    void setDynamicShadowsEnabled(bool enabled);
 
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -242,6 +242,9 @@ private:
     //! is added to the current colorization.
     void colourizeEntity(Ogre::Entity* ent, const Seat* seat, bool markedForDigging, bool playerHasVision);
 
+    //! \brief Maintain local illumination for the visible room tiles around a tile.
+    void rrRefreshRoomLight(const Tile& tile, bool removing = false);
+
     //! \brief Makes the material be transparent with the given opacity (0.0f - 1.0f)
     //! \returns The new material name according to the current opacity.
     std::string setMaterialOpacity(const std::string& materialName, float opacity);

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);


### PR DESCRIPTION
Visible rooms could appear flat or underlit because they relied on global or
cursor lighting.

## Change

Add warm, non-shadow-casting local lights per visible room patch and update
them with room visibility and lifecycle changes. Keep neighbouring tiles alive
until every tile mesh has been destroyed, so shared-light cleanup cannot access
already deleted tiles when disposing of a map during loading.

## Coordination

Depends on #62, which provides the shared material path for ambient and
overlapping world lights. The teardown correction completes this room-lighting
outcome; it is included here rather than submitted as another PR. No matching
open issue was identified for this contribution.

## Verification

The exact updated contribution passes a clean Windows x64 Release build of all
244 translation units and runtime preparation. The production teardown with
instrumented neighbour callbacks fails before the lifetime correction and passes
144 checks afterward, covering different map sizes, both tile modes and repeated
clearing. The user accepted the room appearance and later confirmed loading
during an active game in the complete fork; other platforms remain unverified.

[Review only the room-lighting changes](https://github.com/Rokk001/OpenDungeonsPlus/compare/50a55ab5e6134d4cb6c7daa6c323969773181d43...ddb16b2e6c993335760b75135e9aa9a9d85d4cf6)
