### PR TITLE
Add full-map and minimap navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,9 @@ ENDIF ()
 # Adds the Windows icon resource file when building on windows.
 IF (WIN32)
     SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/icon.rc)
+    IF (MSVC)
+        SET(OD_SOURCEFILES ${OD_SOURCEFILES} ${CMAKE_SOURCE_DIR}/dist/opendungeons.manifest)
+    ENDIF ()
 ENDIF ()
 
 ##################################
@@ -968,4 +971,3 @@ elseif(WIN32)
     install(FILES ${EXT_LIBS}
             DESTINATION ${OD_BIN_PATH})
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +660,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ of development.
 Future versions will have an in-game tutorial, but for now, you can use the
 following resources to learn the basic gameplay concepts:
 
-- In-game help screen, toggled with the F1 key
+- In-game help screen, available through Options
 - Video tutorial (version 0.5.0): https://www.youtube.com/watch?v=P4MClQUdb0E
 - Wiki page: https://github.com/OpenDungeons/OpenDungeons/wiki/Gameplay
 

--- a/dist/icon.rc
+++ b/dist/icon.rc
@@ -1,1 +1,5 @@
 1 ICON "OD-Logo.ico"
+
+#ifdef __GNUC__
+1 24 "opendungeons.manifest"
+#endif

--- a/dist/opendungeons.manifest
+++ b/dist/opendungeons.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/gui/MenuMain.layout
+++ b/gui/MenuMain.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="DefaultWindow" name="Root" >
-        <Property name="Area" value="{{0,40},{0,10},{1,-40},{1,-10}}" />
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Window type="OD/StaticImage" name="WelcomeBanner" >
             <Property name="Area" value="{{0.5,-320},{0,52},{0.5,320},{0,191}}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -137,6 +137,13 @@
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
+        <Window type="OD/Button" name="MiniMapZoomButton">
+            <UserString name="AllowEdgeScrolling" value="true" />
+            <Property name="Area" value="{{1,-61},{1,-52},{1,-17},{1,-8}}" />
+            <Property name="Text" value="+/-" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Property name="TooltipText" value="Minimap: left-click to zoom in, right-click to zoom out; M opens the map" />
+        </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
             <Property name="Area" value="{{0,0},{1,-133},{1,-200},{1,0}}" />
             <Property name="TabHeight" value="{0,35}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -120,7 +120,7 @@
             <Property name="Area" value="{{1,-232},{1,-171},{1,-202},{1,-141}}" />
             <Property name="ButtonImage" value="OpenDungeonsIcons/ObjectivesIcon" />
             <Property name="AlwaysOnTop" value="True" />
-            <Property name="TooltipText" value="Objectives (F3)" />
+            <Property name="TooltipText" value="Objectives" />
             <Property name="ClippedByParent" value="False" />
             <Property name="Visible" value="True" />
         </Window>
@@ -151,6 +151,7 @@
         <LayoutImport type="DefaultWindow" filename="WindowObjectives.layout" name="ObjectivesWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowSkillTree.layout" name="SkillTreeWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowGameOptions.layout" name="GameOptionsMenuImport" />
+        <LayoutImport type="DefaultWindow" filename="WindowUserCameras.layout" name="UserCamerasImport" />
         <LayoutImport type="DefaultWindow" filename="WindowEvent.layout" name="EventWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowChat.layout" name="ChatWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowHelp.layout" name="HelpWindowImport" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -152,6 +152,7 @@
         <LayoutImport type="DefaultWindow" filename="WindowSkillTree.layout" name="SkillTreeWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowGameOptions.layout" name="GameOptionsMenuImport" />
         <LayoutImport type="DefaultWindow" filename="WindowUserCameras.layout" name="UserCamerasImport" />
+        <LayoutImport type="DefaultWindow" filename="WindowMap.layout" name="MapImport" />
         <LayoutImport type="DefaultWindow" filename="WindowEvent.layout" name="EventWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowChat.layout" name="ChatWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowHelp.layout" name="HelpWindowImport" />

--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -2,51 +2,65 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="GameOptionsWindow" >
-        <Property name="Area" value="{{0.5,-110},{0.5,-190},{0.5,110},{0.5,190}}" />
+        <Property name="Area" value="{{0.5,-160},{0.5,-268},{0.5,160},{0.5,268}}" />
         <Property name="Text" value="Options" />
         <Property name="SizingEnabled" value="False" />
         <Window type="OD/IconButton" name="ObjectivesButton" >
-            <Property name="Area" value="{{0.5,-80},{0,40},{0.5,80},{0,73}}" />
+            <Property name="Area" value="{{0,24},{0,36},{1,-24},{0,74}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/ObjectivesIcon" />
-            <Property name="Text" value="Objectives (F3)" />
+            <Property name="Text" value="Objectives" />
             <Property name="TooltipText" value="View the current game objectives." />
         </Window>
         <Window type="OD/IconButton" name="SkillButton" >
-            <Property name="Area" value="{{0.5,-80},{0,83},{0.5,80},{0,116}}" />
+            <Property name="Area" value="{{0,24},{0,82},{1,-24},{0,120}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/SkillIcon" />
-            <Property name="Text" value="Skill (F4)" />
+            <Property name="Text" value="Skill" />
         </Window>
         <Window type="OD/IconButton" name="SaveGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,136},{0.5,80},{0,169}}" />
+            <Property name="Area" value="{{0,24},{0,128},{1,-24},{0,166}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/SaveIcon" />
-            <Property name="Text" value="Save Game (F5)" />
+            <Property name="Text" value="Save Game" />
         </Window>
         <Window type="OD/IconButton" name="LoadGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,180},{0.5,80},{0,213}}" />
+            <Property name="Area" value="{{0,24},{0,174},{1,-24},{0,212}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/LoadIcon" />
             <Property name="Text" value="Load Game (F8)" />
             <Property name="Disabled" value="True" />
             <Property name="TooltipText" value="Not implemented yet" />
         </Window>
         <Window type="OD/IconButton" name="SettingsButton" >
-            <Property name="Area" value="{{0.5,-80},{0,235},{0.5,80},{0,268}}" />
+            <Property name="Area" value="{{0,24},{0,220},{1,-24},{0,258}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/OptionsIcon" />
             <Property name="Text" value="Settings" />
             <Property name="Disabled" value="False" />
             <Property name="TooltipText" value="Open the game settings window." />
         </Window>
         <Window type="OD/IconButton" name="QuitGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,278},{0.5,80},{0,311}}" />
+            <Property name="Area" value="{{0,24},{0,266},{1,-24},{0,304}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="Text" value="Quit to Menu" />
             <Property name="TooltipText" value="Leave this game and return to the main menu..." />
         </Window>
         <Window type="OD/IconButton" name="ExitGameButton" >
-            <Property name="Area" value="{{0.5,-80},{0,321},{0.5,80},{0,354}}" />
+            <Property name="Area" value="{{0,24},{0,312},{1,-24},{0,350}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/AbortIcon" />
             <Property name="IconImageColour" value="FFBB0000" />
             <Property name="Text" value="Exit to System" />
             <Property name="TooltipText" value="Leave this game and exit to the desktop..." />
+        </Window>
+            <Window type="OD/IconButton" name="HelpButton" >
+            <Property name="Area" value="{{0,24},{0,358},{1,-24},{0,396}}" />
+            <Property name="IconImage" value="OpenDungeonsIcons/HelpIcon" />
+            <Property name="Text" value="Help" />
+        </Window>
+            <Window type="OD/IconButton" name="PlayerSettingsButton" >
+            <Property name="Area" value="{{0,24},{0,404},{1,-24},{0,442}}" />
+            <Property name="IconImage" value="OpenDungeonsIcons/SeatIcon" />
+            <Property name="Text" value="Player information" />
+        </Window>
+        <Window type="OD/Button" name="UserCamerasButton">
+            <Property name="Area" value="{{0,24},{0,450},{1,-24},{0,488}}" />
+            <Property name="Text" value="Define user cameras" />
         </Window>
     </Window>
 </GUILayout>

--- a/gui/WindowMap.layout
+++ b/gui/WindowMap.layout
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GUILayout version="4">
+    <Window type="OD/FrameWindow" name="MapWindow">
+        <Property name="Area" value="{{0.02,0},{0.02,0},{0.98,0},{0.98,0}}" />
+        <Property name="Text" value="Map (M)" />
+        <Property name="Visible" value="False" />
+        <Property name="SizingEnabled" value="False" />
+        <Property name="DragMovingEnabled" value="False" />
+        <Window type="OD/StaticImage" name="MapImage">
+            <Property name="Area" value="{{0,0},{0,0},{1,-24},{1,-24}}" />
+            <Property name="AspectMode" value="Shrink" />
+            <Property name="HorizontalAlignment" value="Centre" />
+            <Property name="VerticalAlignment" value="Centre" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
+            <Property name="TooltipText" value="Left-click: go here; right-click or M: close" />
+            <Window type="OD/StaticImage" name="Detail">
+                <Property name="Area" value="{{0,0},{0,0},{0.28,0},{0.28,0}}" />
+                <Property name="AspectMode" value="Shrink" />
+                <Property name="AspectRatio" value="1" />
+                <Property name="MousePassThroughEnabled" value="True" />
+                <Property name="AlwaysOnTop" value="True" />
+                <Property name="FrameEnabled" value="False" />
+                <Property name="BackgroundEnabled" value="False" />
+            </Window>
+        </Window>
+    </Window>
+</GUILayout>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -61,8 +61,7 @@
                     </Window>
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
                         <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
-                        <Property name="Text" value="VSync*" />
-                        <Property name="TooltipText" value="* Needs a restart to be potentially applied." />
+                        <Property name="Text" value="VSync" />
                     </Window>
                 </Window>
             </Window>
@@ -102,12 +101,12 @@
                     <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
                         <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
                         <Property name="Text" value="Keyboard grab" />
-                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
                         <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
                         <Property name="Text" value="Mouse grab" />
-                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications (requires restart)." />
+                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="AutoscrollCheckbox" >
                         <Property name="Area" value="{{0,32},{0,120},{0,150},{0,140}}" />

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,50},{0,750},{0,550}}" />
+        <Property name="Area" value="{{0.5,-272.5},{0.5,-250},{0.5,272.5},{0.5,250}}" />
         <Property name="Text" value="Settings" />
         <Property name="SizingEnabled" value="False" />
         <Property name="AlwaysOnTop" value="True" />
@@ -62,6 +62,18 @@
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
                         <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
                         <Property name="Text" value="VSync" />
+                    </Window>
+                    <Window type="OD/StaticText" name="UIScaleText" >
+                        <Property name="Area" value="{{0,22},{0,150},{0,184},{0,170}}" />
+                        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                        <Property name="Text" value="UI Scale:" />
+                        <Property name="BackgroundEnabled" value="False" />
+                        <Property name="FrameEnabled" value="False" />
+                    </Window>
+                    <Window type="OD/Combobox" name="UIScaleCombobox" >
+                        <Property name="Area" value="{{0,202},{0,145},{0,346},{0,265}}" />
+                        <Property name="ReadOnly" value="True" />
+                        <Property name="TooltipText" value="Scales the interface immediately. Apply saves the setting." />
                     </Window>
                 </Window>
             </Window>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -17,7 +17,7 @@
             <Property name="IconImage" value="OpenDungeonsIcons/CheckIcon" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,10},{0,20},{1,-10},{1,-70}}" />
+            <Property name="Area" value="{{0,10},{0,32},{1,-10},{1,-70}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Window type="DefaultWindow" name="Video" >
@@ -28,26 +28,26 @@
                 <Window type="OD/ScrollablePane" name="VideoSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="ResolutionText" >
-                        <Property name="Area" value="{{0,22},{0,31},{0,184},{0,43}}" />
+                        <Property name="Area" value="{{0,22},{0,20},{0,184},{0,46}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Resolution:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="ResolutionCombobox" >
-                        <Property name="Area" value="{{0,22},{0,42},{0,166},{0,162}}" />
+                        <Property name="Area" value="{{0,22},{0,48},{0,166},{0,168}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/Checkbox" name="FullscreenCheckbox" >
-                        <Property name="Area" value="{{0,202},{0,42},{0,302},{0,68}}" />
+                        <Property name="Area" value="{{0,202},{0,48},{0,302},{0,74}}" />
                         <Property name="Text" value="Fullscreen" />
                     </Window>
                     <Window type="OD/Checkbox" name="DynamicShadowsCheckbox" >
-                        <Property name="Area" value="{{0,342},{0,42},{0,542},{0,68}}" />
+                        <Property name="Area" value="{{0,322},{0,48},{0,502},{0,74}}" />
                         <Property name="Text" value="Dynamic Shadows" />
                     </Window>                   
                     <Window type="OD/StaticText" name="RendererText" >
-                        <Property name="Area" value="{{0,22},{0,78},{0,184},{0,90}}" />
+                        <Property name="Area" value="{{0,22},{0,88},{0,184},{0,114}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Renderer*:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -55,23 +55,23 @@
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Combobox" name="RendererCombobox" >
-                        <Property name="Area" value="{{0,22},{0,90},{0,266},{0,210}}" />
+                        <Property name="Area" value="{{0,22},{0,116},{0,266},{0,236}}" />
                         <Property name="ReadOnly" value="True" />
                         <Property name="TooltipText" value="* Needs a restart to be applied." />
                     </Window>
                     <Window type="OD/Checkbox" name="VSyncCheckbox" >
-                        <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
+                        <Property name="Area" value="{{0,22},{0,156},{0,166},{0,182}}" />
                         <Property name="Text" value="VSync" />
                     </Window>
                     <Window type="OD/StaticText" name="UIScaleText" >
-                        <Property name="Area" value="{{0,22},{0,150},{0,184},{0,170}}" />
+                        <Property name="Area" value="{{0,22},{0,194},{0,184},{0,220}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="UI Scale:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="UIScaleCombobox" >
-                        <Property name="Area" value="{{0,202},{0,145},{0,346},{0,265}}" />
+                        <Property name="Area" value="{{0,202},{0,190},{0,346},{0,310}}" />
                         <Property name="ReadOnly" value="True" />
                         <Property name="TooltipText" value="Scales the interface immediately. Apply saves the setting." />
                     </Window>
@@ -86,7 +86,7 @@
                 <Window type="OD/ScrollablePane" name="AudioSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="MusicText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,220},{0,66}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Music:" />
                         <Property name="BackgroundEnabled" value="False" />
@@ -111,29 +111,29 @@
                 <Window type="OD/ScrollablePane" name="InputSP" >
                     <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                     <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,66}}" />
                         <Property name="Text" value="Keyboard grab" />
                         <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
+                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,106}}" />
                         <Property name="Text" value="Mouse grab" />
                         <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications." />
                     </Window>
                     <Window type="OD/Checkbox" name="AutoscrollCheckbox" >
-                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,140}}" />
+                        <Property name="Area" value="{{0,32},{0,120},{0,150},{0,146}}" />
                         <Property name="Text" value="Autoscroll" />
                         <Property name="TooltipText" value="When checked, if the mouse cousor is on the screen border it will make camera fly " />
                     </Window>
                     <Window type="OD/StaticText" name="PanSpeedText" >
-                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,180}}" />
+                        <Property name="Area" value="{{0,32},{0,160},{0,260},{0,186}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Camera pan speed: 100%" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="PanSpeedSlider" >
-                        <Property name="Area" value="{{0,32},{0,180},{0,327},{0,193}}" />
+                        <Property name="Area" value="{{0,32},{0,190},{0,327},{0,203}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />
@@ -152,47 +152,47 @@
                 <Window type="OD/ScrollablePane" name="GameSP" >
                     <Property name="Area" value="{{0,0},{0,15},{1,0},{1,-5}}" />
                     <Window type="OD/StaticText" name="NicknameText" >
-                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Area" value="{{0,32},{0,46},{0,150},{0,72}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Nickname:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Editbox" name="NicknameEdit" >
-                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,60}}" />
+                        <Property name="Area" value="{{0,160},{0,40},{0,320},{0,80}}" />
                         <Property name="Text" value="" />
                     </Window>
                     <Window type="OD/StaticText" name="KeeperVoiceText" >
-                        <Property name="Area" value="{{0,32},{0,70},{0,150},{0,90}}" />
+                        <Property name="Area" value="{{0,32},{0,90},{0,150},{0,116}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Keeper Voice:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="KeeperVoice" >
-                        <Property name="Area" value="{{0,160},{0,70},{0,320},{0,150}}" />
+                        <Property name="Area" value="{{0,160},{0,90},{0,320},{0,190}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="MinimapText" >
-                        <Property name="Area" value="{{0,32},{0,100},{0,150},{0,120}}" />
+                        <Property name="Area" value="{{0,32},{0,130},{0,150},{0,156}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Minimap Type:" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/Combobox" name="MiniMapType" >
-                        <Property name="Area" value="{{0,160},{0,100},{0,320},{0,180}}" />
+                        <Property name="Area" value="{{0,160},{0,130},{0,320},{0,230}}" />
                         <Property name="ReadOnly" value="True" />
                     </Window>
                     <Window type="OD/StaticText" name="LightText" >
-                        <Property name="Area" value="{{0,32},{0,130},{0,220},{0,150}}" />
+                        <Property name="Area" value="{{0,32},{0,170},{0,220},{0,196}}" />
                         <Property name="MaxSize" value="{{1,0},{1,0}}" />
                         <Property name="Text" value="Ambient Light: +" />
                         <Property name="BackgroundEnabled" value="False" />
                         <Property name="FrameEnabled" value="False" />
                     </Window>
                     <Window type="OD/HorizontalSlider" name="LightSlider" >
-                        <Property name="Area" value="{{0,32},{0,150},{0,327},{0,163}}" />
+                        <Property name="Area" value="{{0,32},{0,200},{0,327},{0,213}}" />
                         <Property name="Text" value="" />
                         <Property name="VerticalSlider" value="False" />
                         <Property name="AutoRenderingSurface" value="True" />

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -106,14 +106,14 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="TempleButton" >
-            <Property name="Area" value="{{0,570},{0,20},{0,630},{0,80}}" />
+            <Property name="Area" value="{{0,300},{0,50},{0,340},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TempleButton" />
             <Property name="TooltipText" value="Build a Temple (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="PortalButton" >
-            <Property name="Area" value="{{0,630},{0,20},{0,690},{0,80}}" />
+            <Property name="Area" value="{{0,340},{0,50},{0,380},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PortalButton" />
             <Property name="TooltipText" value="Build a Portal (3x3)" />

--- a/gui/WindowTabRooms.layout
+++ b/gui/WindowTabRooms.layout
@@ -120,7 +120,7 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/GameTabButton" name="WavePortalButton" >
-            <Property name="Area" value="{{0,690},{0,20},{0,750},{0,80}}" />
+            <Property name="Area" value="{{0,380},{0,50},{0,420},{0,90}}" />
             <Property name="Visible" value="False" />
             <Property name="NormalImage" value="OpenDungeonsIcons/WavePortalButton" />
             <Property name="TooltipText" value="Build a Wave portal (3x3), the room that sends waves of enemies" />

--- a/gui/WindowTabSpells.layout
+++ b/gui/WindowTabSpells.layout
@@ -8,14 +8,18 @@
         <Property name="MaxSize" value="{{1,0},{1,0}}" />
         <Property name="Visible" value="False" />
         <Property name="RiseOnClickEnabled" value="False" />
+        <!-- Two rows of 40x40, the same shape the rooms tab uses: one row of 60s
+             ran to x=700 and the last buttons fell off the right edge of the tab,
+             which is only window width - 200 wide, at anything close to the
+             minimum window size. -->
         <Window type="OD/GameTabButton" name="SummonWorkerButton" >
-            <Property name="Area" value="{{0,100},{0,25},{0,160},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,10},{0,140},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SummonWorkerButton" />
             <Property name="TooltipText" value="Summon a worker" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SummonWorkerButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -27,13 +31,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CallToWarButton" >
-            <Property name="Area" value="{{0,160},{0,25},{0,220},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,10},{0,180},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CallToWarButton" />
             <Property name="TooltipText" value="Casts a spell that calls available creatures" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CallToWarButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -45,13 +49,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHealButton" >
-            <Property name="Area" value="{{0,220},{0,25},{0,280},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,10},{0,220},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHealButton" />
             <Property name="TooltipText" value="Casts a spell that heals owned creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHealButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -63,13 +67,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureExplosionButton" >
-            <Property name="Area" value="{{0,280},{0,25},{0,340},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,10},{0,260},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
             <Property name="TooltipText" value="Casts a spell that damages enemy creatures on allied tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureExplosionButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -81,13 +85,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureHasteButton" >
-            <Property name="Area" value="{{0,340},{0,25},{0,400},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,10},{0,300},{0,50}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureHasteButton" />
             <Property name="TooltipText" value="Increases, target speed. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureHasteButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -99,13 +103,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureDefenseButton" >
-            <Property name="Area" value="{{0,400},{0,25},{0,460},{0,85}}" />
+            <Property name="Area" value="{{0,100},{0,50},{0,140},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureDefenseButton" />
             <Property name="TooltipText" value="Increases target physical defense. Target: friendly creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureDefenseButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -117,13 +121,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureSlowButton" >
-            <Property name="Area" value="{{0,460},{0,25},{0,520},{0,85}}" />
+            <Property name="Area" value="{{0,140},{0,50},{0,180},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureSlowButton" />
             <Property name="TooltipText" value="Decrease target speed. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureSlowButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -135,13 +139,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureStrengthButton" >
-            <Property name="Area" value="{{0,520},{0,25},{0,580},{0,85}}" />
+            <Property name="Area" value="{{0,180},{0,50},{0,220},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureStrengthButton" />
             <Property name="TooltipText" value="Increase target strength. Target: allied creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureStrengthButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -153,13 +157,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="CreatureWeakButton" >
-            <Property name="Area" value="{{0,580},{0,25},{0,640},{0,85}}" />
+            <Property name="Area" value="{{0,220},{0,50},{0,260},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/CreatureWeakButton" />
             <Property name="TooltipText" value="Decrease target strength. Target: enemy creatures on claimed tiles" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="CreatureWeakButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />
@@ -171,13 +175,13 @@
             </Window>
         </Window>
         <Window type="OD/GameTabButton" name="SpellEyeEvilButton" >
-            <Property name="Area" value="{{0,640},{0,25},{0,700},{0,85}}" />
+            <Property name="Area" value="{{0,260},{0,50},{0,300},{0,90}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/SpellEyeEvilButton" />
             <Property name="TooltipText" value="Temporary gives vision on tiles without vision. Target: any tile" />
             <Property name="InheritsAlpha" value="False" />
             <Property name="Visible" value="False" />
             <Window type="OD/ProgressBar" name="SpellEyeEvilButtonProgressBar" >
-                <Property name="Area" value="{{0.0,-20},{0.0,0},{1.0,20},{1.0,0}}" />
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="InheritsTooltipText" value="True" />
                 <Property name="CurrentProgress" value="0.0" />
                 <Property name="MousePassThroughEnabled" value="True" />

--- a/gui/WindowUserCameras.layout
+++ b/gui/WindowUserCameras.layout
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GUILayout version="4">
+    <Window type="OD/FrameWindow" name="UserCamerasWindow">
+        <Property name="Area" value="{{0.5,-240},{0,32},{0.5,240},{0,250}}" />
+        <Property name="Text" value="Define user cameras" />
+        <Property name="Visible" value="False" />
+        <Property name="SizingEnabled" value="False" />
+        <Window type="OD/Button" name="Camera1">
+            <Property name="Area" value="{{0,16},{0,36},{0,158},{0,72}}" />
+            <Property name="Text" value="Camera 1 (F4)" />
+        </Window>
+        <Window type="OD/Button" name="Camera2">
+            <Property name="Area" value="{{0,168},{0,36},{0,310},{0,72}}" />
+            <Property name="Text" value="Camera 2 (F5)" />
+        </Window>
+        <Window type="OD/Button" name="Camera3">
+            <Property name="Area" value="{{0,320},{0,36},{1,-16},{0,72}}" />
+            <Property name="Text" value="Camera 3 (F6)" />
+        </Window>
+        <Window type="OD/StaticText" name="Instructions">
+            <Property name="Area" value="{{0,16},{0,80},{1,-16},{0,164}}" />
+            <Property name="Text" value="Hold Ctrl to adjust:&#10;Insert / Delete: roll   Page Up / Down: yaw&#10;Home / End: pitch" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/Button" name="Store">
+            <Property name="Area" value="{{0.5,-70},{0,170},{0.5,70},{0,204}}" />
+            <Property name="Text" value="Store" />
+        </Window>
+    </Window>
+</GUILayout>

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -9,6 +9,13 @@ if ($LASTEXITCODE -ne 0) {
     & git -C "$taskRoot\src\cegui" apply $taskPatch
     if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
 }
+$taskClippingPatch = Join-Path $PSScriptRoot 'patches/cegui-ogre-clipping.patch'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskClippingPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Restoring CEGUI Ogre rendering clip regions'
+    & git -C "$taskRoot\src\cegui" apply $taskClippingPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI clipping patch failed' }
+}
 $ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,6 +1,15 @@
 $ErrorActionPreference = 'Stop'
 $taskRoot = 'C:\Users\mario\od-deps'
 $taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/ogre-multiwindow-settings.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\ogre" apply --recount --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying OGRE multi-window settings compatibility fixes'
+    & git -C "$taskRoot\src\ogre" apply --recount $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'OGRE compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
 $taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
     '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
     "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/patches/cegui-ogre-clipping.patch
+++ b/scripts/win32/patches/cegui-ogre-clipping.patch
@@ -1,0 +1,11 @@
+diff --git a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
++++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+@@ -211,6 +211,6 @@
+             d_renderSystem._setViewport(currentViewport);
+ #else
+             d_renderSystem.setScissorTest(
+-                false, d_clipRect.left(), d_clipRect.top(),
++                i->clip, d_clipRect.left(), d_clipRect.top(),
+                          d_clipRect.right(), d_clipRect.bottom());
+ #endif

--- a/scripts/win32/patches/ogre-multiwindow-settings.patch
+++ b/scripts/win32/patches/ogre-multiwindow-settings.patch
@@ -1,0 +1,362 @@
+diff --git a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+index 361ff64..f7c6444 100644
+--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
++++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+@@ -126,6 +126,8 @@ namespace Ogre {
+ 
+         void initConfigOptions() override;
+ 
++        void setConfigOption(const String &name, const String &value) override;
++
+         RenderSystemCapabilities* createRenderSystemCapabilities() const override;
+ 
+         void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+index 8b9b623..294afa8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLProgramManager.h
+@@ -74,6 +74,15 @@ namespace Ogre {
+         */
+         GLSLProgram* getActiveProgram(void);
+ 
++        /// Destroy all linked programs in the current OpenGL context.
++        void destroyAllPrograms();
++
++        /// Forget program-pipeline objects owned by a context that is being destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
++        /// Return the context currently selected by the render system.
++        GL3PlusContext* getCurrentContext() const;
++
+         /** Populate a list of uniforms based on an OpenGL program object.
+         */
+         void extractUniformsFromProgram(
+diff --git a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+index 65fec8d..a1b50e7 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
++++ b/RenderSystems/GL3Plus/src/GLSL/include/OgreGLSLSeparableProgram.h
+@@ -90,9 +90,12 @@ namespace Ogre
+         */
+         void activate(void) override;
+ 
++        /// Forget the context-local pipeline before its OpenGL context is destroyed.
++        void notifyContextDestroyed(GL3PlusContext* context);
++
+     protected:
+-        /// GL handle for pipeline object.
+-        GLuint mGLProgramPipelineHandle;
++        /// GL program-pipeline objects are context-local even when shader programs are shared.
++        std::map<GL3PlusContext*, GLuint> mGLProgramPipelineHandles;
+ 
+         /// Compiles and links the separate programs.
+         void compileAndLink(void) override;
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+index da255e6..9c6271e 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLProgramManager.cpp
+@@ -62,6 +62,31 @@ namespace Ogre {
+ 
+     GLSLProgramManager::~GLSLProgramManager(void) {}
+ 
++    void GLSLProgramManager::destroyAllPrograms()
++    {
++        for (auto & program : mPrograms)
++        {
++            delete program.second;
++        }
++        mPrograms.clear();
++        mActiveProgram = NULL;
++    }
++
++    void GLSLProgramManager::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        for (auto & program : mPrograms)
++        {
++            if (auto separableProgram = dynamic_cast<GLSLSeparableProgram*>(program.second))
++                separableProgram->notifyContextDestroyed(context);
++        }
++        mActiveProgram = NULL;
++    }
++
++    GL3PlusContext* GLSLProgramManager::getCurrentContext() const
++    {
++        return mRenderSystem->_getCurrentContext();
++    }
++
+     GL3PlusStateCacheManager* GLSLProgramManager::getStateCacheManager()
+     {
+         return mRenderSystem->_getStateCacheManager();
+diff --git a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+index f22f44f..278f7e8 100644
+--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
++++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLSeparableProgram.cpp
+@@ -45,14 +45,32 @@ namespace Ogre
+ 
+     GLSLSeparableProgram::~GLSLSeparableProgram()
+     {
+-        OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &mGLProgramPipelineHandle));
++        notifyContextDestroyed(GLSLProgramManager::getSingleton().getCurrentContext());
++        mGLProgramPipelineHandles.clear();
+     }
+ 
+     void GLSLSeparableProgram::compileAndLink()
+     {
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        OgreAssert(context, "cannot create a program pipeline without an active OpenGL context");
++
++        if (!mLinked)
++        {
++            auto currentPipeline = mGLProgramPipelineHandles.find(context);
++            if (currentPipeline != mGLProgramPipelineHandles.end())
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &currentPipeline->second));
++            mGLProgramPipelineHandles.clear();
++        }
++
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline != mGLProgramPipelineHandles.end())
++            return;
++
+         // Ensure no monolithic programs are in use.
+         OGRE_CHECK_GL_ERROR(glUseProgram(0));
+-        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &mGLProgramPipelineHandle));
++        GLuint pipelineHandle = 0;
++        OGRE_CHECK_GL_ERROR(glGenProgramPipelines(1, &pipelineHandle));
+ 
+         mLinked = true;
+ 
+@@ -61,51 +79,69 @@ namespace Ogre
+             if(!s) continue;
+ 
+             if(!s->linkSeparable())
+-        {
++            {
+                 mLinked = false;
++                OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipelineHandle));
+                 return;
+             }
+         }
+ 
+-            GLenum ogre2gltype[GPT_COUNT] = {
+-                GL_VERTEX_SHADER_BIT,
+-                GL_FRAGMENT_SHADER_BIT,
+-                GL_GEOMETRY_SHADER_BIT,
+-                GL_TESS_EVALUATION_SHADER_BIT,
+-                GL_TESS_CONTROL_SHADER_BIT,
+-                GL_COMPUTE_SHADER_BIT
+-            };
++        GLenum ogre2gltype[GPT_COUNT] = {
++            GL_VERTEX_SHADER_BIT,
++            GL_FRAGMENT_SHADER_BIT,
++            GL_GEOMETRY_SHADER_BIT,
++            GL_TESS_EVALUATION_SHADER_BIT,
++            GL_TESS_CONTROL_SHADER_BIT,
++            GL_COMPUTE_SHADER_BIT
++        };
+ 
+-            for (auto s : mShaders)
+-            {
++        for (auto s : mShaders)
++        {
+             if(!s) continue;
+ 
+-                OGRE_CHECK_GL_ERROR(glUseProgramStages(mGLProgramPipelineHandle, ogre2gltype[s->getType()],
+-                                                       s->getGLProgramHandle()));
+-            }
++            OGRE_CHECK_GL_ERROR(glUseProgramStages(pipelineHandle, ogre2gltype[s->getType()],
++                                                   s->getGLProgramHandle()));
++        }
+ 
+-            // Validate pipeline
+-            OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(mGLProgramPipelineHandle));
+-            logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), mGLProgramPipelineHandle );
++        // Validate pipeline
++        OGRE_CHECK_GL_ERROR(glValidateProgramPipeline(pipelineHandle));
++        logObjectInfo( getCombinedName() + String("GLSL program pipeline validation result: "), pipelineHandle );
+ 
+-            //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
+-            //                glObjectLabel(GL_PROGRAM_PIPELINE, mGLProgramPipelineHandle, 0,
+-            //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
+-        }
++        mGLProgramPipelineHandles[context] = pipelineHandle;
++
++        //            if (getGLSupport()->checkExtension("GL_KHR_debug") || gl3wIsSupported(4, 3))
++        //                glObjectLabel(GL_PROGRAM_PIPELINE, pipelineHandle, 0,
++        //                                 (mVertexShader->getName() + "/" + mFragmentShader->getName()).c_str());
++    }
+ 
+     void GLSLSeparableProgram::activate(void)
+     {
+-        if (!mLinked)
++        GLSLProgramManager& programManager = GLSLProgramManager::getSingleton();
++        GL3PlusContext* context = programManager.getCurrentContext();
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (!mLinked || pipeline == mGLProgramPipelineHandles.end())
+         {
+             compileAndLink();
++            pipeline = mGLProgramPipelineHandles.find(context);
+         }
+ 
+-        if (mLinked)
++        if (mLinked && pipeline != mGLProgramPipelineHandles.end())
+         {
+-            GLSLProgramManager::getSingleton().getStateCacheManager()->bindGLProgramPipeline(mGLProgramPipelineHandle);
++            programManager.getStateCacheManager()->bindGLProgramPipeline(pipeline->second);
+         }
+     }
+ 
++    void GLSLSeparableProgram::notifyContextDestroyed(GL3PlusContext* context)
++    {
++        auto pipeline = mGLProgramPipelineHandles.find(context);
++        if (pipeline == mGLProgramPipelineHandles.end())
++            return;
++
++        if (GLSLProgramManager::getSingleton().getCurrentContext() == context)
++            OGRE_CHECK_GL_ERROR(glDeleteProgramPipelines(1, &pipeline->second));
++        mGLProgramPipelineHandles.erase(pipeline);
++    }
++
+     void GLSLSeparableProgram::updateUniforms(GpuProgramParametersSharedPtr params,
+                                               uint16 mask, GpuProgramType fromProgType)
+     {
+diff --git a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+index 5695b7f..07e3aa1 100644
+--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
++++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+@@ -34,6 +34,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
+ #include "OgreStringConverter.h"
+ #include "OgreGL3PlusTextureManager.h"
+ #include "OgreGL3PlusHardwareBuffer.h"
++#include "OgreHighLevelGpuProgramManager.h"
+ #include "OgreGLSLShader.h"
+ #include "OgreGpuProgramManager.h"
+ #include "OgreException.h"
+@@ -214,6 +215,78 @@ namespace Ogre {
+         mOptions[opt.name] = opt;
+     }
+ 
++    void GL3PlusRenderSystem::setConfigOption(const String &name, const String &value)
++    {
++        const bool separateShadersChanged = name == "Separate Shader Objects"
++            && mGLInitialised && mSeparateShaderObjectsEnabled != StringConverter::parseBool(value);
++
++        GLRenderSystemCommon::setConfigOption(name, value);
++        if (!mGLInitialised)
++            return;
++
++        if (separateShadersChanged)
++        {
++            std::vector<ResourcePtr> loadedPrograms;
++            ResourceManager::ResourceMapIterator resources =
++                HighLevelGpuProgramManager::getSingleton().getResourceIterator();
++            while (resources.hasMoreElements())
++            {
++                ResourcePtr program = resources.getNext();
++                if (program->isLoaded())
++                    loadedPrograms.push_back(program);
++            }
++            for (int programType = 0; programType < GPT_COUNT; ++programType)
++            {
++                GpuProgramType type = static_cast<GpuProgramType>(programType);
++                if (mCurrentShader[type])
++                    unbindGpuProgram(type);
++            }
++            OGRE_CHECK_GL_ERROR(glUseProgram(0));
++            mStateCacheManager->bindGLProgramPipeline(0);
++            mProgramManager->destroyAllPrograms();
++            for (ResourcePtr & program : loadedPrograms)
++                program->unload();
++
++            mSeparateShaderObjectsEnabled = StringConverter::parseBool(value);
++            if (mSeparateShaderObjectsEnabled)
++                mCurrentCapabilities->setCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            else
++                mCurrentCapabilities->unsetCapability(RSC_SEPARATE_SHADER_OBJECTS);
++            for (ResourcePtr & program : loadedPrograms)
++                program->load();
++        }
++        else if (name == "Reversed Z-Buffer")
++        {
++            const bool clipControlSupported = hasMinGLVersion(4, 5)
++                || checkExtension("GL_ARB_clip_control");
++            mIsReverseDepthBufferEnabled = StringConverter::parseBool(value)
++                && clipControlSupported;
++            if (clipControlSupported)
++            {
++                OGRE_CHECK_GL_ERROR(glClipControl(GL_LOWER_LEFT,
++                    mIsReverseDepthBufferEnabled ? GL_ZERO_TO_ONE : GL_NEGATIVE_ONE_TO_ONE));
++            }
++        }
++        else if (name == "Debug Layer" && getCapabilities()->hasCapability(RSC_DEBUG))
++        {
++            const bool debugEnabled = StringConverter::parseBool(value);
++            if (debugEnabled)
++            {
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT));
++                OGRE_CHECK_GL_ERROR(glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(&GLDebugCallback, NULL));
++                OGRE_CHECK_GL_ERROR(glDebugMessageControlARB(GL_DEBUG_SOURCE_API, GL_DONT_CARE,
++                    GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_FALSE));
++            }
++            else
++            {
++                OGRE_CHECK_GL_ERROR(glDebugMessageCallbackARB(NULL, NULL));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT_SYNCHRONOUS));
++                OGRE_CHECK_GL_ERROR(glDisable(GL_DEBUG_OUTPUT));
++            }
++        }
++    }
++
+     RenderSystemCapabilities* GL3PlusRenderSystem::createRenderSystemCapabilities() const
+     {
+         RenderSystemCapabilities* rsc = OGRE_NEW RenderSystemCapabilities();
+@@ -1398,6 +1471,7 @@ namespace Ogre {
+ 
+     void GL3PlusRenderSystem::_unregisterContext(GL3PlusContext *context)
+     {
++        mProgramManager->notifyContextDestroyed(context);
+         static_cast<GL3PlusHardwareBufferManager*>(HardwareBufferManager::getSingletonPtr())->notifyContextDestroyed(context);
+ 
+         for(auto & rt : mRenderTargets)
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+index 70e89c2..8f8178c 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+@@ -327,7 +327,8 @@ namespace Ogre {
+                         mHasPixelFormatARB = true;
+                     else if (ext == "WGL_ARB_multisample")
+                         mHasMultisample = true;
+-                    else if (ext == "WGL_EXT_framebuffer_sRGB")
++                    else if (ext == "WGL_EXT_framebuffer_sRGB"
++                             || ext == "WGL_ARB_framebuffer_sRGB")
+                         mHasHardwareGamma = true;
+                 }
+             }
+diff --git a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+index c4269f8..f46ddff 100644
+--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
++++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+@@ -551,11 +551,8 @@ namespace Ogre {
+ 
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_TOPMOST, mLeft, mTop, width, height,
+-                    SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+-
++                    SWP_FRAMECHANGED | SWP_NOACTIVATE);
++                windowMovedOrResized();
+             }
+             else
+             {               
+@@ -584,9 +581,6 @@ namespace Ogre {
+                 SetWindowLong(mHWnd, GWL_STYLE, getWindowStyle(mIsFullScreen));
+                 SetWindowPos(mHWnd, HWND_NOTOPMOST, left, top, winWidth, winHeight,
+                     SWP_DRAWFRAME | SWP_FRAMECHANGED | SWP_NOACTIVATE);
+-                mWidth = width;
+-                mHeight = height;
+-
+                 windowMovedOrResized();
+ 
+             }

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -161,7 +161,7 @@ void ODApplication::startClient()
         std::stringstream ss(videoMode);
         // Ignore the x in the middle
         char ignore;
-        ss >> w >> ignore >> h >> h;
+        ss >> w >> ignore >> h;
 
         w = std::max(w, MIN_WIDTH);
         h = std::max(h, MIN_HEIGHT);
@@ -210,11 +210,7 @@ void ODApplication::startClient()
     
     ogreRoot.initialise(false);
 
-    Ogre::NameValuePairList misc;
-    misc["FSAA"] = "0";
-    misc["vsync"] = "true";
-
-    // You can also later load these from config or allow command-line override
+    Ogre::NameValuePairList misc = ogreRoot.getRenderSystem()->getRenderWindowDescription().miscParams;
 
     OD_LOG_INF("Creating window: with resolution " + Helper::toString(w) + " " + Helper::toString(h));
     
@@ -333,6 +329,7 @@ void ODApplication::startClient()
     Ogre::MaterialManager::getSingleton().removeListener(sgListener);
     delete sgListener;
     Ogre::RTShader::ShaderGenerator::destroy();
+    frameListener.prepareRenderWindowShutdown();
     ogreRoot.destroyRenderTarget(renderWindow);
 }
 

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,7 +235,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system

--- a/source/camera/CameraInput.h
+++ b/source/camera/CameraInput.h
@@ -1,0 +1,33 @@
+#ifndef CAMERA_INPUT_H
+#define CAMERA_INPUT_H
+
+#include <OISKeyboard.h>
+
+//! Resolve held keys together so modifier changes and opposing keys are stable.
+struct CameraInput
+{
+    float x = 0.0f;
+    float y = 0.0f;
+    float zoom = 0.0f;
+    float swivel = 0.0f;
+    bool fast = false;
+
+    template<typename KeyDown>
+    static CameraInput read(KeyDown down)
+    {
+        CameraInput input;
+        const bool ctrl = down(OIS::KC_LCONTROL) || down(OIS::KC_RCONTROL);
+        input.fast = down(OIS::KC_LSHIFT) || down(OIS::KC_RSHIFT);
+        input.x = float(down(OIS::KC_D) || (!ctrl && down(OIS::KC_RIGHT)))
+            - float(down(OIS::KC_A) || (!ctrl && down(OIS::KC_LEFT)));
+        input.y = float(down(OIS::KC_W) || (!ctrl && down(OIS::KC_UP)))
+            - float(down(OIS::KC_S) || (!ctrl && down(OIS::KC_DOWN)));
+        input.zoom = float((!ctrl && down(OIS::KC_END)) || (ctrl && down(OIS::KC_DOWN)))
+            - float((!ctrl && down(OIS::KC_HOME)) || (ctrl && down(OIS::KC_UP)));
+        input.swivel = float(down(OIS::KC_Q) || (!ctrl && down(OIS::KC_DELETE)) || (ctrl && down(OIS::KC_LEFT)))
+            - float(down(OIS::KC_E) || (!ctrl && down(OIS::KC_PGDOWN)) || (ctrl && down(OIS::KC_RIGHT)));
+        return input;
+    }
+};
+
+#endif

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -39,9 +39,8 @@
 #include <OgreViewport.h>
 
 #include <algorithm>
-
-const Ogre::Real Z_MOVE_SPEED = 1.0;
-const Ogre::Real Z_MOVE_SPEED_ACCELERATION = 2.0f * Z_MOVE_SPEED;
+#include <cmath>
+#include <sstream>
 
 //! The camera moving speed factor on Z axis.
 const Ogre::Real ZOOM_SPEED = 4.0;
@@ -76,6 +75,8 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mCameraRollDestination(0.0),
     mCurrentDefaultViewMode(ViewModes::defaultView),
     mZChange(0.0),
+    mMoveSpeed(1.0),
+    mMoveSpeedAcceleration(2.0),
     mPanSpeedFactor(1.0),
     mSwivelDegrees(0.0),
     mTranslateVector(Ogre::Vector3(0.0, 0.0, 0.0)),
@@ -225,6 +226,10 @@ void CameraManager::setDefaultOrthogonalView()
 
 void CameraManager::RotateTo(Ogre::Real pitch, Ogre::Real roll)
 {
+    move(fullStop);
+    const Ogre::Real currentPitch = getActiveCameraNode()->getChild(0)->getOrientation().getPitch().valueDegrees();
+    setViewOrientation(getActiveCameraNode()->getOrientation(),
+        Ogre::Quaternion(Ogre::Degree(std::max(0.0f, std::min(50.0f, currentPitch))), Ogre::Vector3::UNIT_X));
     mCameraIsRotating = true;
     mCameraPitchDestination = pitch;
     mCameraRollDestination = roll;
@@ -302,7 +307,9 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     if (!isCameraMovingAtAll())
         return;
 
-    mMoveSpeed = getActiveCameraNode()->getPosition().z / 16.0f * mPanSpeedFactor;
+    if(frameTime <= 0.0f)
+        return;
+    mMoveSpeed = getActiveCameraNode()->getPosition().z / 16.0f * mPanSpeedFactor * mFastPanFactor;
     mMoveSpeedAcceleration = 2.0f * mMoveSpeed;
     
     // Carry out the acceleration/deceleration calculations on the camera translation.
@@ -335,19 +342,17 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     // Get the camera's current position.
     Ogre::Vector3 newPosition =  getActiveCameraNode()->getPosition();
 
-    // Get a quaternion which will rotate the "camera relative" x-y values
-    // for the translateVector into the global x-y used to position the camera.
     Ogre::Vector3 viewTarget = getCameraViewTarget();
-
-    Ogre::Vector3 viewDirection = viewTarget - newPosition;
-
-    viewDirection.z = 0.0;
-
-    Ogre::Quaternion viewDirectionQuaternion = Ogre::Vector3::UNIT_Y.getRotationTo(viewDirection);
+    // The projected view direction vanishes in a top-down view. The camera's
+    // right vector still defines screen-relative pan in every supported view.
+    Ogre::Vector3 right = mActiveCamera->getDerivedRight();
+    right.z = 0.0f;
+    right.normalise();
+    Ogre::Vector3 forward(-right.y, right.x, 0.0f);
 
     // Adjust the newPosition vector to account for the translation due
     // to the movement keys on the keyboard (the arrow keys and/or WASD).
-    if (mZChange != 0)
+    if (mZChange != 0 || mControlZoom != 0)
     {
         // Zoom towards what is in the middle of the screen, not towards the
         // ground under the camera: the camera looks ahead at an angle, so a
@@ -355,7 +360,7 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
         // the ground point at the screen centre fixed means shifting the
         // camera base by the difference of its ground offsets at the two
         // heights.
-        Ogre::Real newZ = newPosition.z + static_cast<Ogre::Real>(mZChange * frameTime * ZOOM_SPEED);
+        Ogre::Real newZ = newPosition.z + static_cast<Ogre::Real>(mControlZoom * frameTime * ZOOM_SPEED + mZChange);
         if (newZ <= MIN_CAMERA_Z)
             newZ = MIN_CAMERA_Z;
         else if (newZ >= MAX_CAMERA_Z)
@@ -365,16 +370,12 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
         newPosition.x += offsetBefore.x - offsetAfter.x;
         newPosition.y += offsetBefore.y - offsetAfter.y;
         newPosition.z = newZ;
-        // We also stow and stop the movement here, as the keyboard release events
-        // and mouse wheel event are otherwise colliding on handling the zoom.
-        if (mZChange > 0)
-            mZChange -= Z_MOVE_SPEED;
-        else if (mZChange < 0)
-            mZChange += Z_MOVE_SPEED;
+        mZChange = 0.0f;
     }
 
     // Update the position for the other axices.
-    newPosition += (viewDirectionQuaternion * mTranslateVector);
+    // Retain the nominal 60 Hz speed while making distance elapsed-time based.
+    newPosition += (right * mTranslateVector.x + forward * mTranslateVector.y) * (60.0f * frameTime);
 
     // Prevent camera from moving down into the tiles or too high.
     if (newPosition.z <= MIN_CAMERA_Z)
@@ -384,42 +385,19 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
 
     clampToMap(newPosition);
 
-    // Prevent the tilting to show a reversed world or looking too high.
-    if (mRotateLocalVector.x != 0)
-    {
-        Ogre::Real currentPitch = getActiveCameraNode()->getChild(0)->getOrientation().getPitch().valueDegrees();
-        if ((currentPitch >= 0.0 && mRotateLocalVector.x < 0)
-            || (currentPitch <= 50.0 && mRotateLocalVector.x > 0))
-        {
-            // Tilt the camera up or down.
-            getActiveCameraNode()->getChild(0)->rotate(Ogre::Vector3::UNIT_X,
-                                        Ogre::Degree(mRotateLocalVector.x * frameTime),
-                                        Ogre::Node::TS_LOCAL);
-        }
-
-    }
-    if (mRotateLocalVector.y != 0)
-    {
-        // Tilt the camera up or down.
-        getActiveCameraNode()->rotate(Ogre::Vector3::UNIT_Z,
-                                      Ogre::Degree(mRotateLocalVector.y * frameTime),
-                                      Ogre::Node::TS_LOCAL);
-    }
-
-    // Swivel the camera to the left or right, while maintaining the same
-    // view target location on the ground.
-    Ogre::Real deltaX = newPosition.x - viewTarget.x;
-    Ogre::Real deltaY = newPosition.y - viewTarget.y;
-
-    Ogre::Real radius = sqrt(deltaX * deltaX + deltaY * deltaY);
-    Ogre::Real theta = atan2(deltaY, deltaX) + mSwivelDegrees.valueRadians() * frameTime;
-
-    newPosition.x = viewTarget.x + radius * cos(theta);
-    newPosition.y = viewTarget.y + radius * sin(theta);
-
+    Ogre::Vector3 groundTarget = newPosition + getGroundOffset(newPosition.z);
+    Ogre::Node* tilt = getActiveCameraNode()->getChild(0);
+    Ogre::Real pitch = tilt->getOrientation().getPitch().valueDegrees();
+    Ogre::Real pitchStep = mRotateLocalVector.x * frameTime;
+    if(pitchStep != 0.0f)
+        pitchStep = std::max(-pitch, std::min(50.0f - pitch, pitchStep));
+    tilt->pitch(Ogre::Degree(pitchStep), Ogre::Node::TS_LOCAL);
     getActiveCameraNode()->rotate(Ogre::Vector3::UNIT_Z,
-                                  Ogre::Degree(mSwivelDegrees * frameTime),
-                                  Ogre::Node::TS_WORLD);
+        Ogre::Degree((mSwivelDegrees.valueDegrees() + mControlSwivel * 117.0f
+            + mRotateLocalVector.y) * frameTime), Ogre::Node::TS_WORLD);
+    newPosition = groundTarget - getGroundOffset(newPosition.z);
+    // groundTarget includes the camera height; getGroundOffset has zero height.
+    Ogre::Real radius = 0.0f;
 
     // If the camera is trying to fly toward a destination, move it in that direction.
     if (mCameraIsFlying)
@@ -465,8 +443,12 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
         Ogre::Real pitchDiff = std::abs(pitch - mCameraPitchDestination);
         Ogre::Real pitchChange = ((pitchUpdate * frameTime) > pitchDiff) ? pitchDiff / frameTime : pitchUpdate;
         bool pitchDone = false;
-        if (pitchDiff < 0.5)
+        if (pitchDiff <= pitchUpdate * frameTime)
         {
+            Ogre::Vector3 anchor = newPosition + getGroundOffset(newPosition.z);
+            getActiveCameraNode()->getChild(0)->setOrientation(
+                Ogre::Quaternion(Ogre::Degree(mCameraPitchDestination), Ogre::Vector3::UNIT_X));
+            newPosition = anchor - getGroundOffset(newPosition.z);
             mRotateLocalVector.x = 0.0;
             pitchDone = true;
         }
@@ -481,8 +463,12 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
         Ogre::Real rollDiff = std::abs(roll - mCameraRollDestination);
         Ogre::Real rollChange = ((rollUpdate * frameTime) > rollDiff) ? rollDiff / frameTime : rollUpdate;
         bool rollDone = false;
-        if (std::abs(roll - mCameraRollDestination) < 0.5)
+        if (rollDiff <= rollUpdate * frameTime)
         {
+            Ogre::Vector3 anchor = newPosition + getGroundOffset(newPosition.z);
+            getActiveCameraNode()->setOrientation(
+                Ogre::Quaternion(Ogre::Degree(mCameraRollDestination), Ogre::Vector3::UNIT_Z));
+            newPosition = anchor - getGroundOffset(newPosition.z);
             mSwivelDegrees = 0.0;
             rollDone = true;
         }
@@ -550,6 +536,9 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
 
 Ogre::Vector3 CameraManager::getGroundOffset(Ogre::Real height) const
 {
+    // Parent rotation does not refresh the attached camera's child transform
+    // until the scene graph update; input needs the new direction immediately.
+    mActiveCameraNode->_update(true, false);
     // Follow the view direction down to z = 0, the same way getCameraViewTarget()
     // does, but for an arbitrary height rather than the current one.
     Ogre::Vector3 cameraDirection = mActiveCamera->getDerivedDirection();
@@ -581,23 +570,10 @@ void CameraManager::clampToMap(Ogre::Vector3& position) const
 
 Ogre::Vector3 CameraManager::getCameraViewTarget() const
 {
-    // Get the position of the camera and direction that the camera is facing.
+    mActiveCameraNode->_update(true, false);
     Ogre::Vector3 position = mActiveCamera->getRealPosition();
-    Ogre::Vector3 viewDirection = mActiveCamera->getDerivedDirection();
-
-    // Compute the offset, this is how far you would move in the x-y plane if
-    // you follow along the view direction vector until you get to z = 0.
-    viewDirection.normalise();
-    viewDirection /= fabs(viewDirection.z);
-    Ogre::Vector3 offset = position.z * viewDirection;
-    offset.z = 0.0;
-
-    // The location we are looking at is then simply the camera's position plus
-    // the view offset computed above.  We zero the z-value on the target for
-    // consistency.
-    Ogre::Vector3 target = position + offset;
-    target.z = 0.0;
-
+    Ogre::Vector3 target = position + getGroundOffset(position.z);
+    target.z = 0.0f;
     return target;
 }
 
@@ -644,6 +620,105 @@ void CameraManager::onMiniMapClick(Ogre::Vector2 cc)
     flyTo(Ogre::Vector3(cc.x, cc.y, 0.0));
 }
 
+void CameraManager::setControls(const Ogre::Vector2& pan, Ogre::Real zoom, Ogre::Real swivel, bool fast)
+{
+    mFastPanFactor = fast ? 2.0f : 1.0f;
+    mMoveSpeed = getActiveCameraNode()->getPosition().z / 16.0f * mPanSpeedFactor * mFastPanFactor;
+    mMoveSpeedAcceleration = 2.0f * mMoveSpeed;
+    mTranslateVectorAccel = Ogre::Vector3(pan.x, pan.y, 0.0f) * mMoveSpeedAcceleration;
+    mTranslateMaxSpeedFactor = Ogre::Vector2(std::abs(pan.x), std::abs(pan.y));
+    mControlZoom = zoom;
+    mControlSwivel = swivel;
+    if(pan != Ogre::Vector2::ZERO || zoom != 0.0f || swivel != 0.0f)
+    {
+        mCameraIsFlying = mCameraIsRotating = false;
+        mSwivelDegrees = Ogre::Degree(0.0f);
+        mRotateLocalVector = Ogre::Vector3::ZERO;
+    }
+}
+
+void CameraManager::zoomBy(Ogre::Real distance)
+{
+    mZChange += distance;
+}
+
+void CameraManager::setViewOrientation(const Ogre::Quaternion& root, const Ogre::Quaternion& tilt)
+{
+    Ogre::Vector3 target = getCameraViewTarget();
+    Ogre::Real height = getActiveCameraNode()->getPosition().z;
+    getActiveCameraNode()->setOrientation(root);
+    getActiveCameraNode()->getChild(0)->setOrientation(tilt);
+    Ogre::Vector3 position = target - getGroundOffset(height);
+    position.z = height;
+    clampToMap(position);
+    getActiveCameraNode()->setPosition(position);
+}
+
+void CameraManager::orbitBy(Ogre::Real swivel, Ogre::Real pitch)
+{
+    mCameraIsRotating = mCameraIsFlying = false;
+    mRotateLocalVector = Ogre::Vector3::ZERO;
+    mSwivelDegrees = Ogre::Degree(0.0f);
+    Ogre::Quaternion root = getActiveCameraNode()->getOrientation();
+    Ogre::Quaternion tilt = getActiveCameraNode()->getChild(0)->getOrientation();
+    Ogre::Real currentPitch = tilt.getPitch().valueDegrees();
+    pitch = std::max(-currentPitch, std::min(50.0f - currentPitch, pitch));
+    setViewOrientation(Ogre::Quaternion(Ogre::Degree(swivel), Ogre::Vector3::UNIT_Z) * root,
+        tilt * Ogre::Quaternion(Ogre::Degree(pitch), Ogre::Vector3::UNIT_X));
+}
+
+void CameraManager::adjustUserView(Ogre::Real roll, Ogre::Real yaw, Ogre::Real pitch)
+{
+    move(fullStop);
+    Ogre::Quaternion root = getActiveCameraNode()->getOrientation();
+    Ogre::Quaternion tilt = getActiveCameraNode()->getChild(0)->getOrientation();
+    tilt = tilt * Ogre::Quaternion(Ogre::Degree(roll), Ogre::Vector3::UNIT_Z)
+        * Ogre::Quaternion(Ogre::Degree(yaw), Ogre::Vector3::UNIT_Y)
+        * Ogre::Quaternion(Ogre::Degree(pitch), Ogre::Vector3::UNIT_X);
+    // Ground-target navigation requires the camera to keep looking downwards.
+    if((root * tilt * Ogre::Vector3::NEGATIVE_UNIT_Z).z < -0.1f)
+        setViewOrientation(root, tilt);
+}
+
+void CameraManager::loadUserView(unsigned int slot)
+{
+    if(slot >= 3)
+        return;
+    std::istringstream values(ConfigManager::getSingleton().getInputValue(
+        "UserCamera" + Helper::toString(slot + 1), "", false));
+    Ogre::Quaternion root, tilt;
+    if(!(values >> root.w >> root.x >> root.y >> root.z >> tilt.w >> tilt.x >> tilt.y >> tilt.z))
+    {
+        move(fullStop);
+        setViewOrientation(Ogre::Quaternion::IDENTITY,
+            Ogre::Quaternion(Ogre::Degree(DEFAULT_X_AXIS_VIEW), Ogre::Vector3::UNIT_X));
+        return;
+    }
+    if(!std::isfinite(root.Norm()) || !std::isfinite(tilt.Norm()) || root.Norm() < 0.01f || tilt.Norm() < 0.01f)
+        return;
+    root.normalise();
+    tilt.normalise();
+    if((root * tilt * Ogre::Vector3::NEGATIVE_UNIT_Z).z >= -0.1f)
+        return;
+    move(fullStop);
+    setViewOrientation(root, tilt);
+}
+
+bool CameraManager::storeUserView(unsigned int slot)
+{
+    if(slot >= 3)
+        return false;
+    const Ogre::Quaternion& root = getActiveCameraNode()->getOrientation();
+    const Ogre::Quaternion& tilt = getActiveCameraNode()->getChild(0)->getOrientation();
+    std::ostringstream values;
+    values.precision(9);
+    values << root.w << ' ' << root.x << ' ' << root.y << ' ' << root.z << ' '
+        << tilt.w << ' ' << tilt.x << ' ' << tilt.y << ' ' << tilt.z;
+    ConfigManager& config = ConfigManager::getSingleton();
+    config.setInputValue("UserCamera" + Helper::toString(slot + 1), values.str());
+    return config.saveUserConfig();
+}
+
 void CameraManager::move(const Direction direction, double aux)
 {
     // NOTE : The camera loses the desired sense of left, right, top, down
@@ -655,13 +730,10 @@ void CameraManager::move(const Direction direction, double aux)
     const bool scaledPan = aux > 0.0;
     const Ogre::Real maxSpeedFactor = scaledPan ?
         static_cast<Ogre::Real>(std::min(aux, 1.0)) : 1.0f;
-    const auto applyPanAcceleration = [this, scaledPan](Ogre::Real& acceleration, Ogre::Real direction)
+    const auto applyPanAcceleration = [this](Ogre::Real& acceleration, Ogre::Real direction)
     {
         const Ogre::Real newAcceleration = direction * mMoveSpeedAcceleration;
-        if(scaledPan)
-            acceleration = newAcceleration;
-        else
-            acceleration += newAcceleration;
+        acceleration = newAcceleration;
     };
 
     switch (direction)
@@ -719,21 +791,21 @@ void CameraManager::move(const Direction direction, double aux)
         break;
 
     case moveUp:
-        mZChange += Z_MOVE_SPEED_ACCELERATION;
+        mZChange += 0.2f;
         break;
 
     case stopUp:
         break;
 
     case moveDown:
-        mZChange -= Z_MOVE_SPEED_ACCELERATION;
+        mZChange -= 0.2f;
         break;
 
     case stopDown:
         break;
 
     case rotateLeft:
-        mSwivelDegrees += 1.3 * ROTATION_SPEED;
+        mSwivelDegrees = 1.3 * ROTATION_SPEED;
         break;
 
     case stopRotRight:
@@ -741,7 +813,7 @@ void CameraManager::move(const Direction direction, double aux)
         break;
 
     case rotateRight:
-        mSwivelDegrees -= 1.3 * ROTATION_SPEED;
+        mSwivelDegrees = -1.3 * ROTATION_SPEED;
         break;
 
     case stopRotLeft:
@@ -749,7 +821,7 @@ void CameraManager::move(const Direction direction, double aux)
         break;
 
     case rotateUp:
-        mRotateLocalVector.x += ROTATION_SPEED.valueDegrees();
+        mRotateLocalVector.x = ROTATION_SPEED.valueDegrees();
         break;
 
     case stopRotDown:
@@ -757,7 +829,7 @@ void CameraManager::move(const Direction direction, double aux)
         break;
 
     case rotateDown:
-        mRotateLocalVector.x -= ROTATION_SPEED.valueDegrees();
+        mRotateLocalVector.x = -ROTATION_SPEED.valueDegrees();
         break;
 
     case stopRotUp:
@@ -778,6 +850,16 @@ void CameraManager::move(const Direction direction, double aux)
 
     case zeroRandomRotateY:
         mRotateLocalVector.x = 0.0;
+        break;
+
+    case fullStop:
+        mTranslateVector = Ogre::Vector3::ZERO;
+        mTranslateVectorAccel = Ogre::Vector3::ZERO;
+        mRotateLocalVector = Ogre::Vector3::ZERO;
+        mZChange = mControlZoom = mControlSwivel = 0.0f;
+        mSwivelDegrees = Ogre::Degree(0.0f);
+        mCameraIsFlying = mCameraIsRotating = false;
+        mFastPanFactor = 1.0f;
         break;
 
     default:
@@ -823,9 +905,9 @@ bool CameraManager::isCameraMovingAtAll() const
             mTranslateVectorAccel.y != 0 ||
             mTranslateVector.x != 0 ||
             mTranslateVector.y != 0 ||
-            mZChange != 0 ||
+            mZChange != 0 || mControlZoom != 0 || mControlSwivel != 0 ||
             mSwivelDegrees.valueDegrees() != 0 ||
-            mRotateLocalVector.x != 0 ||
+            mRotateLocalVector.x != 0 || mRotateLocalVector.y != 0 ||
             mCameraIsFlying ||
             mCameraIsRotating);
 }

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -579,6 +579,8 @@ Ogre::Vector3 CameraManager::getCameraViewTarget() const
 
 void CameraManager::resetCamera(const Ogre::Vector3& position, const Ogre::Vector3& rotation)
 {
+    // Scripted menu shots must not inherit gameplay movement or view animation.
+    move(fullStop);
     Ogre::Node* nodeRotation = getActiveCameraNode()->getChild(0);
     nodeRotation->resetOrientation();
 

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -622,6 +622,16 @@ void CameraManager::onMiniMapClick(Ogre::Vector2 cc)
     flyTo(Ogre::Vector3(cc.x, cc.y, 0.0));
 }
 
+void CameraManager::jumpToViewTarget(const Ogre::Vector2& pos)
+{
+    move(fullStop);
+    const Ogre::Real height = getActiveCameraNode()->getPosition().z;
+    Ogre::Vector3 position(pos.x, pos.y, height);
+    position -= getGroundOffset(height);
+    clampToMap(position);
+    getActiveCameraNode()->setPosition(position);
+}
+
 void CameraManager::setControls(const Ogre::Vector2& pan, Ogre::Real zoom, Ogre::Real swivel, bool fast)
 {
     mFastPanFactor = fast ? 2.0f : 1.0f;

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -80,6 +80,7 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, GameMap* gm, Ogre
     mSwivelDegrees(0.0),
     mTranslateVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mTranslateVectorAccel(Ogre::Vector3(0.0, 0.0, 0.0)),
+    mTranslateMaxSpeedFactor(Ogre::Vector2(1.0, 1.0)),
     mRotateLocalVector(Ogre::Vector3(0.0, 0.0, 0.0)),
     mSceneManager(sceneManager),
     mViewport(nullptr)
@@ -309,6 +310,18 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
     mTranslateVector *= static_cast<Ogre::Real>(std::max(0.0f, speed - (0.75f + (speed / mMoveSpeed))
                         * mMoveSpeedAcceleration * frameTime));
     mTranslateVector += mTranslateVectorAccel * static_cast<Ogre::Real>(frameTime * 2.0f);
+
+    const Ogre::Real maxMoveSpeedX = mMoveSpeed * mTranslateMaxSpeedFactor.x;
+    if(mTranslateVector.x > maxMoveSpeedX)
+        mTranslateVector.x = maxMoveSpeedX;
+    else if(mTranslateVector.x < -maxMoveSpeedX)
+        mTranslateVector.x = -maxMoveSpeedX;
+
+    const Ogre::Real maxMoveSpeedY = mMoveSpeed * mTranslateMaxSpeedFactor.y;
+    if(mTranslateVector.y > maxMoveSpeedY)
+        mTranslateVector.y = maxMoveSpeedY;
+    else if(mTranslateVector.y < -maxMoveSpeedY)
+        mTranslateVector.y = -maxMoveSpeedY;
 
     // If we have sped up to more than the maximum moveSpeed then rescale the
     // vector to that length. We use the squaredLength() in this calculation
@@ -639,54 +652,70 @@ void CameraManager::move(const Direction direction, double aux)
     Ogre::Real currentPitch = getActiveCameraNode()->getOrientation().getPitch().valueDegrees();
     currentPitch = std::fmod(currentPitch, 90.0f);
 
+    const bool scaledPan = aux > 0.0;
+    const Ogre::Real maxSpeedFactor = scaledPan ?
+        static_cast<Ogre::Real>(std::min(aux, 1.0)) : 1.0f;
+    const auto applyPanAcceleration = [this, scaledPan](Ogre::Real& acceleration, Ogre::Real direction)
+    {
+        const Ogre::Real newAcceleration = direction * mMoveSpeedAcceleration;
+        if(scaledPan)
+            acceleration = newAcceleration;
+        else
+            acceleration += newAcceleration;
+    };
+
     switch (direction)
     {
     case moveRight:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopRight:
         if(mTranslateVectorAccel.x >= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveLeft:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.x -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.x += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.x = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.x, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopLeft:
         if(mTranslateVectorAccel.x <= 0)
+        {
             mTranslateVectorAccel.x = 0;
+            mTranslateMaxSpeedFactor.x = 1.0f;
+        }
         break;
 
     case moveBackward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? -1.0f : 1.0f);
         break;
 
     case stopBackward:
         if(mTranslateVectorAccel.y <= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveForward:
-        if (currentPitch <= 0.0f)
-            mTranslateVectorAccel.y += mMoveSpeedAcceleration;
-        else
-            mTranslateVectorAccel.y -= mMoveSpeedAcceleration;
+        mTranslateMaxSpeedFactor.y = maxSpeedFactor;
+        applyPanAcceleration(mTranslateVectorAccel.y, currentPitch <= 0.0f ? 1.0f : -1.0f);
         break;
 
     case stopForward:
         if(mTranslateVectorAccel.y >= 0)
+        {
             mTranslateVectorAccel.y = 0;
+            mTranslateMaxSpeedFactor.y = 1.0f;
+        }
         break;
 
     case moveUp:

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -241,6 +241,30 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
     OD_LOG_INF("Creating viewport...");
 }
 
+void CameraManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    Ogre::Viewport* previousViewport = mViewport;
+    Ogre::RenderTarget* previousTarget = previousViewport->getTarget();
+    Ogre::Viewport* viewport = renderWindow->addViewport(mActiveCamera,
+        previousViewport->getZOrder(), previousViewport->getLeft(), previousViewport->getTop(),
+        previousViewport->getWidth(), previousViewport->getHeight());
+    viewport->setBackgroundColour(previousViewport->getBackgroundColour());
+    viewport->setClearEveryFrame(previousViewport->getClearEveryFrame(), previousViewport->getClearBuffers());
+    viewport->setMaterialScheme(previousViewport->getMaterialScheme());
+    viewport->setOverlaysEnabled(previousViewport->getOverlaysEnabled());
+    viewport->setSkiesEnabled(previousViewport->getSkiesEnabled());
+    viewport->setShadowsEnabled(previousViewport->getShadowsEnabled());
+    viewport->setVisibilityMask(previousViewport->getVisibilityMask());
+
+    mViewport = viewport;
+    previousTarget->removeViewport(previousViewport->getZOrder());
+    if(viewport->getActualHeight() > 0)
+    {
+        mActiveCamera->setAspectRatio(static_cast<Ogre::Real>(viewport->getActualWidth())
+            / static_cast<Ogre::Real>(viewport->getActualHeight()));
+    }
+}
+
 const Ogre::Vector3& CameraManager::getActiveCameraPosition() const
 {
     return getActiveCameraNode()->getPosition();

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -163,6 +163,9 @@ public:
     Ogre::Viewport* getViewport()
     { return mViewport; }
 
+    //! \brief Move the main camera viewport to another render window.
+    void setRenderWindow(Ogre::RenderWindow* renderWindow);
+
     void resetHCSNodes(int nodeValue)
     {
         mXHCS.resetNodes(nodeValue);

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -131,6 +131,15 @@ public:
     */
     void move(const Direction direction, double aux = 0.0);
 
+    //! Continuous input is sampled once per frame, independent of key repeat.
+    void setControls(const Ogre::Vector2& pan, Ogre::Real zoom, Ogre::Real swivel, bool fast);
+    //! Pointer motion and wheel steps are distances, not persistent velocities.
+    void zoomBy(Ogre::Real distance);
+    void orbitBy(Ogre::Real swivel, Ogre::Real pitch);
+    void adjustUserView(Ogre::Real roll, Ogre::Real yaw, Ogre::Real pitch);
+    void loadUserView(unsigned int slot);
+    bool storeUserView(unsigned int slot);
+
     void createCameraNode(const std::string& name);
 
     void destroyCameraNode(const std::string& name);
@@ -194,6 +203,7 @@ private:
     //! \brief Moves the position so that the ground point the camera looks at from it
     //! stays within the map.
     void clampToMap(Ogre::Vector3& position) const;
+    void setViewOrientation(const Ogre::Quaternion& root, const Ogre::Quaternion& tilt);
 
     //! \brief HermiteCatmullSpline members for each axices.
     HermiteCatmullSpline mXHCS;
@@ -275,6 +285,9 @@ private:
     //! \brief User-tunable multiplier on the keyboard/autoscroll pan speed
     //! (1.0 keeps the historic speed). Set from the settings window.
     Ogre::Real mPanSpeedFactor;
+    Ogre::Real mFastPanFactor = 1.0f;
+    Ogre::Real mControlZoom = 0.0f;
+    Ogre::Real mControlSwivel = 0.0f;
 };
 
 #endif // CAMERAMANAGER_H_

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -248,6 +248,9 @@ private:
     Ogre::Vector3   mTranslateVector;
     Ogre::Vector3   mTranslateVectorAccel;
 
+    //! \brief Maximum pan speed per axis, used to scale mouse-edge scrolling.
+    Ogre::Vector2   mTranslateMaxSpeedFactor;
+
     //! \brief The X-axis rotation vector, tilting the point of view (look down or up).
     Ogre::Vector3   mRotateLocalVector;
 

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -107,6 +107,7 @@ public:
     Ogre::Vector3 getCameraViewTarget() const;
 
     void onMiniMapClick(Ogre::Vector2 cc);
+    void jumpToViewTarget(const Ogre::Vector2& pos);
 
     /** \brief Starts the camera moving towards a destination position,
      *  it will stop moving when it gets there.

--- a/source/camera/CullingManager.cpp
+++ b/source/camera/CullingManager.cpp
@@ -110,13 +110,12 @@ void CullingManager::stopTileCulling(const std::vector<Ogre::Vector3>& ogreVecto
 void CullingManager::hideAllTiles(void)
 {
     OD_LOG_INF("starting to hide all game tiles"); 
-    mGameMap->getTile(0,0)->getParentSceneNode()->removeAllChildren();
     for (int jj = 0; jj < mGameMap->getMapSizeY() ; ++jj)
     {
         for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
         {
             Tile* tile = mGameMap->getTile(ii, jj);
-            tile->setTileCullingFlags(mCullingMask, false, false);
+            tile->setTileCullingFlags(mCullingMask, false);
         }
     }
     OD_LOG_INF("done hiding all game tiles");
@@ -227,5 +226,4 @@ void CullingManager::sort(VectorInt64& p1, VectorInt64& p2, bool sortByX)
             std::swap(p1, p2);
     }
 }
-
 

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -509,6 +509,7 @@ bool Tile::isMarkedForDiggingByAnySeat()
 void Tile::addPlayerMarkingTile(const Player *p)
 {
     mPlayersMarkingTile.push_back(p);
+    fireTileStateChanged();
 }
 
 void Tile::removePlayerMarkingTile(const Player *p)
@@ -518,6 +519,7 @@ void Tile::removePlayerMarkingTile(const Player *p)
         return;
 
     mPlayersMarkingTile.erase(it);
+    fireTileStateChanged();
 }
 
 void Tile::addNeighbor(Tile *n)
@@ -2448,6 +2450,7 @@ Creature* Tile::getClosestCreature(SelectionEntityWanted se)
 
 void Tile::setLocalPlayerHasVision(bool localPlayerHasVision)
 {
+    const bool visionChanged = mLocalPlayerHasVision != localPlayerHasVision;
     bool mEverVisibleOld = mEverVisible;
     
     mEverVisible = mEverVisible || localPlayerHasVision;
@@ -2464,7 +2467,8 @@ void Tile::setLocalPlayerHasVision(bool localPlayerHasVision)
     }
 
     mLocalPlayerHasVision = localPlayerHasVision;
-
+    if(visionChanged)
+        fireTileStateChanged();
 }
 
 

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -258,7 +258,10 @@ public:
 
     inline void setEverVisible(bool s)
     {
+        if(mEverVisible == s)
+            return;
         mEverVisible = s;
+        fireTileStateChanged();
     }
 
     

--- a/source/gamemap/MiniMap.cpp
+++ b/source/gamemap/MiniMap.cpp
@@ -24,11 +24,17 @@
 #include "entities/Tile.h"
 #include "game/Player.h"
 #include "game/Seat.h"
+#include "gamemap/GameMap.h"
+#include "render/ODFrameListener.h"
+#include "camera/CameraManager.h"
 #include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 
 #include <CEGUI/BasicImage.h>
 #include <CEGUI/ImageManager.h>
+#include <CEGUI/Renderer.h>
+#include <CEGUI/System.h>
+#include <CEGUI/Texture.h>
 #include <CEGUI/Window.h>
 #include <cmath>
 
@@ -37,8 +43,16 @@ namespace
 class CircularMiniMapImage : public CEGUI::BasicImage
 {
 public:
-    explicit CircularMiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name) {}
-    explicit CircularMiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes) {}
+    explicit CircularMiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name), mDot(name + "Dot") { createDot(); }
+    explicit CircularMiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes), mDot(getName() + "Dot") { createDot(); }
+    ~CircularMiniMapImage() override
+    {
+        CEGUI::System::getSingleton().getRenderer()->destroyTexture(getName() + "DotTexture");
+    }
+
+    bool mShowDirection = false;
+    Ogre::Vector2 mDirectionStart;
+    Ogre::Vector2 mDirectionEnd;
 
     void render(CEGUI::GeometryBuffer& buffer, const CEGUI::Rectf& area,
         const CEGUI::Rectf* clip, const CEGUI::ColourRect& colours) const override
@@ -60,7 +74,37 @@ public:
             if(strip.getWidth() > 0.0f && strip.getHeight() > 0.0f)
                 CEGUI::BasicImage::render(buffer, area, &strip, colours);
         }
+        if(!mShowDirection)
+            return;
+        const Ogre::Vector2 start(area.left() + mDirectionStart.x * area.getWidth(),
+            area.top() + mDirectionStart.y * area.getHeight());
+        const Ogre::Vector2 end(area.left() + mDirectionEnd.x * area.getWidth(),
+            area.top() + mDirectionEnd.y * area.getHeight());
+        const Ogre::Vector2 direction = end - start;
+        const float length = direction.length();
+        if(length < 1.0f)
+            return;
+        for(float distance = 0.0f; distance <= length; distance += 5.0f)
+        {
+            const Ogre::Vector2 dot = start + direction * (distance / length);
+            const float x = (dot.x - centerX) / std::max(1.0f, radiusX - 2.0f);
+            const float y = (dot.y - area.top() - radiusY) / std::max(1.0f, radiusY - 2.0f);
+            if(x * x + y * y > 1.0f)
+                continue;
+            const CEGUI::Rectf rect(dot.x - 1.0f, dot.y - 1.0f, dot.x + 1.0f, dot.y + 1.0f);
+            mDot.render(buffer, rect, clip, colours);
+        }
     }
+private:
+    void createDot()
+    {
+        CEGUI::Texture& texture = CEGUI::System::getSingleton().getRenderer()->createTexture(getName() + "DotTexture");
+        const unsigned char white[] = {255, 255, 255, 255};
+        texture.loadFromMemory(white, CEGUI::Sizef(1, 1), CEGUI::Texture::PF_RGBA);
+        mDot.setTexture(&texture);
+        mDot.setArea(CEGUI::Rectf(0, 0, 1, 1));
+    }
+    CEGUI::BasicImage mDot;
 };
 }
 
@@ -83,6 +127,41 @@ void MiniMap::setZoomLevel(int level)
 Ogre::Real MiniMap::getZoomScale() const
 {
     return std::ldexp(1.0f, -mZoomLevel);
+}
+
+void MiniMap::updateHeartDirection(CEGUI::Window* window, GameMap& map,
+        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation)
+{
+    auto* image = dynamic_cast<CircularMiniMapImage*>(
+        &CEGUI::ImageManager::getSingleton().get(window->getProperty("Image")));
+    if(image == nullptr)
+        return;
+    image->mShowDirection = false;
+    if(getZoomLevel() <= 0)
+    {
+        const auto project = [&centre, &span, rotation](const Ogre::Vector2& world)
+        {
+            const Ogre::Vector2 delta = world - centre;
+            const float x = delta.x * std::cos(rotation) + delta.y * std::sin(rotation);
+            const float y = -delta.x * std::sin(rotation) + delta.y * std::cos(rotation);
+            return Ogre::Vector2(0.5f + x / span.x, 0.5f - y / span.y);
+        };
+        const Ogre::Vector3 target = ODFrameListener::getSingleton().getCameraManager()->getCameraViewTarget();
+        image->mDirectionStart = project(Ogre::Vector2(target.x, target.y));
+        Seat* owner = map.getLocalPlayer()->getSeat();
+        for(int y = 0; y < map.getMapSizeY() && !image->mShowDirection; ++y)
+            for(int x = 0; x < map.getMapSizeX(); ++x)
+            {
+                Tile* tile = map.getTile(x, y);
+                if(tile->getEverVisible() && tile->getSeat() == owner && tile->getTileVisual() == TileVisual::dungeonTempleRoom)
+                {
+                    image->mDirectionEnd = project(Ogre::Vector2(x, y));
+                    image->mShowDirection = true;
+                    break;
+                }
+            }
+    }
+    window->invalidate();
 }
 
 MiniMap::TileColour MiniMap::colourFromTile(Tile& tile, Seat& playerSeat, unsigned int phase)
@@ -204,7 +283,7 @@ static std::vector<std::string> buildMiniMapTypes()
 
 };
 
-const std::string& MiniMap::DEFAULT_MINIMAP = MiniMapTypes::MINIMAP_CAMERA;
+const std::string& MiniMap::DEFAULT_MINIMAP = MiniMapTypes::MINIMAP_DRAWN;
 
 MiniMap* MiniMap::createMiniMap(CEGUI::Window* miniMapWindow)
 {
@@ -219,7 +298,7 @@ MiniMap* MiniMap::createMiniMap(CEGUI::Window* miniMapWindow)
 
     OD_LOG_ERR("Couldn't find requested minimap=" + minimapType);
     // Per default, we return the default minimap
-    return new MiniMapCamera(miniMapWindow);
+    return new MiniMapDrawn(miniMapWindow);
 }
 
 const std::vector<std::string>& MiniMap::getMiniMapTypes()

--- a/source/gamemap/MiniMap.cpp
+++ b/source/gamemap/MiniMap.cpp
@@ -40,17 +40,19 @@
 
 namespace
 {
-class CircularMiniMapImage : public CEGUI::BasicImage
+class MiniMapImage : public CEGUI::BasicImage
 {
 public:
-    explicit CircularMiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name), mDot(name + "Dot") { createDot(); }
-    explicit CircularMiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes), mDot(getName() + "Dot") { createDot(); }
-    ~CircularMiniMapImage() override
+    explicit MiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name), mDot(name + "Dot") { createDot(); }
+    explicit MiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes), mDot(getName() + "Dot") { createDot(); }
+    ~MiniMapImage() override
     {
         CEGUI::System::getSingleton().getRenderer()->destroyTexture(getName() + "DotTexture");
     }
 
+    bool mCircular = true;
     bool mShowDirection = false;
+    std::vector<Ogre::Vector2> mViewport;
     Ogre::Vector2 mDirectionStart;
     Ogre::Vector2 mDirectionEnd;
 
@@ -63,7 +65,9 @@ public:
         const float radiusX = area.getWidth() * 0.5f;
         const float radiusY = area.getHeight() * 0.5f;
         const float centerX = area.left() + radiusX;
-        for(float y = area.top(); y < area.bottom(); y += 1.0f)
+        if(!mCircular)
+            CEGUI::BasicImage::render(buffer, area, clip, colours);
+        else for(float y = area.top(); y < area.bottom(); y += 1.0f)
         {
             const float nextY = std::min(y + 1.0f, area.bottom());
             const float dy = ((y + nextY) * 0.5f - area.top() - radiusY) / radiusY;
@@ -74,28 +78,67 @@ public:
             if(strip.getWidth() > 0.0f && strip.getHeight() > 0.0f)
                 CEGUI::BasicImage::render(buffer, area, &strip, colours);
         }
-        if(!mShowDirection)
+        if(mShowDirection)
+            drawLine(buffer, area, clip, colours, mDirectionStart, mDirectionEnd, true);
+        for(size_t i = 0; i < mViewport.size(); ++i)
+            drawLine(buffer, area, clip, colours, mViewport[i], mViewport[(i + 1) % mViewport.size()], false);
+    }
+
+private:
+    void drawLine(CEGUI::GeometryBuffer& buffer, const CEGUI::Rectf& area,
+            const CEGUI::Rectf* clip, const CEGUI::ColourRect& colours,
+            const Ogre::Vector2& from, const Ogre::Vector2& to, bool dotted) const
+    {
+        Ogre::Vector2 start(area.left() + from.x * area.getWidth(), area.top() + from.y * area.getHeight());
+        const Ogre::Vector2 direction((to.x - from.x) * area.getWidth(), (to.y - from.y) * area.getHeight());
+        const CEGUI::Rectf bounds = clip == nullptr ? area : area.getIntersection(*clip);
+        if(bounds.getWidth() <= 0.0f || bounds.getHeight() <= 0.0f)
             return;
-        const Ogre::Vector2 start(area.left() + mDirectionStart.x * area.getWidth(),
-            area.top() + mDirectionStart.y * area.getHeight());
-        const Ogre::Vector2 end(area.left() + mDirectionEnd.x * area.getWidth(),
-            area.top() + mDirectionEnd.y * area.getHeight());
-        const Ogre::Vector2 direction = end - start;
-        const float length = direction.length();
+        // Clip before sampling: camera ground intersections may be far outside the map.
+        float first = 0.0f, last = 1.0f;
+        const float p[] = {-direction.x, direction.x, -direction.y, direction.y};
+        const float q[] = {start.x - bounds.left(), bounds.right() - start.x,
+            start.y - bounds.top(), bounds.bottom() - start.y};
+        for(int edge = 0; edge < 4; ++edge)
+        {
+            if(p[edge] == 0.0f)
+            {
+                if(q[edge] < 0.0f)
+                    return;
+                continue;
+            }
+            const float distance = q[edge] / p[edge];
+            if(p[edge] < 0.0f)
+                first = std::max(first, distance);
+            else
+                last = std::min(last, distance);
+            if(first > last)
+                return;
+        }
+        start += direction * first;
+        const Ogre::Vector2 segment = direction * (last - first);
+        const float length = segment.length();
         if(length < 1.0f)
             return;
-        for(float distance = 0.0f; distance <= length; distance += 5.0f)
+        const float halfSize = dotted ? 1.0f : 0.5f;
+        for(float distance = 0.0f; distance <= length; distance += dotted ? 5.0f : 0.75f)
         {
-            const Ogre::Vector2 dot = start + direction * (distance / length);
-            const float x = (dot.x - centerX) / std::max(1.0f, radiusX - 2.0f);
-            const float y = (dot.y - area.top() - radiusY) / std::max(1.0f, radiusY - 2.0f);
-            if(x * x + y * y > 1.0f)
-                continue;
-            const CEGUI::Rectf rect(dot.x - 1.0f, dot.y - 1.0f, dot.x + 1.0f, dot.y + 1.0f);
-            mDot.render(buffer, rect, clip, colours);
+            const Ogre::Vector2 dot = start + segment * (distance / length);
+            if(mCircular)
+            {
+                const float radiusX = area.getWidth() * 0.5f, radiusY = area.getHeight() * 0.5f;
+                const float x = (dot.x - area.left() - radiusX) / std::max(1.0f, radiusX - halfSize - 1.0f);
+                const float y = (dot.y - area.top() - radiusY) / std::max(1.0f, radiusY - halfSize - 1.0f);
+                if(x * x + y * y > 1.0f)
+                    continue;
+            }
+            const float left = std::floor(dot.x - halfSize + 0.5f);
+            const float top = std::floor(dot.y - halfSize + 0.5f);
+            mDot.render(buffer, CEGUI::Rectf(left, top,
+                left + halfSize * 2.0f, top + halfSize * 2.0f), &bounds, colours);
         }
     }
-private:
+
     void createDot()
     {
         CEGUI::Texture& texture = CEGUI::System::getSingleton().getRenderer()->createTexture(getName() + "DotTexture");
@@ -108,15 +151,18 @@ private:
 };
 }
 
-CEGUI::BasicImage& MiniMap::createMiniMapImage(CEGUI::Window* miniMapWindow, const std::string& name)
+CEGUI::BasicImage& MiniMap::createMiniMapImage(CEGUI::Window* miniMapWindow, const std::string& name, bool showViewport)
 {
     CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
     const bool circular = miniMapWindow->isUserStringDefined("Circular") &&
         miniMapWindow->getUserString("Circular") == "true";
-    if(circular && !images.isImageTypeAvailable("CircularMiniMap"))
-        images.addImageType<CircularMiniMapImage>("CircularMiniMap");
-    return static_cast<CEGUI::BasicImage&>(images.create(
-        circular ? "CircularMiniMap" : "BasicImage", name));
+    if(!circular && !showViewport)
+        return static_cast<CEGUI::BasicImage&>(images.create("BasicImage", name));
+    if(!images.isImageTypeAvailable("MiniMap"))
+        images.addImageType<MiniMapImage>("MiniMap");
+    auto& image = static_cast<MiniMapImage&>(images.create("MiniMap", name));
+    image.mCircular = circular;
+    return image;
 }
 
 void MiniMap::setZoomLevel(int level)
@@ -129,23 +175,26 @@ Ogre::Real MiniMap::getZoomScale() const
     return std::ldexp(1.0f, -mZoomLevel);
 }
 
-void MiniMap::updateHeartDirection(CEGUI::Window* window, GameMap& map,
-        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation)
+void MiniMap::updateMapOverlay(CEGUI::Window* window, GameMap& map,
+        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation, const std::vector<Ogre::Vector3>& cornerTiles)
 {
-    auto* image = dynamic_cast<CircularMiniMapImage*>(
+    auto* image = dynamic_cast<MiniMapImage*>(
         &CEGUI::ImageManager::getSingleton().get(window->getProperty("Image")));
     if(image == nullptr)
         return;
-    image->mShowDirection = false;
-    if(getZoomLevel() <= 0)
+    const auto project = [&centre, &span, rotation](const Ogre::Vector2& world)
     {
-        const auto project = [&centre, &span, rotation](const Ogre::Vector2& world)
-        {
-            const Ogre::Vector2 delta = world - centre;
-            const float x = delta.x * std::cos(rotation) + delta.y * std::sin(rotation);
-            const float y = -delta.x * std::sin(rotation) + delta.y * std::cos(rotation);
-            return Ogre::Vector2(0.5f + x / span.x, 0.5f - y / span.y);
-        };
+        const Ogre::Vector2 delta = world - centre;
+        const float x = delta.x * std::cos(rotation) + delta.y * std::sin(rotation);
+        const float y = -delta.x * std::sin(rotation) + delta.y * std::cos(rotation);
+        return Ogre::Vector2(0.5f + x / span.x, 0.5f - y / span.y);
+    };
+    image->mViewport.clear();
+    for(const Ogre::Vector3& corner : cornerTiles)
+        image->mViewport.push_back(project(Ogre::Vector2(corner.x, corner.y)));
+    image->mShowDirection = false;
+    if(image->mCircular && getZoomLevel() <= 0)
+    {
         const Ogre::Vector3 target = ODFrameListener::getSingleton().getCameraManager()->getCameraViewTarget();
         image->mDirectionStart = project(Ogre::Vector2(target.x, target.y));
         Seat* owner = map.getLocalPlayer()->getSeat();

--- a/source/gamemap/MiniMap.cpp
+++ b/source/gamemap/MiniMap.cpp
@@ -20,8 +20,172 @@
 #include "gamemap/MiniMapCamera.h"
 #include "gamemap/MiniMapDrawn.h"
 #include "gamemap/MiniMapDrawnFull.h"
+#include "entities/GameEntityType.h"
+#include "entities/Tile.h"
+#include "game/Player.h"
+#include "game/Seat.h"
 #include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
+
+#include <CEGUI/BasicImage.h>
+#include <CEGUI/ImageManager.h>
+#include <CEGUI/Window.h>
+#include <cmath>
+
+namespace
+{
+class CircularMiniMapImage : public CEGUI::BasicImage
+{
+public:
+    explicit CircularMiniMapImage(const CEGUI::String& name) : CEGUI::BasicImage(name) {}
+    explicit CircularMiniMapImage(const CEGUI::XMLAttributes& attributes) : CEGUI::BasicImage(attributes) {}
+
+    void render(CEGUI::GeometryBuffer& buffer, const CEGUI::Rectf& area,
+        const CEGUI::Rectf* clip, const CEGUI::ColourRect& colours) const override
+    {
+        if(area.getWidth() <= 0.0f || area.getHeight() <= 0.0f)
+            return;
+        // Clip the existing texture, preserving its coordinates and all renderer choices.
+        const float radiusX = area.getWidth() * 0.5f;
+        const float radiusY = area.getHeight() * 0.5f;
+        const float centerX = area.left() + radiusX;
+        for(float y = area.top(); y < area.bottom(); y += 1.0f)
+        {
+            const float nextY = std::min(y + 1.0f, area.bottom());
+            const float dy = ((y + nextY) * 0.5f - area.top() - radiusY) / radiusY;
+            const float halfWidth = radiusX * std::sqrt(std::max(0.0f, 1.0f - dy * dy));
+            CEGUI::Rectf strip(centerX - halfWidth, y, centerX + halfWidth, nextY);
+            if(clip != nullptr)
+                strip = strip.getIntersection(*clip);
+            if(strip.getWidth() > 0.0f && strip.getHeight() > 0.0f)
+                CEGUI::BasicImage::render(buffer, area, &strip, colours);
+        }
+    }
+};
+}
+
+CEGUI::BasicImage& MiniMap::createMiniMapImage(CEGUI::Window* miniMapWindow, const std::string& name)
+{
+    CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
+    const bool circular = miniMapWindow->isUserStringDefined("Circular") &&
+        miniMapWindow->getUserString("Circular") == "true";
+    if(circular && !images.isImageTypeAvailable("CircularMiniMap"))
+        images.addImageType<CircularMiniMapImage>("CircularMiniMap");
+    return static_cast<CEGUI::BasicImage&>(images.create(
+        circular ? "CircularMiniMap" : "BasicImage", name));
+}
+
+void MiniMap::setZoomLevel(int level)
+{
+    mZoomLevel = std::max(-3, std::min(2, level));
+}
+
+Ogre::Real MiniMap::getZoomScale() const
+{
+    return std::ldexp(1.0f, -mZoomLevel);
+}
+
+MiniMap::TileColour MiniMap::colourFromTile(Tile& tile, Seat& playerSeat, unsigned int phase)
+{
+    TileColour result;
+    if(!tile.getEverVisible())
+        return result;
+
+    const TileVisual visual = tile.getTileVisual();
+    Seat* owner = tile.getSeat();
+    const bool room = visual >= TileVisual::dungeonTempleRoom && visual < TileVisual::countTileVisual;
+    result.priority = 1;
+    if(room || visual == TileVisual::claimedGround || visual == TileVisual::claimedFull)
+    {
+        result.priority = 3;
+        if(room && (owner == nullptr || owner->isRogueSeat()))
+        {
+            const Ogre::ColourValue colours[] = {Ogre::ColourValue::Red, Ogre::ColourValue::Green,
+                Ogre::ColourValue::Blue, Ogre::ColourValue(1.0f, 1.0f, 0.0f)};
+            result.colour = colours[phase % 4];
+            result.animated = true;
+        }
+        else
+        {
+            result.colour = owner == nullptr ? Ogre::ColourValue(0.36f, 0.18f, 0.05f) : owner->getColorValue();
+            if(visual == TileVisual::dungeonTempleRoom)
+                result.colour = result.colour * 0.65f + Ogre::ColourValue::White * 0.35f;
+            else if(visual == TileVisual::claimedFull)
+                result.colour = result.colour * 0.45f;
+        }
+    }
+    else
+    {
+        switch(visual)
+        {
+            case TileVisual::dirtGround:
+            case TileVisual::goldGround:
+            case TileVisual::gemGround:
+            case TileVisual::rockGround:
+                result.colour = Ogre::ColourValue(0.82f, 0.70f, 0.50f);
+                break;
+            case TileVisual::dirtFull:
+                result.colour = Ogre::ColourValue(0.36f, 0.18f, 0.05f);
+                break;
+            case TileVisual::rockFull:
+                result.colour = Ogre::ColourValue(0.20f, 0.10f, 0.04f);
+                break;
+            case TileVisual::goldFull:
+                result.colour = Ogre::ColourValue(1.0f, 0.90f, 0.0f);
+                result.priority = 4;
+                break;
+            case TileVisual::gemFull:
+                result.colour = Ogre::ColourValue(0.63f, 0.0f, 0.82f);
+                result.priority = 4;
+                break;
+            case TileVisual::waterGround:
+                result.colour = Ogre::ColourValue(0.13f, 0.21f, 0.48f);
+                result.priority = 2;
+                break;
+            case TileVisual::lavaGround:
+                result.colour = Ogre::ColourValue(0.72f, 0.30f, 0.15f);
+                result.priority = 2;
+                break;
+            default:
+                break;
+        }
+    }
+    if(tile.getMarkedForDigging(playerSeat.getPlayer()))
+    {
+        result.colour = Ogre::ColourValue(0.0f, 1.0f, 1.0f);
+        result.priority = 5;
+    }
+    if(tile.getLocalPlayerHasVision())
+    {
+        for(GameEntity* entity : tile.getEntitiesInTile())
+        {
+            if(entity->getObjectType() == GameEntityType::creature)
+            {
+                Seat* creatureOwner = entity->getSeat();
+                if(creatureOwner == &playerSeat)
+                {
+                    result.animated = true;
+                    if(phase % 2 == 0 && result.priority < 7)
+                    {
+                        result.colour = Ogre::ColourValue::Black;
+                        result.priority = 7;
+                    }
+                }
+                else
+                {
+                    result.colour = creatureOwner == nullptr ? Ogre::ColourValue::White : creatureOwner->getColorValue();
+                    result.priority = 8;
+                }
+            }
+            else if(result.priority < 6 && entity->tryPickup(&playerSeat))
+            {
+                result.colour = Ogre::ColourValue(0.87f, 0.87f, 0.07f);
+                result.priority = 6;
+            }
+        }
+    }
+    return result;
+}
 
 namespace MiniMapTypes
 {

--- a/source/gamemap/MiniMap.h
+++ b/source/gamemap/MiniMap.h
@@ -48,7 +48,7 @@ public:
     //! \brief This function will create the minimap according to user preferences
     static MiniMap* createMiniMap(CEGUI::Window* miniMapWindow);
     static CEGUI::BasicImage& createMiniMapImage(CEGUI::Window* miniMapWindow,
-        const std::string& name = "MiniMapImageset");
+        const std::string& name = "MiniMapImageset", bool showViewport = false);
 
     void setZoomLevel(int level);
     int getZoomLevel() const { return mZoomLevel; }
@@ -64,8 +64,8 @@ protected:
         bool animated = false;
     };
     static TileColour colourFromTile(Tile& tile, Seat& playerSeat, unsigned int phase);
-    void updateHeartDirection(CEGUI::Window* window, GameMap& map,
-        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation);
+    void updateMapOverlay(CEGUI::Window* window, GameMap& map,
+        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation, const std::vector<Ogre::Vector3>& cornerTiles);
     Ogre::Real mAnimationTime = 0.0f;
 private:
     int mZoomLevel = 0;

--- a/source/gamemap/MiniMap.h
+++ b/source/gamemap/MiniMap.h
@@ -19,11 +19,16 @@
 #define MINIMAP_H
 
 #include <OgrePrerequisites.h>
+#include <OgreColourValue.h>
 
 namespace CEGUI
 {
+class BasicImage;
 class Window;
 }
+
+class Tile;
+class Seat;
 
 class MiniMap
 {
@@ -41,9 +46,26 @@ public:
 
     //! \brief This function will create the minimap according to user preferences
     static MiniMap* createMiniMap(CEGUI::Window* miniMapWindow);
+    static CEGUI::BasicImage& createMiniMapImage(CEGUI::Window* miniMapWindow,
+        const std::string& name = "MiniMapImageset");
+
+    void setZoomLevel(int level);
+    int getZoomLevel() const { return mZoomLevel; }
+    Ogre::Real getZoomScale() const;
 
     // Returns the list of all possible minimap types
     static const std::vector<std::string>& getMiniMapTypes();
+protected:
+    struct TileColour
+    {
+        Ogre::ColourValue colour = Ogre::ColourValue::Black;
+        unsigned int priority = 0;
+        bool animated = false;
+    };
+    static TileColour colourFromTile(Tile& tile, Seat& playerSeat, unsigned int phase);
+    Ogre::Real mAnimationTime = 0.0f;
+private:
+    int mZoomLevel = 0;
 };
 
 #endif // MINIMAP_H

--- a/source/gamemap/MiniMap.h
+++ b/source/gamemap/MiniMap.h
@@ -29,6 +29,7 @@ class Window;
 
 class Tile;
 class Seat;
+class GameMap;
 
 class MiniMap
 {
@@ -63,6 +64,8 @@ protected:
         bool animated = false;
     };
     static TileColour colourFromTile(Tile& tile, Seat& playerSeat, unsigned int phase);
+    void updateHeartDirection(CEGUI::Window* window, GameMap& map,
+        const Ogre::Vector2& centre, const Ogre::Vector2& span, Ogre::Real rotation);
     Ogre::Real mAnimationTime = 0.0f;
 private:
     int mZoomLevel = 0;

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -168,9 +168,9 @@ void MiniMapCamera::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre
 
     Ogre::RenderTarget* rt = mMiniMapOgreTexture->getBuffer()->getRenderTarget();
     rt->update();
-    updateHeartDirection(mMiniMapWindow, mGameMap, Ogre::Vector2(mCurCamPosX, mCurCamPosY),
+    updateMapOverlay(mMiniMapWindow, mGameMap, Ogre::Vector2(mCurCamPosX, mCurCamPosY),
         Ogre::Vector2::UNIT_SCALE * NB_TILES_DISPLAYED_IN_MINIMAP * getZoomScale(),
-        mUseViewCenter ? 0.0f : mMiniMapCamNode->getOrientation().getRoll().valueRadians());
+        mUseViewCenter ? 0.0f : mMiniMapCamNode->getOrientation().getRoll().valueRadians(), cornerTiles);
 }
 
 void MiniMapCamera::updateMinimapCamera()

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -95,7 +95,7 @@ MiniMapCamera::MiniMapCamera(CEGUI::Window* miniMapWindow) :
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
         CEGUI::Size<float>(static_cast<float>(TEXTURE_SIZE), static_cast<float>(TEXTURE_SIZE))));
 

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -168,6 +168,9 @@ void MiniMapCamera::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre
 
     Ogre::RenderTarget* rt = mMiniMapOgreTexture->getBuffer()->getRenderTarget();
     rt->update();
+    updateHeartDirection(mMiniMapWindow, mGameMap, Ogre::Vector2(mCurCamPosX, mCurCamPosY),
+        Ogre::Vector2::UNIT_SCALE * NB_TILES_DISPLAYED_IN_MINIMAP * getZoomScale(),
+        mUseViewCenter ? 0.0f : mMiniMapCamNode->getOrientation().getRoll().valueRadians());
 }
 
 void MiniMapCamera::updateMinimapCamera()

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -140,14 +140,15 @@ Ogre::Vector2 MiniMapCamera::camera_2dPositionFromClick(int xx, int yy)
     if(mCurCamPosY == -1)
         return Ogre::Vector2::ZERO;
 
-    const Ogre::Quaternion& orientation = mCameraManager.getActiveCameraNode()->getOrientation();
-    Ogre::Radian angle = orientation.getRoll();
+    const Ogre::Quaternion& orientation = mMiniMapCamNode->getOrientation();
+    Ogre::Radian angle = mUseViewCenter ? Ogre::Radian(0.0f) : orientation.getRoll();
     Ogre::Real cos = Ogre::Math::Cos(angle);
     Ogre::Real sin = Ogre::Math::Sin(angle);
 
     // Compute tile clicked
-    Ogre::Real diffX = ((xx - mTopLeftCornerX) / mWidth - 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
-    Ogre::Real diffY = ((mTopLeftCornerY - yy) / mHeight + 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP;
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
+    Ogre::Real diffX = ((xx - mTopLeftCornerX) / displaySize.d_width - 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP * getZoomScale();
+    Ogre::Real diffY = ((mTopLeftCornerY - yy) / displaySize.d_height + 0.5) * NB_TILES_DISPLAYED_IN_MINIMAP * getZoomScale();
 
     Ogre::Vector2 pos(diffX * cos - diffY * sin + mCurCamPosX, diffX * sin + diffY * cos + mCurCamPosY);
     OD_LOG_INF("Clicked minimap pos=" + Helper::toString(pos.x) + ", " + Helper::toString(pos.y));
@@ -171,22 +172,31 @@ void MiniMapCamera::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre
 
 void MiniMapCamera::updateMinimapCamera()
 {
-    const Ogre::Vector3& camPos = mCameraManager.getActiveCameraNode()->getPosition();
-    mCurCamPosX = Helper::round(camPos.x);
-    mCurCamPosY = Helper::round(camPos.y);
+    const Ogre::Vector3 camPos = mCameraManager.getCameraViewTarget();
+    mCurCamPosX = Helper::round(mUseViewCenter ? mViewCenter.x : camPos.x);
+    mCurCamPosY = Helper::round(mUseViewCenter ? mViewCenter.y : camPos.y);
 
     const Ogre::Quaternion& orientation = mCameraManager.getActiveCameraNode()->getOrientation();
-    mMiniMapCamNode->setPosition(mCurCamPosX, mCurCamPosY, CAM_HEIGHT);
+    mMiniMapCamNode->setPosition(mCurCamPosX, mCurCamPosY, CAM_HEIGHT * getZoomScale());
     mMiniMapCamNode->lookAt(Ogre::Vector3(mCurCamPosX, mCurCamPosY, 0.0),
                      Ogre::Node::TransformSpace::TS_WORLD);
     Ogre::Quaternion qq;
-    qq.FromAngleAxis(orientation.getRoll(), Ogre::Vector3::UNIT_Z);
+    qq.FromAngleAxis(mUseViewCenter ? Ogre::Radian(0.0f) : orientation.getRoll(), Ogre::Vector3::UNIT_Z);
     mMiniMapCamNode->setOrientation(qq);
+    mMiniMapCamNode->_update(true, false);
+}
+
+void MiniMapCamera::setViewCenter(const Ogre::Vector2& center)
+{
+    if(!mUseViewCenter || mViewCenter != center)
+        mElapsedTime = MIN_TIME_REFRESH_SECS;
+    mUseViewCenter = true;
+    mViewCenter = center;
 }
 
 void MiniMapCamera::preRenderTargetUpdate(const Ogre::RenderTargetEvent& rte)
 {
-    RenderManager::getSingleton().rrMinimapRendering(false);
+    RenderManager::getSingleton().rrMinimapRendering(false, mUseViewCenter);
 }
 
 void MiniMapCamera::postRenderTargetUpdate(const Ogre::RenderTargetEvent& rte)

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -123,6 +123,7 @@ MiniMapCamera::~MiniMapCamera()
     rt->removeAllListeners();
     Ogre::SceneManager* sceneManager = RenderManager::getSingleton().getSceneManager();
     sceneManager->destroyCamera(mMiniMapCam);
+    sceneManager->destroySceneNode(mMiniMapCamNode);
     Ogre::String mm("miniMapOgreTexture");
     Ogre::TextureManager::getSingletonPtr()->remove(mm,Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     CEGUI::ImageManager::getSingletonPtr()->destroy("MiniMapImageset");
@@ -131,6 +132,8 @@ MiniMapCamera::~MiniMapCamera()
 
 Ogre::Vector2 MiniMapCamera::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     if(mCurCamPosX == -1)
         return Ogre::Vector2::ZERO;
 

--- a/source/gamemap/MiniMapCamera.h
+++ b/source/gamemap/MiniMapCamera.h
@@ -47,6 +47,9 @@ public:
 
     void update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre::Vector3>& cornerTiles) override;
 
+    //! Use the same minimap camera as a full-map detail view.
+    void setViewCenter(const Ogre::Vector2& center);
+
     //! This functions allow to hook minimap rendering to adjust nodes we want to display or not
     virtual void preRenderTargetUpdate(const Ogre::RenderTargetEvent& rte) override;
     virtual void postRenderTargetUpdate(const Ogre::RenderTargetEvent& rte) override;
@@ -72,6 +75,8 @@ private:
 
     int mCurCamPosX;
     int mCurCamPosY;
+    bool mUseViewCenter = false;
+    Ogre::Vector2 mViewCenter = Ogre::Vector2::ZERO;
     Ogre::Camera* mMiniMapCam;
     Ogre::SceneNode* mMiniMapCamNode;
 

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -96,6 +96,8 @@ MiniMapDrawn::~MiniMapDrawn()
 
 Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Real mm, nn, oo, pp;
     // Compute move and normalise
     mm = (xx - mTopLeftCornerX) / static_cast<double>(mWidth) - 0.5;

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -165,6 +165,6 @@ void MiniMapDrawn::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre:
     }
 
     mPixelBuffer->unlock();
-    updateHeartDirection(mMiniMapWindow, mGameMap, mCamera_2dPosition,
-        Ogre::Vector2(mWidth, mHeight) * (getZoomScale() / mGrainSize), rotation);
+    updateMapOverlay(mMiniMapWindow, mGameMap, mCamera_2dPosition,
+        Ogre::Vector2(mWidth, mHeight) * (getZoomScale() / mGrainSize), rotation, cornerTiles);
 }

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -29,6 +29,8 @@
 #include "gamemap/GameMap.h"
 #include "render/ODFrameListener.h"
 
+#include <cmath>
+
 #include <OgrePrerequisites.h>
 #include <OgreSceneNode.h>
 #include <OgreTextureManager.h>
@@ -106,14 +108,13 @@ Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
     oo = nn * mSinRotation + mm * mCosRotation;
     pp = nn * mCosRotation - mm * mSinRotation;
     // Apply result to camera
-    mCamera_2dPosition.x += static_cast<Ogre::Real>(oo * mWidth / mGrainSize);
-    mCamera_2dPosition.y -= static_cast<Ogre::Real>(pp * mHeight / mGrainSize);
-
-    return mCamera_2dPosition;
+    return mCamera_2dPosition + Ogre::Vector2(oo * mWidth / mGrainSize,
+        -pp * mHeight / mGrainSize) * getZoomScale();
 }
 
 void MiniMapDrawn::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre::Vector3>& cornerTiles)
 {
+    mAnimationTime = std::fmod(mAnimationTime + timeSinceLastFrame, 2.0f);
     Ogre::Vector3 vv = mCameraManager.getCameraViewTarget();
     double rotation = mCameraManager.getActiveCameraNode()->getOrientation().getRoll().valueRadians();
     mCamera_2dPosition = Ogre::Vector2(vv.x, vv.y);
@@ -127,8 +128,8 @@ void MiniMapDrawn::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre:
              jj >= 0; ++nn, jj -= mGrainSize)
         {
             // Applying rotation
-            int oo = mCamera_2dPosition.x + static_cast<int>((mm - mCamera_2dPosition.x) * mCosRotation - (nn - mCamera_2dPosition.y) * mSinRotation);
-            int pp = mCamera_2dPosition.y + static_cast<int>((mm - mCamera_2dPosition.x) * mSinRotation + (nn - mCamera_2dPosition.y) * mCosRotation);
+            int oo = mCamera_2dPosition.x + static_cast<int>(((mm - mCamera_2dPosition.x) * mCosRotation - (nn - mCamera_2dPosition.y) * mSinRotation) * getZoomScale());
+            int pp = mCamera_2dPosition.y + static_cast<int>(((mm - mCamera_2dPosition.x) * mSinRotation + (nn - mCamera_2dPosition.y) * mCosRotation) * getZoomScale());
 
             /*FIXME: even if we use a THREE byte pixel format (PF_R8G8B8),
              * for some reason it only works if we have FOUR increments
@@ -142,105 +143,11 @@ void MiniMapDrawn::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre:
                 continue;
             }
 
-            if(tile->getHasFogOfWar())
-            {
-                
-                drawPixel(ii,jj, 100, 100, 100);
-                continue;
-            }
-            if (tile->getMarkedForDigging(mGameMap.getLocalPlayer()))
-            {
-                drawPixel(ii, jj, 0xFF, 0xA8, 0x00);
-                continue;
-            }
-
-            switch (tile->getTileVisual())
-            {
-                case TileVisual::claimedGround:
-                {
-                    Seat* tempSeat = tile->getSeat();
-                    if (tempSeat != nullptr)
-                    {
-                        Ogre::ColourValue color = tempSeat->getColorValue();
-                        drawPixel(ii, jj, color.r*200.0, color.g*200.0, color.b*200.0);
-                    }
-                    else
-                    {
-                        drawPixel(ii, jj, 0x5C, 0x37, 0x1B);
-                    }
-                    break;
-                }
-
-                case TileVisual::claimedFull:
-                {
-                    Seat* tempSeat = tile->getSeat();
-                    if (tempSeat != nullptr)
-                    {
-                        Ogre::ColourValue color = tempSeat->getColorValue();
-                        drawPixel(ii, jj, color.r*255.0, color.g*255.0, color.b*255.0);
-                    }
-                    else
-                    {
-                        drawPixel(ii, jj, 0x86, 0x50, 0x28);
-                    }
-                    break;
-                }
-
-                case TileVisual::waterGround:
-                    drawPixel(ii, jj, 0x21, 0x36, 0x7A);
-                    break;
-
-                case TileVisual::lavaGround:
-                    drawPixel(ii, jj, 0xB2, 0x22, 0x22);
-                    break;
-
-                case TileVisual::dirtGround:
-                    drawPixel(ii, jj, 0x3B, 0x1D, 0x08);
-                    break;
-
-                case TileVisual::dirtFull:
-                    drawPixel(ii, jj, 0x5B, 0x2D, 0x0C);
-                    break;
-
-                case TileVisual::rockGround:
-                    drawPixel(ii, jj, 0x30, 0x30, 0x30);
-                    break;
-
-                case TileVisual::rockFull:
-                    drawPixel(ii, jj, 0x41, 0x41, 0x41);
-                    break;
-
-                case TileVisual::goldGround:
-                    drawPixel(ii, jj, 0x3B, 0x1D, 0x08);
-                    break;
-
-                case TileVisual::goldFull:
-                    drawPixel(ii, jj, 0xB5, 0xB3, 0x2F);
-                    break;
-
-                case TileVisual::nullTileVisual:
-                    drawPixel(ii, jj, 0x00, 0x00, 0x00);
-                    break;
-
-                default:
-                    drawPixel(ii,jj,0x00,0xFF,0x7F);
-                    break;
-            }
+            const TileColour colour = colourFromTile(*tile, *mGameMap.getLocalPlayer()->getSeat(),
+                static_cast<unsigned int>(mAnimationTime * 2.0f));
+            drawPixel(ii, jj, colour.colour.r * 255.0f, colour.colour.g * 255.0f, colour.colour.b * 255.0f);
         }
     }
-
-    // Draw creatures on map.
-    // std::vector<Creature*>::iterator updatedCreatureIndex = mGameMap->creatures.begin();
-    // for(; updatedCreatureIndex < mGameMap->creatures.end(); ++updatedCreatureIndex)
-    // {
-    //     if((*updatedCreatureIndex)->getIsOnMap())
-    //     {
-    //         double  ii = (*updatedCreatureIndex)->getPosition().x;
-    //         double  jj = (*updatedCreatureIndex)->getPosition().y;
-
-    //         drawPixel(ii, jj, 0x94, 0x0, 0x94);
-    //     }
-    // }
 
     auto output = mPixelBuffer->lock(mPixelBox, Ogre::HardwareBuffer::HBL_NORMAL);
 

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -70,7 +70,7 @@ MiniMapDrawn::MiniMapDrawn(CEGUI::Window* miniMapWindow) :
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
                                       CEGUI::Size<float>(
                                           static_cast<float>(mWidth), static_cast<float>(mHeight)
@@ -102,8 +102,9 @@ Ogre::Vector2 MiniMapDrawn::camera_2dPositionFromClick(int xx, int yy)
     mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Real mm, nn, oo, pp;
     // Compute move and normalise
-    mm = (xx - mTopLeftCornerX) / static_cast<double>(mWidth) - 0.5;
-    nn = (yy - mTopLeftCornerY) / static_cast<double>(mHeight) - 0.5;
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
+    mm = (xx - mTopLeftCornerX) / static_cast<double>(displaySize.d_width) - 0.5;
+    nn = (yy - mTopLeftCornerY) / static_cast<double>(displaySize.d_height) - 0.5;
     // Applying rotation
     oo = nn * mSinRotation + mm * mCosRotation;
     pp = nn * mCosRotation - mm * mSinRotation;

--- a/source/gamemap/MiniMapDrawn.cpp
+++ b/source/gamemap/MiniMapDrawn.cpp
@@ -165,4 +165,6 @@ void MiniMapDrawn::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre:
     }
 
     mPixelBuffer->unlock();
+    updateHeartDirection(mMiniMapWindow, mGameMap, mCamera_2dPosition,
+        Ogre::Vector2(mWidth, mHeight) * (getZoomScale() / mGrainSize), rotation);
 }

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -336,6 +336,10 @@ void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<O
     image.setArea(CEGUI::Rectf(mViewOrigin.x * mWidth, mViewOrigin.y * mHeight,
         (mViewOrigin.x + scale) * mWidth, (mViewOrigin.y + scale) * mHeight));
     mMiniMapWindow->invalidate();
+    updateHeartDirection(mMiniMapWindow, mGameMap,
+        Ogre::Vector2((mViewOrigin.x + scale * 0.5f) * mGameMap.getMapSizeX(),
+            (1.0f - mViewOrigin.y - scale * 0.5f) * mGameMap.getMapSizeY()),
+        Ogre::Vector2(mGameMap.getMapSizeX(), mGameMap.getMapSizeY()) * scale, 0.0f);
 
     const Ogre::Vector3& topRight = cornerTiles[0];
     const Ogre::Vector3& topLeft = cornerTiles[1];

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -24,6 +24,8 @@
 #include "gamemap/GameMap.h"
 #include "render/ODFrameListener.h"
 
+#include <cmath>
+
 #include <OgrePrerequisites.h>
 #include <OgreSceneNode.h>
 #include <OgreTextureManager.h>
@@ -67,10 +69,11 @@ public:
 
     void fireTileStateChanged()
     {
-        mMinimap.updateTileState(mMinimapXMin, mMinimapXMax, mMinimapYMin,
+        mAnimated = mMinimap.updateTileState(mMinimapXMin, mMinimapXMax, mMinimapYMin,
             mMinimapYMax, mTileXMin, mTileXMax, mTileYMin, mTileYMax);
     }
 
+    bool mAnimated = false;
     const uint32_t mMinimapXMin;
     const uint32_t mMinimapXMax;
     const uint32_t mMinimapYMin;
@@ -84,259 +87,32 @@ private:
     MiniMapDrawnFull& mMinimap;
 };
 
-//! \brief This enum represents the possible values a pixel can have in the minimap.
-//! If a pixel corresponds to several game tiles, the highest value will be used
-//! to display the pixel
-enum class MiniMapDrawnFullPixel
-{
-    dirtFull,
-    dirtGround,
-    rockFull,
-    rockGround,
-    claimedFull,
-    claimedGround,
-    lava,
-    water,
-    goldFull,
-    goldGround,
-    gemFull,
-    gemGround,
-    pickupEntity,
-    alliedCreature,
-    enemyCreature
-};
-
 namespace
 {
-MiniMapDrawnFullPixel getPixelValueFromTile(Seat& playerSeat, Tile& tile)
+void fillPixelRegion(const Ogre::ColourValue& colour, Ogre::PixelBox& output,
+        uint32_t xMin, uint32_t xMax, uint32_t yMin, uint32_t yMax)
 {
-    MiniMapDrawnFullPixel value = MiniMapDrawnFullPixel::dirtFull;
-    const std::vector<GameEntity*>& entities = tile.getEntitiesInTile();
-    for(GameEntity* entity : entities)
-    {
-        if(entity->getObjectType() == GameEntityType::creature)
-        {
-            if(!entity->getSeat()->isAlliedSeat(&playerSeat))
-            {
-                if(value < MiniMapDrawnFullPixel::enemyCreature)
-                    value = MiniMapDrawnFullPixel::enemyCreature;
-            }
-            else
-            {
-                if(value < MiniMapDrawnFullPixel::alliedCreature)
-                    value = MiniMapDrawnFullPixel::alliedCreature;
-            }
-        }
-        else if(entity->tryPickup(&playerSeat))
-        {
-            if(value < MiniMapDrawnFullPixel::pickupEntity)
-                value = MiniMapDrawnFullPixel::pickupEntity;
-        }
-    }
-
-    // If something interesting is on the tile, we return the computed value
-    if(value != MiniMapDrawnFullPixel::dirtFull)
-        return value;
-
-    // Otherwise, we compute a value according to its type
-    switch(tile.getTileVisual())
-    {
-        case TileVisual::lavaGround:
-            value = MiniMapDrawnFullPixel::lava;
-            break;
-        case TileVisual::waterGround:
-            value = MiniMapDrawnFullPixel::water;
-            break;
-        case TileVisual::goldFull:
-            value = MiniMapDrawnFullPixel::goldFull;
-            break;
-        case TileVisual::goldGround:
-            value = MiniMapDrawnFullPixel::goldGround;
-            break;
-        case TileVisual::gemFull:
-            value = MiniMapDrawnFullPixel::gemFull;
-            break;
-        case TileVisual::gemGround:
-            value = MiniMapDrawnFullPixel::gemGround;
-            break;
-        case TileVisual::rockFull:
-            value = MiniMapDrawnFullPixel::rockFull;
-            break;
-        case TileVisual::rockGround:
-            value = MiniMapDrawnFullPixel::rockGround;
-            break;
-        case TileVisual::claimedGround:
-            value = MiniMapDrawnFullPixel::claimedGround;
-            break;
-        case TileVisual::claimedFull:
-            value = MiniMapDrawnFullPixel::claimedFull;
-            break;
-        case TileVisual::dirtGround:
-            value = MiniMapDrawnFullPixel::dirtGround;
-            break;
-        case TileVisual::dirtFull:
-            value = MiniMapDrawnFullPixel::dirtFull;
-            break;
-        default:
-            break;
-    }
-
-    return value;
-}
-
-void colourFromPixelValue(MiniMapDrawnFullPixel pixelValue, Seat* seatIfClaimed,
-        Ogre::HardwarePixelBufferSharedPtr& pixelBuffer, Ogre::PixelBox pixelBox,
-        uint32_t minimapWidth, uint32_t minimapHeight, uint32_t minimapXMin,
-        uint32_t minimapXMax, uint32_t minimapYMin, uint32_t minimapYMax)
-{
-    Ogre::uint8 RR = 0x00;
-    Ogre::uint8 GG = 0x00;
-    Ogre::uint8 BB = 0x00;
-    switch(pixelValue)
-    {
-        case MiniMapDrawnFullPixel::enemyCreature:
-        {
-            RR = 0xFF;
-            GG = 0x00;
-            BB = 0x00;
-            break;
-        }
-        case MiniMapDrawnFullPixel::claimedFull:
-        {
-            if(seatIfClaimed == nullptr)
-            {
-                RR = 0x86;
-                GG = 0x50;
-                BB = 0x28;
-            }
-            else
-            {
-                const Ogre::ColourValue& color = seatIfClaimed->getColorValue();
-                RR = color.r * 255.0;
-                GG = color.g * 255.0;
-                BB = color.b * 255.0;
-            }
-            break;
-        }
-        case MiniMapDrawnFullPixel::claimedGround:
-        {
-            if(seatIfClaimed == nullptr)
-            {
-                RR = 0x5C;
-                GG = 0x37;
-                BB = 0x1B;
-            }
-            else
-            {
-                const Ogre::ColourValue& color = seatIfClaimed->getColorValue();
-                RR = color.r * 200.0;
-                GG = color.g * 200.0;
-                BB = color.b * 200.0;
-            }
-            break;
-        }
-        case MiniMapDrawnFullPixel::goldFull:
-        {
-            RR = 0xB5;
-            GG = 0xB3;
-            BB = 0x2F;
-            break;
-        }
-        case MiniMapDrawnFullPixel::goldGround:
-        {
-            RR = 0x3B;
-            GG = 0x1D;
-            BB = 0x08;
-            break;
-        }
-        case MiniMapDrawnFullPixel::water:
-        {
-            RR = 0x21;
-            GG = 0x36;
-            BB = 0x7A;
-            break;
-        }
-        case MiniMapDrawnFullPixel::lava:
-        {
-            RR = 0xB2;
-            GG = 0x22;
-            BB = 0x22;
-            break;
-        }
-        case MiniMapDrawnFullPixel::dirtGround:
-        {
-            RR = 0x3B;
-            GG = 0x1D;
-            BB = 0x08;
-            break;
-        }
-        case MiniMapDrawnFullPixel::dirtFull:
-        {
-            RR = 0x5B;
-            GG = 0x2D;
-            BB = 0x0C;
-            break;
-        }
-        case MiniMapDrawnFullPixel::rockGround:
-        {
-            RR = 0x30;
-            GG = 0x30;
-            BB = 0x30;
-            break;
-        }
-        case MiniMapDrawnFullPixel::rockFull:
-        {
-            RR = 0x41;
-            GG = 0x41;
-            BB = 0x41;
-            break;
-        }
-        default:
-        {
-            RR = 0x00;
-            GG = 0x00;
-            BB = 0xFF;
-            break;
-        }
-        case MiniMapDrawnFullPixel::pickupEntity:
-        {
-            RR = 0xDD;
-            GG = 0xDD;
-            BB = 0x12;
-            break;
-        }
-    }
-
-    auto output = pixelBuffer->lock(pixelBox, Ogre::HardwareBuffer::HBL_NORMAL);
-
-    assert(minimapXMax <= output.getWidth());
-    assert(minimapYMax <= output.getHeight());
-
-    for(size_t xx = minimapXMin; xx < minimapXMax; ++xx)
-    {
-        for(size_t yy = minimapYMin; yy < minimapYMax; ++yy)
-        {
-            // TODO: This is probably a bit inefficient at the moment.
-            output.setColourAt(Ogre::ColourValue(RR/255.0, GG/255.0, BB/255.0), xx, output.getHeight() - yy, 0);
-
-        }
-    }
-
-    pixelBuffer->unlock();
+    assert(xMax <= output.getWidth());
+    assert(yMax <= output.getHeight());
+    for(uint32_t x = xMin; x < xMax; ++x)
+        for(uint32_t y = yMin; y < yMax; ++y)
+            output.setColourAt(colour, x, output.getHeight() - 1 - y, 0);
 }
 }
 
-MiniMapDrawnFull::MiniMapDrawnFull(CEGUI::Window* miniMapWindow) :
+MiniMapDrawnFull::MiniMapDrawnFull(CEGUI::Window* miniMapWindow, const std::string& suffix) :
     mMiniMapWindow(miniMapWindow),
+    mResourceSuffix(suffix),
     mGameMap(*ODFrameListener::getSingleton().getClientGameMap()),
     mCameraManager(*ODFrameListener::getSingleton().getCameraManager()),
     mTopLeftCornerX(0),
     mTopLeftCornerY(0),
     mWidth(static_cast<unsigned int>(mMiniMapWindow->getPixelSize().d_width)),
     mHeight(static_cast<unsigned int>(mMiniMapWindow->getPixelSize().d_height)),
-    mPixelBox(mWidth, mHeight, 1, Ogre::PF_R8G8B8),
+    mPixels(mWidth * mHeight * 3, 0),
+    mPixelBox(mWidth, mHeight, 1, Ogre::PF_R8G8B8, mPixels.data()),
     mMiniMapOgreTexture(Ogre::TextureManager::getSingletonPtr()->createManual(
-            "miniMapOgreTexture",
+            "miniMapOgreTexture" + suffix,
             Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             Ogre::TEX_TYPE_2D,
             mWidth, mHeight, 0, Ogre::PF_R8G8B8,
@@ -404,10 +180,12 @@ MiniMapDrawnFull::MiniMapDrawnFull(CEGUI::Window* miniMapWindow) :
         listener->fireTileStateChanged();
     }
 
-    CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
-                                            ->getRenderer())->createTexture("miniMapTextureGui", mMiniMapOgreTexture);
+    mPixelBuffer->blitFromMemory(mPixelBox);
 
-    CEGUI::BasicImage& imageset = dynamic_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingletonPtr()->create("BasicImage", "MiniMapImageset"));
+    CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
+                                            ->getRenderer())->createTexture("miniMapTextureGui" + suffix, mMiniMapOgreTexture);
+
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow, "MiniMapImageset" + suffix);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
                                       CEGUI::Size<float>(
                                           static_cast<float>(mWidth), static_cast<float>(mHeight)
@@ -443,10 +221,10 @@ MiniMapDrawnFull::~MiniMapDrawnFull()
     }
     mTileStateListeners.clear();
     mMiniMapWindow->setProperty("Image", "");
-    Ogre::String mm("miniMapOgreTexture");
+    Ogre::String mm("miniMapOgreTexture" + mResourceSuffix);
     Ogre::TextureManager::getSingletonPtr()->remove(mm,Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);    
-    CEGUI::ImageManager::getSingletonPtr()->destroy("MiniMapImageset");
-    CEGUI::System::getSingletonPtr()->getRenderer()->destroyTexture("miniMapTextureGui");
+    CEGUI::ImageManager::getSingletonPtr()->destroy("MiniMapImageset" + mResourceSuffix);
+    CEGUI::System::getSingletonPtr()->getRenderer()->destroyTexture("miniMapTextureGui" + mResourceSuffix);
 }
 
 Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
@@ -454,54 +232,39 @@ Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
     mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
     mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Vector2 v(0, 0);
-    Ogre::Real gainX = static_cast<Ogre::Real>(mGameMap.getMapSizeX())
-        / static_cast<Ogre::Real>(mWidth);
-    Ogre::Real gainY = static_cast<Ogre::Real>(mGameMap.getMapSizeY())
-        / static_cast<Ogre::Real>(mHeight);
-
-    v.x = round(static_cast<Ogre::Real>(xx - mTopLeftCornerX) * gainX);
-    v.y = round(static_cast<Ogre::Real>(mHeight - yy + mTopLeftCornerY) * gainY);
+    const CEGUI::Sizef displaySize = mMiniMapWindow->getPixelSize();
+    v.x = std::max(0.0f, std::min(static_cast<Ogre::Real>(mGameMap.getMapSizeX() - 1),
+        (mViewOrigin.x + (xx - mTopLeftCornerX) / displaySize.d_width * mViewSize.x) * mGameMap.getMapSizeX()));
+    v.y = std::max(0.0f, std::min(static_cast<Ogre::Real>(mGameMap.getMapSizeY() - 1),
+        (1.0f - mViewOrigin.y - (yy - mTopLeftCornerY) / displaySize.d_height * mViewSize.y) * mGameMap.getMapSizeY()));
 
     return v;
 }
 
-void MiniMapDrawnFull::updateTileState(uint32_t minimapXMin, uint32_t minimapXMax,
+bool MiniMapDrawnFull::updateTileState(uint32_t minimapXMin, uint32_t minimapXMax,
         uint32_t minimapYMin, uint32_t minimapYMax, uint32_t tileXMin,
         uint32_t tileXMax, uint32_t tileYMin, uint32_t tileYMax)
 {
-    Seat& localPlayerSeat = *(mGameMap.getLocalPlayer()->getSeat());
-    // We compute the tile representation
-    MiniMapDrawnFullPixel curValue = MiniMapDrawnFullPixel::dirtFull;
-    Seat* seatIfClaimed = nullptr;
-    for(uint32_t xxx = tileXMin; xxx < tileXMax; ++xxx)
+    Seat& localPlayerSeat = *mGameMap.getLocalPlayer()->getSeat();
+    TileColour selected;
+    bool animated = false;
+    for(uint32_t x = tileXMin; x < tileXMax; ++x)
     {
-        for(uint32_t yyy = tileYMin; yyy < tileYMax; ++yyy)
+        for(uint32_t y = tileYMin; y < tileYMax; ++y)
         {
-            Tile* tile = mGameMap.getTile(xxx, yyy);
+            Tile* tile = mGameMap.getTile(x, y);
             if(tile == nullptr)
                 continue;
-
-            MiniMapDrawnFullPixel value = getPixelValueFromTile(localPlayerSeat,
-                *tile);
-            if(value > curValue)
-            {
-                curValue = value;
-                switch(value)
-                {
-                    case MiniMapDrawnFullPixel::claimedGround:
-                    case MiniMapDrawnFullPixel::claimedFull:
-                        seatIfClaimed = tile->getSeat();
-                        break;
-                    default:
-                        break;
-                }
-            }
+            const TileColour colour = colourFromTile(*tile, localPlayerSeat,
+                static_cast<unsigned int>(mAnimationTime * 2.0f));
+            animated |= colour.animated;
+            if(colour.priority > selected.priority)
+                selected = colour;
         }
     }
-
-    // We paint corresponding pixels
-    colourFromPixelValue(curValue, seatIfClaimed, mPixelBuffer, mPixelBox,
-        mWidth, mHeight, minimapXMin, minimapXMax, minimapYMin, minimapYMax);
+    fillPixelRegion(selected.colour, mPixelBox, minimapXMin, minimapXMax, minimapYMin, minimapYMax);
+    mPixelsDirty = true;
+    return animated;
 }
 
 bool MiniMapDrawnFull::crossSegment(const Ogre::Vector3& p1, const Ogre::Vector3& p2,
@@ -557,6 +320,23 @@ bool MiniMapDrawnFull::crossSegment(const Ogre::Vector3& p1, const Ogre::Vector3
 
 void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre::Vector3>& cornerTiles)
 {
+    const unsigned int oldPhase = static_cast<unsigned int>(mAnimationTime * 2.0f);
+    mAnimationTime = std::fmod(mAnimationTime + timeSinceLastFrame, 2.0f);
+    if(oldPhase != static_cast<unsigned int>(mAnimationTime * 2.0f))
+        for(MiniMapDrawnFullTileStateListener* listener : mTileStateListeners)
+            if(listener->mAnimated)
+                listener->fireTileStateChanged();
+
+    const Ogre::Real scale = std::min(1.0f, getZoomScale());
+    const Ogre::Vector3 target = mCameraManager.getCameraViewTarget();
+    mViewSize = Ogre::Vector2(scale, scale);
+    mViewOrigin.x = std::max(0.0f, std::min(1.0f - scale, target.x / mGameMap.getMapSizeX() - scale * 0.5f));
+    mViewOrigin.y = std::max(0.0f, std::min(1.0f - scale, 1.0f - target.y / mGameMap.getMapSizeY() - scale * 0.5f));
+    auto& image = static_cast<CEGUI::BasicImage&>(CEGUI::ImageManager::getSingleton().get("MiniMapImageset" + mResourceSuffix));
+    image.setArea(CEGUI::Rectf(mViewOrigin.x * mWidth, mViewOrigin.y * mHeight,
+        (mViewOrigin.x + scale) * mWidth, (mViewOrigin.y + scale) * mHeight));
+    mMiniMapWindow->invalidate();
+
     const Ogre::Vector3& topRight = cornerTiles[0];
     const Ogre::Vector3& topLeft = cornerTiles[1];
     const Ogre::Vector3& bottomLeft = cornerTiles[2];
@@ -570,7 +350,7 @@ void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<O
         isSame &= (val <= squareDiffMin);
     }
 
-    if(isSame)
+    if(isSame && !mPixelsDirty)
         return;
 
     // We save corner tiles
@@ -584,7 +364,7 @@ void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<O
     mVisibleRectangle.clear();
 
     // And we paint the new visible rectangle
-    auto output = mPixelBuffer->lock(mPixelBox, Ogre::HardwareBuffer::HBL_NORMAL);
+    Ogre::PixelBox& output = mPixelBox;
 
     // we look for the tiles at the border of vision to paint them black
     for(MiniMapDrawnFullTileStateListener* listener : mTileStateListeners)
@@ -629,9 +409,10 @@ void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<O
             for(uint32_t yyy = listener->mMinimapYMin; yyy < listener->mMinimapYMax; ++yyy)
             {
                 output.setColourAt(Ogre::ColourValue(0.0f, 0.0f, 0.0f), xxx,
-                                   output.getHeight() - yyy, 0);
+                                   output.getHeight() - 1 - yyy, 0);
             }
         }
     }
-    mPixelBuffer->unlock();
+    mPixelBuffer->blitFromMemory(mPixelBox);
+    mPixelsDirty = false;
 }

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -185,7 +185,7 @@ MiniMapDrawnFull::MiniMapDrawnFull(CEGUI::Window* miniMapWindow, const std::stri
     CEGUI::Texture& miniMapTextureGui = static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingletonPtr()
                                             ->getRenderer())->createTexture("miniMapTextureGui" + suffix, mMiniMapOgreTexture);
 
-    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow, "MiniMapImageset" + suffix);
+    CEGUI::BasicImage& imageset = MiniMap::createMiniMapImage(mMiniMapWindow, "MiniMapImageset" + suffix, true);
     imageset.setArea(CEGUI::Rectf(CEGUI::Vector2f(0.0, 0.0),
                                       CEGUI::Size<float>(
                                           static_cast<float>(mWidth), static_cast<float>(mHeight)
@@ -267,57 +267,6 @@ bool MiniMapDrawnFull::updateTileState(uint32_t minimapXMin, uint32_t minimapXMa
     return animated;
 }
 
-bool MiniMapDrawnFull::crossSegment(const Ogre::Vector3& p1, const Ogre::Vector3& p2,
-        uint32_t xMin, uint32_t xMax, uint32_t yMin, uint32_t yMax)
-{
-    if((p1.x < static_cast<Ogre::Real>(xMin)) &&
-       (p2.x < static_cast<Ogre::Real>(xMin)))
-    {
-        return false;
-    }
-    if((p1.x > static_cast<Ogre::Real>(xMax)) &&
-       (p2.x > static_cast<Ogre::Real>(xMax)))
-    {
-        return false;
-    }
-
-    if((p1.y < static_cast<Ogre::Real>(yMin)) &&
-       (p2.y < static_cast<Ogre::Real>(yMin)))
-    {
-        return false;
-    }
-    if((p1.y > static_cast<Ogre::Real>(yMax)) &&
-       (p2.y > static_cast<Ogre::Real>(yMax)))
-    {
-        return false;
-    }
-
-    Ogre::Real diffYPoints = p2.y - p1.y;
-    Ogre::Real diffXPoints = p2.x - p1.x;
-    Ogre::Real diffYMin = p2.y - static_cast<Ogre::Real>(yMin);
-    Ogre::Real diffXMin = p2.x - static_cast<Ogre::Real>(xMin);
-    Ogre::Real diffYMax = p2.y - static_cast<Ogre::Real>(yMax);
-    Ogre::Real diffXMax = p2.x - static_cast<Ogre::Real>(xMax);
-
-    // Magic number to change the size of the line
-    static const Ogre::Real DIFF_MIN = 5;
-    if(
-       (
-        (diffYMin * diffXPoints - diffYPoints * diffXMin - DIFF_MIN< 0) &&
-        (diffYMax * diffXPoints - diffYPoints * diffXMax + DIFF_MIN >= 0)
-       ) ||
-       (
-        (diffYMax * diffXPoints - diffYPoints * diffXMax - DIFF_MIN< 0) &&
-        (diffYMin * diffXPoints - diffYPoints * diffXMin + DIFF_MIN >= 0)
-       )
-      )
-    {
-        return true;
-    }
-
-    return false;
-}
-
 void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre::Vector3>& cornerTiles)
 {
     const unsigned int oldPhase = static_cast<unsigned int>(mAnimationTime * 2.0f);
@@ -336,87 +285,13 @@ void MiniMapDrawnFull::update(Ogre::Real timeSinceLastFrame, const std::vector<O
     image.setArea(CEGUI::Rectf(mViewOrigin.x * mWidth, mViewOrigin.y * mHeight,
         (mViewOrigin.x + scale) * mWidth, (mViewOrigin.y + scale) * mHeight));
     mMiniMapWindow->invalidate();
-    updateHeartDirection(mMiniMapWindow, mGameMap,
+    updateMapOverlay(mMiniMapWindow, mGameMap,
         Ogre::Vector2((mViewOrigin.x + scale * 0.5f) * mGameMap.getMapSizeX(),
             (1.0f - mViewOrigin.y - scale * 0.5f) * mGameMap.getMapSizeY()),
-        Ogre::Vector2(mGameMap.getMapSizeX(), mGameMap.getMapSizeY()) * scale, 0.0f);
+        Ogre::Vector2(mGameMap.getMapSizeX(), mGameMap.getMapSizeY()) * scale, 0.0f, cornerTiles);
 
-    const Ogre::Vector3& topRight = cornerTiles[0];
-    const Ogre::Vector3& topLeft = cornerTiles[1];
-    const Ogre::Vector3& bottomLeft = cornerTiles[2];
-    const Ogre::Vector3& bottomRight = cornerTiles[3];
-
-    bool isSame = (mLastCornerTiles.size() == cornerTiles.size());
-    static const Ogre::Real squareDiffMin = 0.5;
-    for(uint32_t iii = 0; isSame && iii < mLastCornerTiles.size(); ++iii)
-    {
-        Ogre::Real val = (mLastCornerTiles[iii] - cornerTiles[iii]).squaredLength();
-        isSame &= (val <= squareDiffMin);
-    }
-
-    if(isSame && !mPixelsDirty)
+    if(!mPixelsDirty)
         return;
-
-    // We save corner tiles
-    mLastCornerTiles = cornerTiles;
-
-    // We refresh the old rectangle
-    for(MiniMapDrawnFullTileStateListener* listener : mVisibleRectangle)
-    {
-        listener->fireTileStateChanged();
-    }
-    mVisibleRectangle.clear();
-
-    // And we paint the new visible rectangle
-    Ogre::PixelBox& output = mPixelBox;
-
-    // we look for the tiles at the border of vision to paint them black
-    for(MiniMapDrawnFullTileStateListener* listener : mTileStateListeners)
-    {
-        bool isInBorder = false;
-
-        // We check if the listener tiles are on the top line
-        if(!isInBorder &&
-            crossSegment(topRight, topLeft, listener->mTileXMin, listener->mTileXMax,
-                listener->mTileYMin, listener->mTileYMax))
-        {
-            isInBorder = true;
-        }
-
-        if(!isInBorder &&
-            crossSegment(topLeft, bottomLeft, listener->mTileXMin, listener->mTileXMax,
-                listener->mTileYMin, listener->mTileYMax))
-        {
-            isInBorder = true;
-        }
-
-        if(!isInBorder &&
-            crossSegment(bottomLeft, bottomRight, listener->mTileXMin, listener->mTileXMax,
-                listener->mTileYMin, listener->mTileYMax))
-        {
-            isInBorder = true;
-        }
-
-        if(!isInBorder &&
-            crossSegment(bottomRight, topRight, listener->mTileXMin, listener->mTileXMax,
-                listener->mTileYMin, listener->mTileYMax))
-        {
-            isInBorder = true;
-        }
-
-        if(!isInBorder)
-            continue;
-
-        mVisibleRectangle.push_back(listener);
-        for(uint32_t xxx = listener->mMinimapXMin; xxx < listener->mMinimapXMax; ++xxx)
-        {
-            for(uint32_t yyy = listener->mMinimapYMin; yyy < listener->mMinimapYMax; ++yyy)
-            {
-                output.setColourAt(Ogre::ColourValue(0.0f, 0.0f, 0.0f), xxx,
-                                   output.getHeight() - 1 - yyy, 0);
-            }
-        }
-    }
     mPixelBuffer->blitFromMemory(mPixelBox);
     mPixelsDirty = false;
 }

--- a/source/gamemap/MiniMapDrawnFull.cpp
+++ b/source/gamemap/MiniMapDrawnFull.cpp
@@ -451,6 +451,8 @@ MiniMapDrawnFull::~MiniMapDrawnFull()
 
 Ogre::Vector2 MiniMapDrawnFull::camera_2dPositionFromClick(int xx, int yy)
 {
+    mTopLeftCornerX = static_cast<int>(mMiniMapWindow->getPixelPosition().d_x);
+    mTopLeftCornerY = static_cast<int>(mMiniMapWindow->getPixelPosition().d_y);
     Ogre::Vector2 v(0, 0);
     Ogre::Real gainX = static_cast<Ogre::Real>(mGameMap.getMapSizeX())
         / static_cast<Ogre::Real>(mWidth);

--- a/source/gamemap/MiniMapDrawnFull.h
+++ b/source/gamemap/MiniMapDrawnFull.h
@@ -60,11 +60,6 @@ public:
     Ogre::Vector2 camera_2dPositionFromClick(int xx, int yy) override;
 
 private:
-    //! \brief Returns true is the segment between p1 and p2 (using x and y only)
-    //! crosses the values within xMin, xMax, yMin and yMax
-    bool crossSegment(const Ogre::Vector3& p1, const Ogre::Vector3& p2,
-        uint32_t xMin, uint32_t xMax, uint32_t yMin, uint32_t yMax);
-
     CEGUI::Window* mMiniMapWindow;
     std::string mResourceSuffix;
     Ogre::Vector2 mViewOrigin = Ogre::Vector2::ZERO;
@@ -74,10 +69,6 @@ private:
     CameraManager& mCameraManager;
 
     std::vector<MiniMapDrawnFullTileStateListener*> mTileStateListeners;
-
-    std::vector<MiniMapDrawnFullTileStateListener*> mVisibleRectangle;
-
-    std::vector<Ogre::Vector3> mLastCornerTiles;
 
     int mTopLeftCornerX;
     int mTopLeftCornerY;

--- a/source/gamemap/MiniMapDrawnFull.h
+++ b/source/gamemap/MiniMapDrawnFull.h
@@ -42,7 +42,7 @@ class Tile;
 class MiniMapDrawnFull : public MiniMap
 {
 public:
-    MiniMapDrawnFull(CEGUI::Window* miniMapWindow);
+    MiniMapDrawnFull(CEGUI::Window* miniMapWindow, const std::string& suffix = "");
     ~MiniMapDrawnFull();
 
     Ogre::uint getWidth() const
@@ -53,7 +53,7 @@ public:
 
     void update(Ogre::Real timeSinceLastFrame, const std::vector<Ogre::Vector3>& cornerTiles) override;
 
-    void updateTileState(uint32_t minimapXMin, uint32_t xMinimapMax,
+    bool updateTileState(uint32_t minimapXMin, uint32_t xMinimapMax,
         uint32_t minimapYMin, uint32_t minimapYMax, uint32_t tileXMin,
         uint32_t tileXMax, uint32_t tileYMin, uint32_t tileYMax);
 
@@ -66,6 +66,9 @@ private:
         uint32_t xMin, uint32_t xMax, uint32_t yMin, uint32_t yMax);
 
     CEGUI::Window* mMiniMapWindow;
+    std::string mResourceSuffix;
+    Ogre::Vector2 mViewOrigin = Ogre::Vector2::ZERO;
+    Ogre::Vector2 mViewSize = Ogre::Vector2::UNIT_SCALE;
 
     GameMap& mGameMap;
     CameraManager& mCameraManager;
@@ -83,6 +86,8 @@ private:
 
     Ogre::Vector2 mCamera_2dPosition;
 
+    std::vector<Ogre::uint8> mPixels;
+    bool mPixelsDirty = true;
     Ogre::PixelBox mPixelBox;
     Ogre::TexturePtr mMiniMapOgreTexture;
     Ogre::HardwarePixelBufferSharedPtr mPixelBuffer;

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -102,6 +102,7 @@ public:
 
     //! \brief Game mode specific rendering methods.
     virtual void onFrameStarted(const Ogre::FrameEvent& evt) {};
+    virtual void updateCameraControls(float elapsed) {};
     virtual void onFrameEnded(const Ogre::FrameEvent& evt) {};
 
     bool changeModeEvent(ModeManager::ModeType mode, const CEGUI::EventArgs&)

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -122,7 +122,7 @@ EditorMode::EditorMode(ModeManager* modeManager):
     mPortalWaveRefreshing(false),
     mMouseX(0),
     mMouseY(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mModifiedMapBit(false)
 {
 

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -29,6 +29,7 @@
 #include "rooms/RoomType.h"
 #include "traps/TrapType.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/MakeUnique.h"
 
 #include <Ogre.h>
@@ -94,6 +95,7 @@ GameEditorModeBase::GameEditorModeBase(ModeManager* modeManager, ModeManager::Mo
     mChatMessageDisplayTime(0),
     mChatMessageBoxDisplay(ChatMessageBoxDisplay::hide),
     mMiniMap(MiniMap::createMiniMap(rootWindow->getChild(Gui::MINIMAP))),
+    mMiniMapType(ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false)),
     mMainCullingManager( new CullingManager(mGameMap, CullingType::SHOW_MAIN_WINDOW)),
     mKeepReplayAtDisconnect(false),
     mCameraTilesIntersections(std::vector<Ogre::Vector3>(4, Ogre::Vector3::ZERO)),
@@ -192,6 +194,14 @@ bool GameEditorModeBase::onMinimapClick(const CEGUI::EventArgs& arg)
 
 void GameEditorModeBase::onFrameStarted(const Ogre::FrameEvent& evt)
 {
+    const std::string miniMapType = ConfigManager::getSingleton().getGameValue(Config::MINIMAP_TYPE, MiniMap::DEFAULT_MINIMAP, false);
+    if(miniMapType != mMiniMapType)
+    {
+        delete mMiniMap;
+        mMiniMap = nullptr;
+        mMiniMap = MiniMap::createMiniMap(mRootWindow->getChild(Gui::MINIMAP));
+        mMiniMapType = miniMapType;
+    }
     updateMessages(evt.timeSinceLastFrame);
     if(mMainCullingManager != nullptr)
     {
@@ -336,4 +346,3 @@ void GameEditorModeBase::leaveConsole()
     mCurrentInputMode = InputModeNormal;
     activate();
 }
-

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -34,6 +34,7 @@
 
 #include <Ogre.h>
 
+#include <CEGUI/widgets/FrameWindow.h>
 #include <CEGUI/widgets/PushButton.h>
 #include <CEGUI/widgets/Scrollbar.h>
 
@@ -179,15 +180,35 @@ void GameEditorModeBase::connectGuiAction(const std::string& buttonName, Abstrac
     );
 }
 
+bool GameEditorModeBase::cameraInputBlocked()
+{
+    if(mCurrentInputMode != InputModeNormal || !isConnected() ||
+        !ODFrameListener::getSingleton().getRenderWindow()->isActive())
+        return true;
+    for(size_t i = 0; i < mRootWindow->getChildCount(); ++i)
+    {
+        CEGUI::Window* child = mRootWindow->getChildAtIdx(i);
+        if(child->isVisible() && dynamic_cast<CEGUI::FrameWindow*>(child) != nullptr)
+            return true;
+    }
+    return false;
+}
+
 bool GameEditorModeBase::onMinimapClick(const CEGUI::EventArgs& arg)
 {
     const CEGUI::MouseEventArgs& mouseEvt = static_cast<const CEGUI::MouseEventArgs&>(arg);
+    if(getModeType() == ModeManager::GAME &&
+        (mouseEvt.button != CEGUI::LeftButton || cameraInputBlocked()))
+        return true;
 
     ODFrameListener& frameListener = ODFrameListener::getSingleton();
 
     Ogre::Vector2 cc = mMiniMap->camera_2dPositionFromClick(static_cast<int>(mouseEvt.position.d_x),
         static_cast<int>(mouseEvt.position.d_y));
-    frameListener.getCameraManager()->onMiniMapClick(cc);
+    if(getModeType() == ModeManager::GAME)
+        frameListener.getCameraManager()->jumpToViewTarget(cc);
+    else
+        frameListener.getCameraManager()->onMiniMapClick(cc);
 
     return true;
 }

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -133,6 +133,8 @@ protected:
     //! If in chat mode, then the game keyboard keys are interpreted as regular keys.
     InputMode mCurrentInputMode;
 
+    bool cameraInputBlocked();
+
     void connectGuiAction(const std::string& buttonName, AbstractApplicationMode::GuiAction action);
 
     //! \brief Update the chat and event messages seen.

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -156,6 +156,7 @@ protected:
 
     //! \brief The minimap used in this mode
     MiniMap* mMiniMap;
+    std::string mMiniMapType;
 
     //! \brief Culling manager for the main map
     CullingManager* mMainCullingManager;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -18,6 +18,7 @@
 #include "modes/GameMode.h"
 
 #include "camera/CameraManager.h"
+#include "camera/CameraInput.h"
 #include "entities/Creature.h"
 #include "entities/GameEntityType.h"
 #include "entities/Tile.h"
@@ -92,10 +93,23 @@ GameMode::GameMode(ModeManager *modeManager):
     mCurrentSkillType(SkillType::nullSkillType),
     mCurrentSkillProgress(0.0),
     mPreviousMousePosition(MouseMoveEvent{0, 0}),
-    directionKeyPressed(false),
     showTileDebugWindow(false),
     config(ConfigManager::getSingleton())
 {
+    addEventConnection(mRootWindow->getChild("GameOptionsWindow/UserCamerasButton")->subscribeEvent(
+        CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(&GameMode::showUserCameras, this)));
+    addEventConnection(mRootWindow->getChild("UserCamerasWindow")->subscribeEvent(
+        CEGUI::FrameWindow::EventCloseClicked, CEGUI::Event::Subscriber(&GameMode::closeUserCameras, this)));
+    for(unsigned int slot = 0; slot < 3; ++slot)
+    {
+        CEGUI::Window* button = mRootWindow->getChild("UserCamerasWindow/Camera" + Helper::toString(slot + 1));
+        button->setID(slot);
+        addEventConnection(button->subscribeEvent(CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&GameMode::selectUserCamera, this)));
+    }
+    addEventConnection(mRootWindow->getChild("UserCamerasWindow/Store")->subscribeEvent(
+        CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(&GameMode::storeUserCamera, this)));
+
     // Set per default the input on the map
     mModeManager->getInputManager().mMouseDownOnCEGUIWindow = false;
 
@@ -378,42 +392,18 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     InputManager& inputManager = mModeManager->getInputManager();
     inputManager.mCommandState = (inputManager.mLMouseDown ? InputCommandState::building : InputCommandState::infoOnly);
 
-    // TODO: Here we should check whether the terminal is active...
-    if(inputManager.mMMouseDown)
+    if(!cameraInputBlocked() && !blocksEdgeScrolling(
+        CEGUI::System::getSingleton().getDefaultGUIContext().getWindowContainingMouse()))
     {
-        ODFrameListener::getSingleton().moveCamera(CameraManager::randomRotateX,mouseDelta.x);
-        ODFrameListener::getSingleton().moveCamera(CameraManager::randomRotateY,mouseDelta.y);
+        CameraManager* camera = ODFrameListener::getSingleton().getCameraManager();
+        if(getKeyboard()->isKeyDown(OIS::KC_X))
+            camera->orbitBy(mouseDelta.x * 0.25f, 0.0f);
+        else if(getKeyboard()->isKeyDown(OIS::KC_Z))
+            camera->zoomBy(-mouseDelta.y * 0.025f);
+        else if(inputManager.mMMouseDown)
+            camera->orbitBy(mouseDelta.x * 0.25f, mouseDelta.y * 0.25f);
     }
 
-    if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
-    {
-        const bool mouseOverGui = isMouseWheelOnCEGUIWindow();
-        const double leftIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
-        const double rightIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
-        const double topIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
-        const double bottomIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
-
-        if (leftIntensity > 0.0)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);
-        else
-            ODFrameListener::getSingleton().moveCamera(CameraManager::stopLeft);
-
-        if (rightIntensity > 0.0)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight, rightIntensity);
-        else
-            ODFrameListener::getSingleton().moveCamera(CameraManager::stopRight);
-
-        if (topIntensity > 0.0)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward, topIntensity);
-        else
-            ODFrameListener::getSingleton().moveCamera(CameraManager::stopForward);
-
-        if (bottomIntensity > 0.0)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward, bottomIntensity);
-        else
-            ODFrameListener::getSingleton().moveCamera(CameraManager::stopBackward);            
-    }
- 
     // If we have a room/trap/spell selected, show it
     // TODO: This should be changed, or combined with an icon or something later.
     TextRenderer& textRenderer = TextRenderer::getSingleton();
@@ -476,6 +466,9 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
 
     ODFrameListener& frameListener = ODFrameListener::getSingleton();
 
+    if(cameraInputBlocked())
+        return;
+
     if (arg.delta > 0)
     {
         if (getKeyboard()->isModifierDown(OIS::Keyboard::Ctrl))
@@ -484,7 +477,7 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
         }
         else
         {
-            frameListener.moveCamera(CameraManager::moveDown);
+            frameListener.getCameraManager()->zoomBy(-0.2f * arg.delta);
         }
     }
     else if (arg.delta < 0)
@@ -495,7 +488,7 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
         }
         else
         {
-            frameListener.moveCamera(CameraManager::moveUp);
+            frameListener.getCameraManager()->zoomBy(-0.2f * arg.delta);
         }
     }
 }
@@ -836,23 +829,22 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
     switch (arg.key)
     {
     case OIS::KC_F1:
-        toggleHelpWindow();
+        if(!cameraInputBlocked())
+            frameListener.getCameraManager()->setDefaultIsometricView();
         break;
-
     case OIS::KC_F2:
-        togglePlayerSettingsWindow();
+        if(!cameraInputBlocked())
+            frameListener.getCameraManager()->setDefaultOrthogonalView();
         break;
-
     case OIS::KC_F3:
-        toggleObjectivesWindow();
+        if(!cameraInputBlocked())
+            frameListener.getCameraManager()->setDefaultView();
         break;
-
     case OIS::KC_F4:
-        toggleSkillWindow();
-        break;
-
     case OIS::KC_F5:
-        saveGame();
+    case OIS::KC_F6:
+        if(!cameraInputBlocked())
+            frameListener.getCameraManager()->loadUserView(arg.key - OIS::KC_F4);
         break;
 
     case OIS::KC_F9:
@@ -872,56 +864,9 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         enterConsole();
         break;
 
-    case OIS::KC_LEFT:
-    case OIS::KC_A:
-        frameListener.moveCamera(CameraManager::Direction::moveLeft);
-        directionKeyPressed = true;
-        break;
-
-    case OIS::KC_RIGHT:
-    case OIS::KC_D:
-        frameListener.moveCamera(CameraManager::Direction::moveRight);
-        directionKeyPressed = true;        
-        break;
-
-    case OIS::KC_UP:
-    case OIS::KC_W:
-        frameListener.moveCamera(CameraManager::Direction::moveForward);
-        directionKeyPressed = true;
-        break;
-
-    case OIS::KC_DOWN:
-    case OIS::KC_S:
-        frameListener.moveCamera(CameraManager::Direction::moveBackward);
-        directionKeyPressed = true;
-        break;
-
-    case OIS::KC_Q:
-        frameListener.moveCamera(CameraManager::Direction::rotateLeft);
-        break;
-
-    case OIS::KC_E:
-        frameListener.moveCamera(CameraManager::Direction::rotateRight);
-        break;
-
-    case OIS::KC_HOME:
-        frameListener.moveCamera(CameraManager::Direction::moveDown);
-        break;
-
-    case OIS::KC_END:
-        frameListener.moveCamera(CameraManager::Direction::moveUp);
-        break;
-
-    case OIS::KC_PGUP:
-        frameListener.moveCamera(CameraManager::Direction::rotateUp);
-        break;
-
-    case OIS::KC_PGDOWN:
-        frameListener.moveCamera(CameraManager::Direction::rotateDown);
-        break;
-
+    case OIS::KC_H:
     case OIS::KC_T:
-        if(isConnected()) // If we are in a game.
+        if(isConnected() && !cameraInputBlocked()) // If we are in a game.
         {
             Seat* tempSeat = mGameMap->getLocalPlayer()->getSeat();
             frameListener.cameraFlyTo(tempSeat->getStartingPosition());
@@ -929,7 +874,8 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         break;
 
     case OIS::KC_V:
-        ODFrameListener::getSingleton().getCameraManager()->setNextDefaultView();
+        if(!cameraInputBlocked())
+            frameListener.getCameraManager()->setNextDefaultView();
         break;
 
     case OIS::KC_LMENU:
@@ -1075,54 +1021,6 @@ bool GameMode::keyReleasedNormal(const OIS::KeyEvent &arg)
 
     switch (arg.key)
     {
-    case OIS::KC_LEFT:
-    case OIS::KC_A:
-        frameListener.moveCamera(CameraManager::Direction::stopLeft);
-        directionKeyPressed = false;
-        break;
-
-    case OIS::KC_RIGHT:
-    case OIS::KC_D:
-        frameListener.moveCamera(CameraManager::Direction::stopRight);
-        directionKeyPressed = false;
-        break;
-
-    case OIS::KC_UP:
-    case OIS::KC_W:
-        frameListener.moveCamera(CameraManager::Direction::stopForward);
-        directionKeyPressed = false;       
-        break;
-
-    case OIS::KC_DOWN:
-    case OIS::KC_S:
-        frameListener.moveCamera(CameraManager::Direction::stopBackward);
-        directionKeyPressed = false;
-        break;
-
-    case OIS::KC_Q:
-        frameListener.moveCamera(CameraManager::Direction::stopRotLeft);
-        break;
-
-    case OIS::KC_E:
-        frameListener.moveCamera(CameraManager::Direction::stopRotRight);
-        break;
-
-    case OIS::KC_HOME:
-        frameListener.moveCamera(CameraManager::Direction::stopDown);
-        break;
-
-    case OIS::KC_END:
-        frameListener.moveCamera(CameraManager::Direction::stopUp);
-        break;
-
-    case OIS::KC_PGUP:
-        frameListener.moveCamera(CameraManager::Direction::stopRotUp);
-        break;
-
-    case OIS::KC_PGDOWN:
-        frameListener.moveCamera(CameraManager::Direction::stopRotDown);
-        break;
-
     case OIS::KC_LMENU:
         RenderManager::getSingleton().rrSetCreaturesTextOverlay(*mGameMap, false);
         break;
@@ -1155,6 +1053,92 @@ void GameMode::handleHotkeys(OIS::KeyCode keycode)
         frameListener.getCameraManager()->getActiveCameraNode()->setOrientation(  inputManager.mHotkeyLocation[keynumber].qq);
         frameListener.getCameraManager()->getActiveCameraNode()->getChild(0)->setOrientation(  inputManager.mHotkeyLocation[keynumber].qq2);                
     }
+}
+
+bool GameMode::cameraInputBlocked()
+{
+    if(mCurrentInputMode != InputModeNormal || !isConnected() ||
+        !ODFrameListener::getSingleton().getRenderWindow()->isActive())
+        return true;
+    for(size_t i = 0; i < mRootWindow->getChildCount(); ++i)
+    {
+        CEGUI::Window* child = mRootWindow->getChildAtIdx(i);
+        if(child->isVisible() && dynamic_cast<CEGUI::FrameWindow*>(child) != nullptr)
+            return true;
+    }
+    return false;
+}
+
+void GameMode::updateCameraControls(float elapsed)
+{
+    CameraManager* camera = ODFrameListener::getSingleton().getCameraManager();
+    const auto down = [this](OIS::KeyCode key) { return getKeyboard()->isKeyDown(key); };
+    if(cameraInputBlocked())
+    {
+        camera->move(CameraManager::fullStop);
+        if(mCurrentInputMode == InputModeNormal && mRootWindow->getChild("UserCamerasWindow")->isVisible()
+            && ODFrameListener::getSingleton().getRenderWindow()->isActive()
+            && getKeyboard()->isModifierDown(OIS::Keyboard::Ctrl))
+        {
+            camera->adjustUserView((float(down(OIS::KC_INSERT)) - float(down(OIS::KC_DELETE))) * 90.0f * elapsed,
+                (float(down(OIS::KC_PGUP)) - float(down(OIS::KC_PGDOWN))) * 90.0f * elapsed,
+                (float(down(OIS::KC_HOME)) - float(down(OIS::KC_END))) * 90.0f * elapsed);
+        }
+        return;
+    }
+    CameraInput input = CameraInput::read(down);
+    if(input.x == 0.0f && input.y == 0.0f && input.zoom == 0.0f && input.swivel == 0.0f
+        && !down(OIS::KC_X) && !down(OIS::KC_Z)
+        && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
+    {
+        CEGUI::GUIContext& context = CEGUI::System::getSingleton().getDefaultGUIContext();
+        if(!blocksEdgeScrolling(context.getWindowContainingMouse()))
+        {
+            const CEGUI::Vector2f& mouse = context.getMouseCursor().getPosition();
+            Ogre::RenderWindow* window = ODFrameListener::getSingleton().getRenderWindow();
+            input.x = static_cast<float>(getAutoscrollIntensity(static_cast<int>(mouse.d_x), window->getWidth(), false)
+                - getAutoscrollIntensity(static_cast<int>(mouse.d_x), window->getWidth(), true));
+            input.y = static_cast<float>(getAutoscrollIntensity(static_cast<int>(mouse.d_y), window->getHeight(), true)
+                - getAutoscrollIntensity(static_cast<int>(mouse.d_y), window->getHeight(), false));
+        }
+    }
+    camera->setControls(Ogre::Vector2(input.x, input.y), input.zoom, input.swivel, input.fast);
+}
+
+bool GameMode::showUserCameras(const CEGUI::EventArgs&)
+{
+    mRootWindow->getChild("GameOptionsWindow")->hide();
+    CEGUI::Window* window = mRootWindow->getChild("UserCamerasWindow");
+    window->show();
+    window->moveToFront();
+    window->setText("Define user camera " + Helper::toString(mUserCameraSlot + 1));
+    ODFrameListener::getSingleton().getCameraManager()->move(CameraManager::fullStop);
+    return true;
+}
+
+bool GameMode::closeUserCameras(const CEGUI::EventArgs&)
+{
+    mRootWindow->getChild("UserCamerasWindow")->hide();
+    ODFrameListener::getSingleton().getCameraManager()->move(CameraManager::fullStop);
+    return true;
+}
+
+bool GameMode::selectUserCamera(const CEGUI::EventArgs& args)
+{
+    mUserCameraSlot = static_cast<const CEGUI::WindowEventArgs&>(args).window->getID();
+    CameraManager* camera = ODFrameListener::getSingleton().getCameraManager();
+    camera->loadUserView(mUserCameraSlot);
+    mRootWindow->getChild("UserCamerasWindow")->setText("Define user camera " + Helper::toString(mUserCameraSlot + 1));
+    return true;
+}
+
+bool GameMode::storeUserCamera(const CEGUI::EventArgs&)
+{
+    if(ODFrameListener::getSingleton().getCameraManager()->storeUserView(mUserCameraSlot))
+        closeUserCameras();
+    else
+        mRootWindow->getChild("UserCamerasWindow")->setText("Could not save camera settings");
+    return true;
 }
 
 void GameMode::onFrameStarted(const Ogre::FrameEvent& evt)
@@ -1482,11 +1466,11 @@ void GameMode::setHelpWindowText()
         << "Well, at least you don't seem as dumb as a pit demon, so let's cover the basics again." << std::endl << std::endl;
     txt << formatTitleOn << "Camera controls" << formatTitleOff << std::endl
         << "The camera is your eyes - be watchful! Take the time to learn how to use it efficiently:" << std::endl
-        << "  - Camera translation: Arrow keys or WASD." << std::endl
-        << "  - Camera rotation: A (left) or E (right)." << std::endl
-        << "  - Camera zooming: Mouse wheel, Home (zoom out) or End (zoom in)." << std::endl
-        << "  - Camera tilting: Page Up (look up), Page Down (look down)." << std::endl
-        << "  - Cycle through camera modes: V." << std::endl << std::endl;
+        << "  - Pan: Arrow keys or WASD; hold Shift to scroll faster." << std::endl
+        << "  - Rotate: Delete / Page Down, Ctrl+Left / Right, or hold X and move the mouse." << std::endl
+        << "  - Zoom: Home / End, Ctrl+Up / Down, wheel, or hold Z and move the mouse vertically." << std::endl
+        << "  - Views: F1 isometric, F2 top down, F3 oblique; F4-F6 user cameras." << std::endl
+        << "  - Define user cameras in Options; H focuses the dungeon heart; V cycles views." << std::endl << std::endl;
     txt << formatTitleOn << "Keeper hand controls" << formatTitleOff << std::endl
         << "Use your hand wisely to keep all minions under control and let your dungeon thrive!" << std::endl
         << "  - Mouse left click: Select an action, Confirm an action." << std::endl
@@ -1503,7 +1487,7 @@ void GameMode::setHelpWindowText()
         << "in place (thanks to your evil tricks, the first tile is free!) so that your workers can store the gold they mine." << std::endl
         << "Be sure to build a dormitory and a hatchery to fulfill your creatures' lowest needs, and a library to skill "
         << "new buildings, spells and traps. Varied buildings, wealth and great dungeons will attract more powerful creatures." << std::endl
-        << "  - Use the Skill Manager (F4) to set the priority for the various skills that can be uncovered at the library."
+        << "  - Use the Skill Manager in Options to set the priority for the various skills that can be uncovered at the library."
         << "Make sure to have intelligent creatures always at work at your library - if you can find any among your dumb minions!" << std::endl
         << "  - Once you have a workshop, set traps to protect your dungeon - your creatures will then craft them at the workshop." << std::endl
         << "  - Use spells to macro-manage your creatures more efficiently." << std::endl << std::endl;
@@ -2013,4 +1997,3 @@ void GameMode::buildPlayerSettingsWindow()
 
     getModeManager().getGui().registerWindowHierarchy(tmpWin);
 }
-

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -28,6 +28,8 @@
 #include "game/Seat.h"
 #include "game/SkillType.h"
 #include "gamemap/GameMap.h"
+#include "gamemap/MiniMapCamera.h"
+#include "gamemap/MiniMapDrawnFull.h"
 #include "gamemap/Pathfinding.h"
 #include "modes/GameEditorModeConsole.h"
 #include "modes/InputBridge.h"
@@ -110,6 +112,16 @@ GameMode::GameMode(ModeManager *modeManager):
     showTileDebugWindow(false),
     config(ConfigManager::getSingleton())
 {
+    addEventConnection(mRootWindow->getChild("MiniMapZoomButton")->subscribeEvent(
+        CEGUI::Window::EventMouseClick, CEGUI::Event::Subscriber(&GameMode::zoomMiniMap, this)));
+    addEventConnection(mRootWindow->getChild("MapWindow")->subscribeEvent(
+        CEGUI::FrameWindow::EventCloseClicked, CEGUI::Event::Subscriber(&GameMode::closeMap, this)));
+    addEventConnection(mRootWindow->getChild("MapWindow")->subscribeEvent(
+        CEGUI::Window::EventHidden, CEGUI::Event::Subscriber(&GameMode::closeMap, this)));
+    addEventConnection(mRootWindow->getChild("MapWindow")->subscribeEvent(
+        CEGUI::Window::EventMouseClick, CEGUI::Event::Subscriber(&GameMode::clickMap, this)));
+    addEventConnection(mRootWindow->getChild("MapWindow/MapImage")->subscribeEvent(
+        CEGUI::Window::EventMouseClick, CEGUI::Event::Subscriber(&GameMode::clickMap, this)));
     addEventConnection(mRootWindow->getChild("GameOptionsWindow/UserCamerasButton")->subscribeEvent(
         CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(&GameMode::showUserCameras, this)));
     addEventConnection(mRootWindow->getChild("UserCamerasWindow")->subscribeEvent(
@@ -315,6 +327,8 @@ GameMode::GameMode(ModeManager *modeManager):
 
 GameMode::~GameMode()
 {
+    // Remove tile listeners before the base destructor clears the game map.
+    mFullMap.reset();
     CEGUI::ToggleButton* checkBox =
         dynamic_cast<CEGUI::ToggleButton*>(
             mRootWindow->getChild(
@@ -556,6 +570,11 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
         return true;
 
     inputManager.mMouseDownOnCEGUIWindow = isMouseDownOnCEGUIWindow();
+    if(mFullMap)
+    {
+        inputManager.mMouseDownOnCEGUIWindow = true;
+        return true;
+    }
     if (inputManager.mMouseDownOnCEGUIWindow)
         return true;
 
@@ -846,6 +865,22 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
 {
     ODFrameListener& frameListener = ODFrameListener::getSingleton();
 
+    if(arg.key == OIS::KC_M)
+    {
+        if(!mMapKeyDown)
+        {
+            mMapKeyDown = true;
+            toggleMap();
+        }
+        return true;
+    }
+    if(mFullMap)
+    {
+        if(arg.key == OIS::KC_ESCAPE)
+            closeMap();
+        return true;
+    }
+
     switch (arg.key)
     {
     case OIS::KC_F1:
@@ -885,6 +920,13 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         break;
 
     case OIS::KC_H:
+        if(!cameraInputBlocked())
+            focusRoom(RoomType::dungeonTemple);
+        break;
+    case OIS::KC_P:
+        if(!cameraInputBlocked())
+            focusRoom(RoomType::portal);
+        break;
     case OIS::KC_T:
         if(isConnected() && !cameraInputBlocked()) // If we are in a game.
         {
@@ -904,8 +946,11 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         break;
 
     // Zooms to the next event
+    case OIS::KC_F:
     case OIS::KC_SPACE:
     {
+        if(cameraInputBlocked())
+            break;
         Player* player = mGameMap->getLocalPlayer();
         const PlayerEvent* event = player->getNextEvent(mIndexEvent);
         if(event == nullptr)
@@ -1027,6 +1072,8 @@ void GameMode::refreshPlayerGoals(const std::string& goalsDisplayString)
 
 bool GameMode::keyReleased(const OIS::KeyEvent &arg)
 {
+    if(arg.key == OIS::KC_M)
+        mMapKeyDown = false;
     CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyUp(static_cast<CEGUI::Key::Scan>(arg.key));
 
     if (mCurrentInputMode == InputModeChat || mCurrentInputMode == InputModeConsole)
@@ -1075,24 +1122,12 @@ void GameMode::handleHotkeys(OIS::KeyCode keycode)
     }
 }
 
-bool GameMode::cameraInputBlocked()
-{
-    if(mCurrentInputMode != InputModeNormal || !isConnected() ||
-        !ODFrameListener::getSingleton().getRenderWindow()->isActive())
-        return true;
-    for(size_t i = 0; i < mRootWindow->getChildCount(); ++i)
-    {
-        CEGUI::Window* child = mRootWindow->getChildAtIdx(i);
-        if(child->isVisible() && dynamic_cast<CEGUI::FrameWindow*>(child) != nullptr)
-            return true;
-    }
-    return false;
-}
-
 void GameMode::updateCameraControls(float elapsed)
 {
     CameraManager* camera = ODFrameListener::getSingleton().getCameraManager();
     const auto down = [this](OIS::KeyCode key) { return getKeyboard()->isKeyDown(key); };
+    if(!down(OIS::KC_M))
+        mMapKeyDown = false;
     if(cameraInputBlocked())
     {
         camera->move(CameraManager::fullStop);
@@ -1123,6 +1158,153 @@ void GameMode::updateCameraControls(float elapsed)
         }
     }
     camera->setControls(Ogre::Vector2(input.x, input.y), input.zoom, input.swivel, input.fast);
+}
+
+bool GameMode::toggleMap(const CEGUI::EventArgs&)
+{
+    if(mFullMap)
+        return closeMap();
+    if(cameraInputBlocked())
+        return true;
+
+    InputManager& input = mModeManager->getInputManager();
+    input.mLMouseDown = input.mRMouseDown = input.mMMouseDown = false;
+    input.mCommandState = InputCommandState::infoOnly;
+    unselectAllTiles();
+    ODFrameListener::getSingleton().getCameraManager()->move(CameraManager::fullStop);
+
+    CEGUI::Window* window = mRootWindow->getChild("MapWindow");
+    CEGUI::Window* map = window->getChild("MapImage");
+    map->setAspectRatio(static_cast<float>(mGameMap->getMapSizeX()) / mGameMap->getMapSizeY());
+    window->show();
+    window->moveToFront();
+    window->setModalState(true);
+    mFullMap.reset(new MiniMapDrawnFull(map, "FullMap"));
+    mSavedMiniMapZoom = mMiniMap->getZoomLevel();
+    delete mMiniMap;
+    mMiniMap = nullptr;
+    mMiniMap = new MiniMapCamera(map->getChild("Detail"));
+    mMiniMap->setZoomLevel(1);
+    updateMapDetail();
+    return true;
+}
+
+bool GameMode::closeMap(const CEGUI::EventArgs&)
+{
+    if(!mFullMap)
+        return true;
+    mFullMap.reset();
+    delete mMiniMap;
+    mMiniMap = nullptr;
+    mMiniMap = MiniMap::createMiniMap(mRootWindow->getChild(Gui::MINIMAP));
+    mMiniMap->setZoomLevel(mSavedMiniMapZoom);
+    CEGUI::Window* window = mRootWindow->getChild("MapWindow");
+    window->setModalState(false);
+    window->hide();
+    return true;
+}
+
+bool GameMode::clickMap(const CEGUI::EventArgs& arg)
+{
+    if(!mFullMap)
+        return true;
+    const auto& mouse = static_cast<const CEGUI::MouseEventArgs&>(arg);
+    if(mouse.button == CEGUI::RightButton)
+        return closeMap();
+    if(mouse.button != CEGUI::LeftButton ||
+        !mRootWindow->getChild("MapWindow/MapImage")->getUnclippedOuterRect().get().isPointInRect(mouse.position))
+        return true;
+    const Ogre::Vector2 target = mFullMap->camera_2dPositionFromClick(
+        static_cast<int>(mouse.position.d_x), static_cast<int>(mouse.position.d_y));
+    closeMap();
+    ODFrameListener::getSingleton().getCameraManager()->jumpToViewTarget(target);
+    return true;
+}
+
+bool GameMode::zoomMiniMap(const CEGUI::EventArgs& arg)
+{
+    if(cameraInputBlocked())
+        return true;
+    const auto& mouse = static_cast<const CEGUI::MouseEventArgs&>(arg);
+    if(mouse.button != CEGUI::LeftButton && mouse.button != CEGUI::RightButton)
+        return true;
+    int level = mMiniMap->getZoomLevel() + (mouse.button == CEGUI::LeftButton ? 1 : -1);
+    if(dynamic_cast<MiniMapDrawnFull*>(mMiniMap) != nullptr)
+        level = std::max(0, level);
+    mMiniMap->setZoomLevel(level);
+    mMiniMap->update(0.5f, mCameraTilesIntersections);
+    return true;
+}
+
+void GameMode::updateMapDetail()
+{
+    CEGUI::Window* map = mRootWindow->getChild("MapWindow/MapImage");
+    CEGUI::Window* detail = map->getChild("Detail");
+    const CEGUI::Vector2f mouse = CEGUI::System::getSingleton().getDefaultGUIContext().getMouseCursor().getPosition();
+    const CEGUI::Rectf area = map->getUnclippedOuterRect().get();
+    detail->setVisible(area.isPointInRect(mouse));
+    if(!detail->isVisible())
+        return;
+    const CEGUI::Sizef size = detail->getPixelSize();
+    const float x = std::max(0.0f, std::min(area.getWidth() - size.d_width, mouse.d_x - area.left() + 12.0f));
+    const float y = std::max(0.0f, std::min(area.getHeight() - size.d_height, mouse.d_y - area.top() + 12.0f));
+    detail->setPosition(CEGUI::UVector2(CEGUI::UDim(0, x), CEGUI::UDim(0, y)));
+    static_cast<MiniMapCamera*>(mMiniMap)->setViewCenter(mFullMap->camera_2dPositionFromClick(
+        static_cast<int>(mouse.d_x), static_cast<int>(mouse.d_y)));
+}
+
+void GameMode::focusRoom(RoomType type)
+{
+    // Rooms are server objects; the client receives their owned tile visuals.
+    const TileVisual visual = type == RoomType::portal ? TileVisual::portalRoom : TileVisual::dungeonTempleRoom;
+    const Seat* owner = mGameMap->getLocalPlayer()->getSeat();
+    const int width = mGameMap->getMapSizeX();
+    const int height = mGameMap->getMapSizeY();
+    std::vector<bool> visited(width * height, false);
+    std::vector<Ogre::Vector2> centres;
+    for(int y = 0; y < height; ++y)
+    {
+        for(int x = 0; x < width; ++x)
+        {
+            Tile* first = mGameMap->getTile(x, y);
+            if(visited[y * width + x] || first->getTileVisual() != visual || first->getSeat() != owner)
+                continue;
+            std::vector<Tile*> tiles(1, first);
+            visited[y * width + x] = true;
+            Ogre::Vector2 centre = Ogre::Vector2::ZERO;
+            for(size_t i = 0; i < tiles.size(); ++i)
+            {
+                Tile* tile = tiles[i];
+                centre += Ogre::Vector2(tile->getX(), tile->getY());
+                const int dx[] = {-1, 1, 0, 0};
+                const int dy[] = {0, 0, -1, 1};
+                for(int direction = 0; direction < 4; ++direction)
+                {
+                    Tile* neighbour = mGameMap->getTile(tile->getX() + dx[direction], tile->getY() + dy[direction]);
+                    if(neighbour == nullptr || neighbour->getTileVisual() != visual || neighbour->getSeat() != owner)
+                        continue;
+                    const int index = neighbour->getY() * width + neighbour->getX();
+                    if(visited[index])
+                        continue;
+                    visited[index] = true;
+                    tiles.push_back(neighbour);
+                }
+            }
+            centre /= static_cast<Ogre::Real>(tiles.size());
+            Tile* centralTile = *std::min_element(tiles.begin(), tiles.end(), [&centre](Tile* a, Tile* b)
+            {
+                return Ogre::Vector2(a->getX(), a->getY()).squaredDistance(centre) <
+                    Ogre::Vector2(b->getX(), b->getY()).squaredDistance(centre);
+            });
+            centres.emplace_back(centralTile->getX(), centralTile->getY());
+        }
+    }
+    if(centres.empty())
+        return;
+    const size_t index = type == RoomType::portal ? mIndexPortal % centres.size() : 0;
+    ODFrameListener::getSingleton().getCameraManager()->jumpToViewTarget(centres[index]);
+    if(type == RoomType::portal)
+        mIndexPortal = index + 1;
 }
 
 bool GameMode::showUserCameras(const CEGUI::EventArgs&)
@@ -1163,7 +1345,11 @@ bool GameMode::storeUserCamera(const CEGUI::EventArgs&)
 
 void GameMode::onFrameStarted(const Ogre::FrameEvent& evt)
 {
+    if(mFullMap)
+        updateMapDetail();
     GameEditorModeBase::onFrameStarted(evt);
+    if(mFullMap)
+        mFullMap->update(evt.timeSinceLastFrame, mCameraTilesIntersections);
 
     refreshGuiSkill();
     refreshSpellButtonCoolDowns();
@@ -1490,7 +1676,9 @@ void GameMode::setHelpWindowText()
         << "  - Rotate: Delete / Page Down, Ctrl+Left / Right, or hold X and move the mouse." << std::endl
         << "  - Zoom: Home / End, Ctrl+Up / Down, wheel, or hold Z and move the mouse vertically." << std::endl
         << "  - Views: F1 isometric, F2 top down, F3 oblique; F4-F6 user cameras." << std::endl
-        << "  - Define user cameras in Options; H focuses the dungeon heart; V cycles views." << std::endl << std::endl;
+        << "  - Define user cameras in Options; H focuses the dungeon heart; P cycles portals; F focuses fights." << std::endl
+        << "  - M opens the map: left-click to move there, right-click or M to close; V cycles views." << std::endl
+        << "  - Minimap +/-: left-click to zoom in, right-click to zoom out." << std::endl << std::endl;
     txt << formatTitleOn << "Keeper hand controls" << formatTitleOff << std::endl
         << "Use your hand wisely to keep all minions under control and let your dungeon thrive!" << std::endl
         << "  - Mouse left click: Select an action, Confirm an action." << std::endl

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -387,10 +387,11 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        const double leftIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
-        const double rightIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
-        const double topIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
-        const double bottomIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
+        const bool mouseOverGui = isMouseWheelOnCEGUIWindow();
+        const double leftIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
+        const double rightIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
+        const double topIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
+        const double bottomIntensity = mouseOverGui ? 0.0 : getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
 
         if (leftIntensity > 0.0)
             ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -469,6 +469,12 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
     if(cameraInputBlocked())
         return;
 
+    // Native OIS reports 120 units per wheel notch; the SFML bridge reports notches.
+    float wheelNotches = static_cast<float>(arg.delta);
+#ifndef OD_USE_SFML_WINDOW
+    wheelNotches /= 120.0f;
+#endif
+
     if (arg.delta > 0)
     {
         if (getKeyboard()->isModifierDown(OIS::Keyboard::Ctrl))
@@ -477,7 +483,7 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
         }
         else
         {
-            frameListener.getCameraManager()->zoomBy(-0.2f * arg.delta);
+            frameListener.getCameraManager()->zoomBy(-0.2f * wheelNotches);
         }
     }
     else if (arg.delta < 0)
@@ -488,7 +494,7 @@ void GameMode::handleMouseWheel(const MouseWheelEvent &arg)
         }
         else
         {
-            frameListener.getCameraManager()->zoomBy(-0.2f * arg.delta);
+            frameListener.getCameraManager()->zoomBy(-0.2f * wheelNotches);
         }
     }
 }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -87,7 +87,7 @@ GameMode::GameMode(ModeManager *modeManager):
     mDigSetBool(false),
     mIsSpellCooldownDisplayed(false),
     mIndexEvent(0),
-    mSettings(SettingsWindow(mRootWindow)),
+    mSettings(mRootWindow, modeManager->getGui()),
     mIsSkillWindowOpen(false),
     mCurrentSkillType(SkillType::nullSkillType),
     mCurrentSkillProgress(0.0),
@@ -2010,7 +2010,7 @@ void GameMode::buildPlayerSettingsWindow()
         mSeatIds.push_back(seat->getId());
         offset += 15;
     }
+
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
 }
-
-
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -83,6 +83,20 @@ static double getAutoscrollIntensity(int mousePosition, int screenSize, bool min
     return std::max(0.0, std::min(1.0, (edgeSize - distanceFromEdge) / edgeSize));
 }
 
+static bool blocksEdgeScrolling(CEGUI::Window* window)
+{
+    if(window == nullptr || window->getName() == "Root")
+        return false;
+
+    for(CEGUI::Window* parent = window; parent != nullptr; parent = parent->getParent())
+    {
+        if(parent->isUserStringDefined("AllowEdgeScrolling") &&
+           parent->getUserString("AllowEdgeScrolling") == "true")
+            return false;
+    }
+    return true;
+}
+
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -70,6 +70,18 @@ const std::string TEXT_SEAT_ID_PREFIX = "TextSeat";
 const std::string TEXT_SEAT_PLAYER_NICKNAME_PREFIX = "TextSeatPlayerNick";
 const std::string TEXT_SEAT_TEAM_ID_PREFIX = "TextSeatTeam";
 
+const double AUTOSCROLL_EDGE_RATIO = 0.02;
+
+static double getAutoscrollIntensity(int mousePosition, int screenSize, bool minimumEdge)
+{
+    if(screenSize <= 1)
+        return 0.0;
+
+    const double edgeSize = AUTOSCROLL_EDGE_RATIO * screenSize;
+    const int distanceFromEdge = minimumEdge ? mousePosition : screenSize - 1 - mousePosition;
+    return std::max(0.0, std::min(1.0, (edgeSize - distanceFromEdge) / edgeSize));
+}
+
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
@@ -375,23 +387,28 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     if (!directionKeyPressed && config.getInputValue(Config::AUTOSCROLL, "No", false) == "Yes")
     {
-        if (arg.state.X.abs <= 0.02 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft);
+        const double leftIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, true);
+        const double rightIntensity = getAutoscrollIntensity(arg.state.X.abs, arg.state.width, false);
+        const double topIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, true);
+        const double bottomIntensity = getAutoscrollIntensity(arg.state.Y.abs, arg.state.height, false);
+
+        if (leftIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveLeft, leftIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopLeft);
 
-        if (arg.state.X.abs >= 0.98 * arg.state.width)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight);
+        if (rightIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveRight, rightIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopRight);
 
-        if (arg.state.Y.abs <= 0.02 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward);
+        if (topIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveForward, topIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopForward);
 
-        if (arg.state.Y.abs >= 0.98 * arg.state.height)
-            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward);
+        if (bottomIntensity > 0.0)
+            ODFrameListener::getSingleton().moveCamera(CameraManager::moveBackward, bottomIntensity);
         else
             ODFrameListener::getSingleton().moveCamera(CameraManager::stopBackward);            
     }

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -33,6 +33,7 @@ class Window;
 }
 
 class Creature;
+class MiniMapDrawnFull;
 
 enum class SpellType;
 enum class SkillType;
@@ -272,13 +273,23 @@ private:
     bool isMouseDownOnCEGUIWindow();
     bool isMouseWheelOnCEGUIWindow();
 
-    bool cameraInputBlocked();
     void updateCameraControls(float elapsed) override;
     bool showUserCameras(const CEGUI::EventArgs& = {});
     bool closeUserCameras(const CEGUI::EventArgs& = {});
     bool selectUserCamera(const CEGUI::EventArgs&);
     bool storeUserCamera(const CEGUI::EventArgs&);
     unsigned int mUserCameraSlot = 0;
+
+    bool toggleMap(const CEGUI::EventArgs& = {});
+    bool closeMap(const CEGUI::EventArgs& = {});
+    bool clickMap(const CEGUI::EventArgs&);
+    bool zoomMiniMap(const CEGUI::EventArgs&);
+    void updateMapDetail();
+    void focusRoom(RoomType type);
+    std::unique_ptr<MiniMapDrawnFull> mFullMap;
+    int mSavedMiniMapZoom = 0;
+    size_t mIndexPortal = 0;
+    bool mMapKeyDown = false;
 
 
     //! \brief whether to allow showing the window with debug Tile info under middlemouse button click

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -272,8 +272,13 @@ private:
     bool isMouseDownOnCEGUIWindow();
     bool isMouseWheelOnCEGUIWindow();
 
-    //! \brief Whether the keyboard keys moving camera are pressed down
-    bool directionKeyPressed;
+    bool cameraInputBlocked();
+    void updateCameraControls(float elapsed) override;
+    bool showUserCameras(const CEGUI::EventArgs& = {});
+    bool closeUserCameras(const CEGUI::EventArgs& = {});
+    bool selectUserCamera(const CEGUI::EventArgs&);
+    bool storeUserCamera(const CEGUI::EventArgs&);
+    unsigned int mUserCameraSlot = 0;
 
 
     //! \brief whether to allow showing the window with debug Tile info under middlemouse button click

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -29,6 +29,7 @@
 
 #include <OISInputManager.h>
 #include <OgreRenderWindow.h>
+#include <exception>
 
 InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager(nullptr),
@@ -52,7 +53,10 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mMouse(nullptr),
     mCurrentAMode(nullptr),
     mHighlightedCreature(nullptr),
-    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied)
+    mCreatureTypeForOutliner(SelectionEntityWanted::creatureAliveAllied),
+    mRenderWindow(renderWindow),
+    mMouseGrab(false),
+    mKeyboardGrab(false)
 #ifdef OD_USE_SFML_WINDOW
     ,
     mListener(Utils::make_unique<SFMLToOISListener>(mCurrentAMode, renderWindow->getWidth(), renderWindow->getHeight()))
@@ -67,17 +71,20 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
         mHotkeyLocation[i].qq = Ogre::Quaternion::IDENTITY;
     }
 
+    ConfigManager& config = ConfigManager::getSingleton();
+    createInputDevices(config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes",
+                       config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes");
+}
+
+void InputManager::createInputDevices(bool mouseGrab, bool keyboardGrab)
+{
 #ifndef OD_USE_SFML_WINDOW
 
     // Get the Window attribute for OIS.
     size_t windowHnd = 0;
-    renderWindow->getCustomAttribute("WINDOW", &windowHnd);
+    mRenderWindow->getCustomAttribute("WINDOW", &windowHnd);
     std::ostringstream windowHndStr;
     windowHndStr << windowHnd;
-
-    ConfigManager& config = ConfigManager::getSingleton();
-    bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
-    bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
 
     //setup parameter list for OIS
     OIS::ParamList paramList;
@@ -101,7 +108,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mInputManager = OIS::InputManager::createInputSystem(paramList);
 
     //setup Keyboard
-    auto oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
+    OIS::Keyboard* oisKeyboard = static_cast<OIS::Keyboard*>(mInputManager->createInputObject(OIS::OISKeyboard, true));
 
     oisKeyboard->setTextTranslation(OIS::Keyboard::Unicode);
 
@@ -112,6 +119,11 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
 #else
     mKeyboard.reset(new Keyboard());
 #endif
+    mMouseGrab = mouseGrab;
+    mKeyboardGrab = keyboardGrab;
+    setWidthAndHeight(mRenderWindow->getWidth(), mRenderWindow->getHeight());
+    if(mCurrentAMode != nullptr)
+        setCurrentAMode(*mCurrentAMode);
 }
 
 template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
@@ -120,12 +132,79 @@ template<> InputManager* Ogre::Singleton<InputManager>::msSingleton = nullptr;
 InputManager::~InputManager()
 {
     OD_LOG_INF("*** Destroying Input Manager ***");
-#ifndef OD_USE_SFML_WINDOW
-    mInputManager->destroyInputObject(mMouse);
-    mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+    destroyInputDevices();
+}
 
-    OIS::InputManager::destroyInputSystem(mInputManager);
+void InputManager::destroyInputDevices()
+{
+#ifndef OD_USE_SFML_WINDOW
+    if(mInputManager != nullptr)
+    {
+        if(mMouse != nullptr)
+            mInputManager->destroyInputObject(mMouse);
+        if(mKeyboard != nullptr)
+            mInputManager->destroyInputObject(mKeyboard->getKeyboard());
+        OIS::InputManager::destroyInputSystem(mInputManager);
+    }
     mInputManager = nullptr;
+    mMouse = nullptr;
+#endif
+    mKeyboard.reset();
+}
+
+void InputManager::refreshSettings()
+{
+    // Called before capturing input, never from inside an OIS callback.
+    ConfigManager& config = ConfigManager::getSingleton();
+    const bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
+    const bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
+    if(mouseGrab == mMouseGrab && keyboardGrab == mKeyboardGrab)
+        return;
+
+    const bool previousMouseGrab = mMouseGrab;
+    const bool previousKeyboardGrab = mKeyboardGrab;
+    destroyInputDevices();
+    try
+    {
+        createInputDevices(mouseGrab, keyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply input capture settings: " + std::string(error.what()));
+        destroyInputDevices();
+        config.setInputValue(Config::MOUSE_GRAB, previousMouseGrab ? "Yes" : "No");
+        config.setInputValue(Config::KEYBOARD_GRAB, previousKeyboardGrab ? "Yes" : "No");
+        config.saveUserConfig();
+        createInputDevices(previousMouseGrab, previousKeyboardGrab);
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+}
+
+bool InputManager::setRenderWindow(Ogre::RenderWindow* renderWindow)
+{
+    if(renderWindow == mRenderWindow)
+        return true;
+
+#ifdef OD_USE_SFML_WINDOW
+    return false;
+#else
+    Ogre::RenderWindow* previousWindow = mRenderWindow;
+    destroyInputDevices();
+    mRenderWindow = renderWindow;
+    try
+    {
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not move input to the new render window: " + std::string(error.what()));
+        destroyInputDevices();
+        mRenderWindow = previousWindow;
+        createInputDevices(mMouseGrab, mKeyboardGrab);
+        return false;
+    }
+    mLMouseDown = mRMouseDown = mMMouseDown = false;
+    return true;
 #endif
 }
 

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -75,6 +75,8 @@ public:
     void setWidthAndHeight(int width, int height);
     void setCurrentAMode(AbstractApplicationMode& mode);
     void handleSFMLEvent(const sf::Event& evt);
+    void refreshSettings();
+    bool setRenderWindow(Ogre::RenderWindow* renderWindow);
 
     OIS::InputManager*  mInputManager;
 
@@ -104,6 +106,11 @@ public:
     
     private:
     AbstractApplicationMode* mCurrentAMode;
+    Ogre::RenderWindow* mRenderWindow;
+    bool mMouseGrab;
+    bool mKeyboardGrab;
+    void createInputDevices(bool mouseGrab, bool keyboardGrab);
+    void destroyInputDevices();
 #ifdef OD_USE_SFML_WINDOW
     std::unique_ptr<SFMLToOISListener> mListener;
 #endif

--- a/source/modes/Keyboard.cpp
+++ b/source/modes/Keyboard.cpp
@@ -1,5 +1,6 @@
 #ifdef OD_USE_SFML_WINDOW
 #include <SFML/Window/Keyboard.hpp>
+#include "modes/SFMLToOISListener.h"
 #endif
 
 #include "Keyboard.h"
@@ -23,5 +24,25 @@ bool Keyboard::isModifierDown(OIS::Keyboard::Modifier code)
     return false;
 #else
     return mKeyboard->isModifierDown(code);
+#endif
+}
+
+bool Keyboard::isKeyDown(OIS::KeyCode code)
+{
+#ifdef OD_USE_SFML_WINDOW
+    if(code == OIS::KC_UNASSIGNED)
+        return false;
+    static const auto keyMap = []
+    {
+        std::array<CEGUI::Key::Scan, sf::Keyboard::KeyCount> keys{};
+        initKeyTable(keys);
+        return keys;
+    }();
+    for(size_t i = 0; i < keyMap.size(); ++i)
+        if(static_cast<OIS::KeyCode>(keyMap[i]) == code)
+            return sf::Keyboard::isKeyPressed(static_cast<sf::Keyboard::Key>(i));
+    return false;
+#else
+    return mKeyboard->isKeyDown(code);
 #endif
 }

--- a/source/modes/Keyboard.h
+++ b/source/modes/Keyboard.h
@@ -8,6 +8,7 @@ class Keyboard
 {
 public:
     bool isModifierDown(OIS::Keyboard::Modifier code);
+    bool isKeyDown(OIS::KeyCode code);
 #ifndef OD_USE_SFML_WINDOW
     Keyboard(OIS::Keyboard* kb) : mKeyboard(kb) {}
 

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -259,6 +259,8 @@ void MenuModeConfigureSeats::activate()
         offset += 30;
     }
 
+    getModeManager().getGui().registerWindowHierarchy(tmpWin);
+
     tmpWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers/LaunchGameButton");
     tmpWin->setEnabled(enabled);
 

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -71,7 +71,7 @@ public:
 
 MenuModeMain::MenuModeMain(ModeManager *modeManager):
     AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN),
-    mSettings(SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
+    mSettings(getModeManager().getGui().getGuiSheet(Gui::mainMenu), modeManager->getGui())
 {
     CEGUI::Window* rootWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);
     OD_ASSERT_TRUE(rootWin != nullptr);

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -165,5 +165,6 @@ void ModeManager::update(const Ogre::FrameEvent& evt)
 #endif
     //currentMode->mouseMoved(OIS::MouseEvent(nullptr, currentMode->getMouse()->getMouseState()));
 
+    currentMode->updateCameraControls(evt.timeSinceLastFrame);
     currentMode->onFrameStarted(evt);
 }

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -154,6 +154,7 @@ void ModeManager::checkModeChange()
 void ModeManager::update(const Ogre::FrameEvent& evt)
 {
     checkModeChange();
+    mInputManager.refreshSettings();
 
     // We update the current mode
     AbstractApplicationMode* currentMode = getCurrentMode();

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -18,6 +18,7 @@
 #include "modes/SettingsWindow.h"
 
 #include "gamemap/MiniMap.h"
+#include "network/ODClient.h"
 #include "camera/CameraManager.h"
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
@@ -33,17 +34,20 @@
 #include <CEGUI/WindowManager.h>
 
 #include <OgreRoot.h>
+#include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreSceneManager.h>
 
 #include <SFML/Audio/Listener.hpp>
 
 #include <algorithm>
+#include <exception>
+#include <map>
 
 SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
-    mRootWindow(rootWindow),
-    dynamicShadowsChanged(false)
+    mRootWindow(rootWindow)
 {
     if (rootWindow == nullptr)
     {
@@ -140,14 +144,6 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
             CEGUI::Event::Subscriber(&SettingsWindow::onPopupApplySettings, this)
         )
     );
-
-    addEventConnection(
-        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/DynamicShadowsCheckbox")->subscribeEvent(
-            CEGUI::ToggleButton::EventSelectStateChanged,
-            CEGUI::Event::Subscriber(&SettingsWindow::onTriggerDynamicShadows, this)
-        )
-    );
-    
 
     initConfig();
 }
@@ -292,7 +288,6 @@ void SettingsWindow::initConfig()
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
     dynamicShadowsCheckBox->setSelected( config.getUserValue(Config::Ctg::AUDIO,Config::SHADOWS,"",false) == "Yes");
-    dynamicShadowsChanged = false;
     Ogre::ConfigOptionMap::const_iterator it = options.find(Config::VIDEO_MODE);
     if (it != options.end())
     {
@@ -409,7 +404,7 @@ void SettingsWindow::initConfig()
     }
 }
 
-void SettingsWindow::saveConfig()
+bool SettingsWindow::saveConfig()
 {
     Ogre::Root* ogreRoot = Ogre::Root::getSingletonPtr();
     ConfigManager& config = ConfigManager::getSingleton();
@@ -419,6 +414,7 @@ void SettingsWindow::saveConfig()
     CEGUI::Editbox* usernameEb = static_cast<CEGUI::Editbox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/NicknameEdit"));
     config.setGameValue(Config::NICKNAME, usernameEb->getText().c_str());
+    ODClient::getSingleton().requestNicknameChange(usernameEb->getText().c_str());
 
     CEGUI::Combobox* keeperVoiceCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/KeeperVoice"));
@@ -470,98 +466,136 @@ void SettingsWindow::saveConfig()
     // Video
     Ogre::RenderSystem* renderer = ogreRoot->getRenderSystem();
 
-    // Changing Ogre renderer needs a restart to allow to load shaders and requested stuff
     CEGUI::Combobox* rdrCb = static_cast<CEGUI::Combobox*>(
     mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/RendererCombobox"));
     std::string rendererName = rdrCb->getSelectedItem()->getText().c_str();
-    if (rendererName != renderer->getName() || dynamicShadowsChanged)
+    if (rendererName != renderer->getName())
     {
-        renderer = ogreRoot->getRenderSystemByName(rendererName);
-        if (renderer == nullptr)
-        {
-            const Ogre::RenderSystemList& renderers = ogreRoot->getAvailableRenderers();
-            if (renderers.empty())
-            {
-                OD_LOG_ERR("No valid renderer found while searching for " + std::string(rdrCb->getSelectedItem()->getText().c_str()));
-                return;
-            }
-            renderer = *renderers.begin();
-            OD_LOG_WRN("Wanted renderer : " + std::string(rdrCb->getSelectedItem()->getText().c_str()) + " not found. Using the first available: " + renderer->getName());
-        }
-
-        config.setVideoValue(Config::RENDERER, renderer->getName());
-        config.saveUserConfig();
-
-        // If render changed, we need to restart game.
-        // Note that we do not change values according to the others inputs. The reason
-        // is that we don't know if the given values are acceptable for the selected renderer
-        if(rendererName != renderer->getName())
-            OD_LOG_INF("Changed Ogre renderer to " + rendererName + ". We need to restart");
-        else
-            OD_LOG_INF("Changed Ogre dynamic shadows. We need to restart.");
-        exit(0);
+        OD_LOG_ERR("Cannot replace the active renderer while the game is running: " + rendererName);
+        return false;
     }
 
-    
     config.setVideoValue(Config::RENDERER, renderer->getName());
 
-    // Set renderer-dependent options now we know it didn't change.
     CEGUI::ToggleButton* fsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/FullscreenCheckbox"));
-    renderer->setConfigOption(Config::FULL_SCREEN, (fsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::FULL_SCREEN, fsCheckBox->isSelected() ? "Yes" : "No");
-
     CEGUI::Combobox* resCb = static_cast<CEGUI::Combobox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/ResolutionCombobox"));
-    renderer->setConfigOption(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-    config.setVideoValue(Config::VIDEO_MODE, resCb->getSelectedItem()->getText().c_str());
-
-    // Stores the renderer dependent options
     CEGUI::ToggleButton* vsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/VSyncCheckbox"));
-    renderer->setConfigOption(Config::VSYNC, (vsCheckBox->isSelected() ? "Yes" : "No"));
-    config.setVideoValue(Config::VSYNC, fsCheckBox->isSelected() ? "Yes" : "No");
 
-    // Save renderer dependent settings and apply them.
+    std::map<std::string, std::string> selectedVideoOptions;
+    selectedVideoOptions[Config::FULL_SCREEN] = fsCheckBox->isSelected() ? "Yes" : "No";
+    selectedVideoOptions[Config::VIDEO_MODE] = resCb->getSelectedItem()->getText().c_str();
+    selectedVideoOptions[Config::VSYNC] = vsCheckBox->isSelected() ? "Yes" : "No";
     for (CEGUI::Window* combo : mCustomVideoComboBoxes)
-    {
-        std::string optionName = combo->getName().c_str();
-        std::string optionValue = combo->getText().c_str();
-        renderer->setConfigOption(optionName, optionValue);
-        config.setVideoValue(optionName, optionValue);
-    }
+        selectedVideoOptions[combo->getName().c_str()] = combo->getText().c_str();
 
-    config.saveUserConfig();
-
-    // Apply config
-
-    // Video
-    Ogre::RenderWindow* win = ogreRoot->getAutoCreatedWindow();
-    if(win == nullptr)
+    const Ogre::ConfigOptionMap initialRendererOptions = renderer->getConfigOptions();
+    std::map<std::string, std::string> previousRendererOptions;
+    std::map<std::string, std::string> previousVideoConfig;
+    bool resizeRenderWindow = false;
+    bool recreateRenderWindow = false;
+    for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
     {
-        OD_LOG_WRN("Changing window options when using sfml is not implemented yet! Please restart for the changes to have an effect.");
-    }
-    else
-    {
-        std::vector<std::string> resVtr = Helper::split(resCb->getSelectedItem()->getText().c_str(), 'x');
-        if (resVtr.size() == 2)
+        Ogre::ConfigOptionMap::const_iterator previous = initialRendererOptions.find(selected.first);
+        if(previous == initialRendererOptions.end())
+            continue;
+        previousRendererOptions[selected.first] = previous->second.currentValue;
+        previousVideoConfig[selected.first] = config.getVideoValue(
+            selected.first, previous->second.currentValue, false);
+        if(previous->second.currentValue == selected.second)
+            continue;
+        if(selected.first == Config::FULL_SCREEN || selected.first == Config::VIDEO_MODE)
         {
-            uint32_t width = static_cast<uint32_t>(Helper::toInt(resVtr[0]));
-            uint32_t height = static_cast<uint32_t>(Helper::toInt(resVtr[1]));
-            win->setFullscreen(fsCheckBox->isSelected(), width, height);
-
-            // In windowed mode, the window needs resizing through other means
-            // NOTE: Doesn't work when the window is maximized on certain Composers.
-            if (!fsCheckBox->isSelected())
-              win->resize(width, height);
+            resizeRenderWindow = true;
+            continue;
+        }
+        if(selected.first != Config::VSYNC && selected.first != "VSync Interval"
+            && selected.first != "Reversed Z-Buffer"
+            && selected.first != "Separate Shader Objects" && selected.first != "Debug Layer")
+        {
+            recreateRenderWindow = true;
         }
     }
+
+    ODFrameListener& frameListener = ODFrameListener::getSingleton();
+    try
+    {
+        renderer->setConfigOption(Config::FULL_SCREEN, selectedVideoOptions[Config::FULL_SCREEN]);
+        renderer->setConfigOption(Config::VIDEO_MODE, selectedVideoOptions[Config::VIDEO_MODE]);
+        renderer->setConfigOption(Config::VSYNC, selectedVideoOptions[Config::VSYNC]);
+        for (CEGUI::Window* combo : mCustomVideoComboBoxes)
+            renderer->setConfigOption(combo->getName().c_str(), combo->getText().c_str());
+
+        for(const std::pair<const std::string, std::string>& selected : selectedVideoOptions)
+            config.setVideoValue(selected.first, selected.second);
+        config.saveUserConfig();
+
+        const Ogre::SceneManager::CameraList& cameras = RenderManager::getSingleton().getSceneManager()->getCameras();
+        for(const std::pair<const Ogre::String, Ogre::Camera*>& camera : cameras)
+            camera.second->setAspectRatio(camera.second->getAspectRatio());
+
+        if(recreateRenderWindow)
+        {
+            frameListener.requestRenderWindowRecreation(previousRendererOptions, previousVideoConfig);
+        }
+        else
+        {
+            Ogre::RenderWindow* window = frameListener.getRenderWindow();
+            if(resizeRenderWindow)
+            {
+                const std::vector<std::string> resolution = Helper::split(
+                    selectedVideoOptions[Config::VIDEO_MODE], 'x');
+                if(resolution.size() != 2)
+                    throw std::runtime_error("invalid video mode: " + selectedVideoOptions[Config::VIDEO_MODE]);
+
+                const uint32_t width = static_cast<uint32_t>(Helper::toInt(resolution[0]));
+                const uint32_t height = static_cast<uint32_t>(Helper::toInt(resolution[1]));
+                const bool fullscreen = fsCheckBox->isSelected();
+                window->setFullscreen(fullscreen, width, height);
+                if(!fullscreen)
+                    window->resize(width, height);
+                window->windowMovedOrResized();
+                frameListener.windowResized(window);
+            }
+            window->setVSyncInterval(static_cast<unsigned int>(Helper::toInt(
+                config.getVideoValue("VSync Interval", "1", false))));
+            window->setVSyncEnabled(vsCheckBox->isSelected());
+        }
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        std::map<std::string, std::string>::const_iterator fullscreen =
+            previousRendererOptions.find(Config::FULL_SCREEN);
+        if(fullscreen != previousRendererOptions.end())
+            renderer->setConfigOption(fullscreen->first, fullscreen->second);
+        std::map<std::string, std::string>::const_iterator videoMode =
+            previousRendererOptions.find(Config::VIDEO_MODE);
+        if(videoMode != previousRendererOptions.end())
+            renderer->setConfigOption(videoMode->first, videoMode->second);
+        for(const std::pair<const std::string, std::string>& option : previousRendererOptions)
+        {
+            if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+                continue;
+            renderer->setConfigOption(option.first, option.second);
+        }
+        for(const std::pair<const std::string, std::string>& option : previousVideoConfig)
+            config.setVideoValue(option.first, option.second);
+        config.saveUserConfig();
+        initConfig();
+        return false;
+    }
+    RenderManager::getSingleton().setDynamicShadowsEnabled(dynamicShadowsCheckBox->isSelected());
+    return true;
 }
 
 void SettingsWindow::show()
 {
     if (mSettingsWindow)
     {
+        initConfig();
         // Input only allowed on this window when visible.
         mSettingsWindow->setModalState(true);
         mSettingsWindow->show();
@@ -630,8 +664,8 @@ bool SettingsWindow::onApplySettings(const CEGUI::EventArgs&)
         return true;
     }
 
-    saveConfig();
-    hide();
+    if(saveConfig())
+        hide();
     return true;
 }
 
@@ -709,11 +743,6 @@ bool SettingsWindow::onLightFactorChanged(const CEGUI::EventArgs&)
     return true;
 }
 
-
-void SettingsWindow::onTriggerDynamicShadows(const CEGUI::EventArgs&)
-{
-    dynamicShadowsChanged = !dynamicShadowsChanged;
-}
 
 void SettingsWindow::setLightFactorValue(float lightFactor)
 {

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -20,6 +20,7 @@
 #include "gamemap/MiniMap.h"
 #include "network/ODClient.h"
 #include "camera/CameraManager.h"
+#include "render/Gui.h"
 #include "render/ODFrameListener.h"
 #include "render/RenderManager.h"
 #include "utils/ConfigManager.h"
@@ -43,11 +44,13 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <sstream>
 
-SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
+SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow, Gui& gui):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
-    mRootWindow(rootWindow)
+    mRootWindow(rootWindow),
+    mGui(gui)
 {
     if (rootWindow == nullptr)
     {
@@ -145,7 +148,15 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
         )
     );
 
+    addEventConnection(
+        mSettingsWindow->getChild("MainTabControl/Video/VideoSP/UIScaleCombobox")->subscribeEvent(
+            CEGUI::Combobox::EventListSelectionAccepted,
+            CEGUI::Event::Subscriber(&SettingsWindow::onUiScaleChanged, this)
+        )
+    );
+
     initConfig();
+    mGui.registerWindowHierarchy(mApplyWindow);
 }
 
 SettingsWindow::~SettingsWindow()
@@ -331,6 +342,32 @@ void SettingsWindow::initConfig()
         vsCheckBox->setSelected((vsync.currentValue == "Yes"));
     }
 
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    uiScaleCb->setReadOnly(true);
+    uiScaleCb->resetList();
+    int configuredUiScale = 100;
+    std::istringstream uiScaleParser(config.getGameValue(Config::UI_SCALE, "100", false));
+    if(!(uiScaleParser >> configuredUiScale))
+        configuredUiScale = 100;
+    configuredUiScale = std::max(static_cast<int>(Gui::MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<int>(Gui::MAX_UI_SCALE_PERCENT), configuredUiScale));
+    configuredUiScale = (configuredUiScale + 5) / 10 * 10;
+    for(uint32_t uiScale = Gui::MIN_UI_SCALE_PERCENT;
+        uiScale <= Gui::MAX_UI_SCALE_PERCENT; uiScale += 10)
+    {
+        CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(
+            Helper::toString(uiScale) + "%", uiScale);
+        item->setSelectionBrushImage(selImg);
+        uiScaleCb->addItem(item);
+        if(static_cast<int>(uiScale) == configuredUiScale)
+        {
+            uiScaleCb->setItemSelectState(item, true);
+            uiScaleCb->setText(item->getText());
+        }
+    }
+    mGui.setUserScalePercent(static_cast<float>(configuredUiScale));
+
     //! First of all, clear up the previously created windows.
     CEGUI::WindowManager& winMgr = CEGUI::WindowManager::getSingleton();
     CEGUI::Window* parentWindow = mSettingsWindow->getChild("MainTabControl/Video/VideoSP/");
@@ -370,13 +407,13 @@ void SettingsWindow::initConfig()
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));
-        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 155 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
+        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 190 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
         videoCbText->setText(optionName + ": ");
         videoCbText->setProperty("FrameEnabled", "False");
         videoCbText->setProperty("BackgroundEnabled", "False");
 
         CEGUI::Combobox* videoCb = static_cast<CEGUI::Combobox*>(videoTab->createChild("OD/Combobox", optionName));
-        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 160 + offset), CEGUI::UDim(0.5, -20),
+        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 195 + offset), CEGUI::UDim(0.5, -20),
                          CEGUI::UDim(0, config.possibleValues.size() * 17 + 30));
         videoCb->setReadOnly(true);
         videoCb->setSortingEnabled(true);
@@ -402,6 +439,8 @@ void SettingsWindow::initConfig()
         }
         offset += 30;
     }
+
+    mGui.registerWindowHierarchy(mSettingsWindow);
 }
 
 bool SettingsWindow::saveConfig()
@@ -458,6 +497,12 @@ bool SettingsWindow::saveConfig()
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     config.setAudioValue(Config::MUSIC_VOLUME, Helper::toString(volumeSlider->getCurrentValue()));
+
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* uiScaleItem = uiScaleCb->getSelectedItem();
+    if(uiScaleItem != nullptr)
+        config.setGameValue(Config::UI_SCALE, Helper::toString(uiScaleItem->getID()));
 
     CEGUI::ToggleButton* dynamicShadowsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/DynamicShadowsCheckbox"));
@@ -691,6 +736,16 @@ bool SettingsWindow::onMusicVolumeChanged(const CEGUI::EventArgs&)
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Audio/AudioSP/MusicSlider"));
     setMusicVolumeValue(volumeSlider->getCurrentValue());
+    return true;
+}
+
+bool SettingsWindow::onUiScaleChanged(const CEGUI::EventArgs&)
+{
+    CEGUI::Combobox* uiScaleCb = static_cast<CEGUI::Combobox*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VideoSP/UIScaleCombobox"));
+    CEGUI::ListboxItem* selectedItem = uiScaleCb->getSelectedItem();
+    if(selectedItem != nullptr)
+        mGui.setUserScalePercent(static_cast<float>(selectedItem->getID()));
     return true;
 }
 

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -407,13 +407,13 @@ void SettingsWindow::initConfig()
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));
-        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 190 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 30));
+        videoCbText->setArea(CEGUI::UDim(0, 20), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.4, 0), CEGUI::UDim(0, 34));
         videoCbText->setText(optionName + ": ");
         videoCbText->setProperty("FrameEnabled", "False");
         videoCbText->setProperty("BackgroundEnabled", "False");
 
         CEGUI::Combobox* videoCb = static_cast<CEGUI::Combobox*>(videoTab->createChild("OD/Combobox", optionName));
-        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 195 + offset), CEGUI::UDim(0.5, -20),
+        videoCb->setArea(CEGUI::UDim(0.5, 0), CEGUI::UDim(0, 238 + offset), CEGUI::UDim(0.5, -20),
                          CEGUI::UDim(0, config.possibleValues.size() * 17 + 30));
         videoCb->setReadOnly(true);
         videoCb->setSortingEnabled(true);
@@ -437,7 +437,7 @@ void SettingsWindow::initConfig()
             }
             ++cbIndex;
         }
-        offset += 30;
+        offset += 40;
     }
 
     mGui.registerWindowHierarchy(mSettingsWindow);

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -37,6 +37,8 @@
 
 #include <SFML/Audio/Listener.hpp>
 
+#include <algorithm>
+
 SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     mSettingsWindow(nullptr),
     mApplyWindow(nullptr),
@@ -365,6 +367,11 @@ void SettingsWindow::initConfig()
         // If the option is immutable, we can't change it and shouldn't see it. (at least for now)
         if (config.immutable || config.possibleValues.empty())
             continue;
+
+        // OGRE may repeat colour depths for different fullscreen refresh rates.
+        std::sort(config.possibleValues.begin(), config.possibleValues.end());
+        config.possibleValues.erase(std::unique(config.possibleValues.begin(), config.possibleValues.end()),
+                                   config.possibleValues.end());
 
         // The text next to the combobox
         CEGUI::DefaultWindow* videoCbText = static_cast<CEGUI::DefaultWindow*>(videoTab->createChild("OD/StaticText", optionName + "_Text"));

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -25,6 +25,8 @@
 
 #include <vector>
 
+class Gui;
+
 //! \brief This class is creating a setting window gui child to the current gui context
 //! and populates its widgets with the current game, video, audio values.
 //! It also permits to change them.
@@ -34,7 +36,7 @@ public:
     //! \brief Settings window constructor
     //! \param rootWindow The main CEGUI window used as background to the current mode.
     //! Used to load and later show the settings window.
-    SettingsWindow(CEGUI::Window* rootWindow);
+    SettingsWindow(CEGUI::Window* rootWindow, Gui& gui);
 
     ~SettingsWindow();
 
@@ -64,6 +66,8 @@ private:
 
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
+
+    Gui& mGui;
 
     //! \brief The temporary video comboboxes and texts created depending on the video settings.
     std::vector<CEGUI::Window*> mCustomVideoComboBoxes;
@@ -99,6 +103,9 @@ private:
     //! \brief Called when changing the ambient light factor value.
     bool onLightFactorChanged(const CEGUI::EventArgs&);
     bool onPanSpeedChanged(const CEGUI::EventArgs&);
+
+    //! \brief Applies the selected UI scale immediately.
+    bool onUiScaleChanged(const CEGUI::EventArgs&);
 
     //! \brief Set the volume value in the ambient light factor setting text and slider.
     void setLightFactorValue(float lightFactor);

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -52,7 +52,6 @@ public:
     //! \brief Called when pushing the cancel button on the settings window.
     bool onCancelSettings(const CEGUI::EventArgs& e = {});
 
-    void onTriggerDynamicShadows(const CEGUI::EventArgs& );
 private:
     //! \brief Vector of cegui event bindings to be cleared on exiting the mode
     std::vector<CEGUI::Event::Connection> mEventConnections;
@@ -73,8 +72,8 @@ private:
     //! \brief Set the different widget values according to current config.
     void initConfig();
 
-    //! \brief Save the config, potentially stopping the application if it needs to.
-    void saveConfig();
+    //! \brief Save and apply the config. Returns false if a selected value could not be applied.
+    bool saveConfig();
 
     //! \brief Adds an event binding to be cleared on exiting the mode.
     inline void addEventConnection(CEGUI::Event::Connection conn)
@@ -105,7 +104,6 @@ private:
     void setLightFactorValue(float lightFactor);
     void setPanSpeedValue(float panSpeedPercent);
 
-    bool dynamicShadowsChanged;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -127,6 +127,8 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "editorAskPortalWaveData";
         case ClientNotificationType::editorSetPortalWaveData:
             return "editorSetPortalWaveData";
+        case ClientNotificationType::changeNick:
+            return "changeNick";
         default:
             OD_LOG_ERR("Unknown enum for ClientNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -79,7 +79,10 @@ enum class ClientNotificationType
     editorAskCreateMapLight,
     editorSetCreatureLevel,
     editorAskPortalWaveData,
-    editorSetPortalWaveData
+    editorSetPortalWaveData,
+
+    // Append new messages to preserve existing network and replay identifiers.
+    changeNick
 };
 
 ODPacket& operator<<(ODPacket& os, const ClientNotificationType& nt);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -224,9 +224,17 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             ServerMode serverMode;
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
+            // Older servers and replays end this packet after the server mode.
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            setSupportsLiveNickname(liveNickname);
+
             ODPacket packSend;
             const std::string& nick = gameMap->getLocalPlayerNick();
             packSend << ClientNotificationType::setNick << nick;
+            if(liveNickname)
+                packSend << true;
             send(packSend);
 
             // We can proceed to configure seat level
@@ -289,6 +297,23 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
                 OD_ASSERT_TRUE(packetReceived >> nick >> id);
                 mode->addPlayer(nick, id);
                 addEventMessage(new EventMessage(nick + " is now connected."));
+            }
+            break;
+        }
+
+        case ServerNotificationType::playerNickChanged:
+        {
+            int32_t playerId;
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> playerId >> nickname);
+            for(Player* player : gameMap->getPlayers())
+            {
+                if(player->getId() != playerId)
+                    continue;
+                player->setNick(nickname);
+                if(player == getPlayer())
+                    gameMap->setLocalPlayerNick(nickname);
+                break;
             }
             break;
         }
@@ -1465,6 +1490,18 @@ bool ODClient::replay(const std::string& filename)
 void ODClient::queueClientNotification(ClientNotification* n)
 {
     mClientNotificationQueue.push_back(n);
+}
+
+void ODClient::requestNicknameChange(const std::string& nickname)
+{
+    if(getSource() != ODSource::network || getPlayer() == nullptr || getPlayer()->getNick() == nickname)
+        return;
+    if(!supportsLiveNickname())
+    {
+        OD_LOG_WRN("The connected server does not support changing the current player's nickname.");
+        return;
+    }
+    queueClientNotification(ClientNotificationType::changeNick, nickname);
 }
 
 void ODClient::disconnect(bool keepReplay)

--- a/source/network/ODClient.h
+++ b/source/network/ODClient.h
@@ -58,6 +58,8 @@ class ODClient: public Ogre::Singleton<ODClient>,
     //! \brief Adds a client notification to the client notification queue.
     void queueClientNotification(ClientNotification* n);
 
+    void requestNicknameChange(const std::string& nickname);
+
     /*! \brief Adds a client notification to the client notification queue.
      *  \param type The type of the notification
      *  \param args The arguments that are to be piped into the notification.

--- a/source/network/ODPacket.h
+++ b/source/network/ODPacket.h
@@ -122,6 +122,9 @@ class ODPacket
          */
         operator bool() const;
 
+        bool endOfPacket() const
+        { return mPacket.endOfPacket(); }
+
         /*! \brief Clears the packet. After calling Clear, the packet should
          * be empty.
          */
@@ -158,4 +161,3 @@ class ODPacket
 };
 
 #endif // ODPACKET_H
-

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -896,7 +896,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             clientSocket->setState("nick");
             // Tell the client to give us their nickname
             ODPacket packetSend;
-            packetSend << ServerNotificationType::pickNick << mServerMode;
+            packetSend << ServerNotificationType::pickNick << mServerMode << true;
             clientSocket->send(packetSend);
             break;
         }
@@ -909,6 +909,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // Pick nick
             std::string clientNick;
             OD_ASSERT_TRUE(packetReceived >> clientNick);
+            bool liveNickname = false;
+            if(!packetReceived.endOfPacket())
+                OD_ASSERT_TRUE(packetReceived >> liveNickname);
+            clientSocket->setSupportsLiveNickname(liveNickname);
 
             // NOTE : playerId 0 is reserved for inactive players and 1 is reserved for AI
             int32_t playerId = mUniqueNumberPlayer + Seat::PLAYER_ID_HUMAN_MIN;
@@ -962,6 +966,27 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             packetSend << ServerNotificationType::startGameMode << seatId << mServerMode;
             clientSocket->send(packetSend);
             mSeatsConfigured = true;
+            break;
+        }
+
+        case ClientNotificationType::changeNick:
+        {
+            if(mServerState != ServerState::StateGame || !clientSocket->supportsLiveNickname()
+                || clientSocket->getPlayer() == nullptr)
+                break;
+
+            std::string nickname;
+            OD_ASSERT_TRUE(packetReceived >> nickname);
+            Player* player = clientSocket->getPlayer();
+            player->setNick(nickname);
+            const int32_t playerId = player->getId();
+            ODPacket packetSend;
+            packetSend << ServerNotificationType::playerNickChanged << playerId << nickname;
+            for(ODSocketClient* client : mSockClients)
+            {
+                if(client->supportsLiveNickname())
+                    client->send(packetSend);
+            }
             break;
         }
 

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -60,6 +60,7 @@ bool ODSocketClient::replay(const std::string& filename)
 
 void ODSocketClient::disconnect(bool keepReplay)
 {
+    mSupportsLiveNickname = false;
     mPendingTimestamp = -1;
     ODSource src = mSource;
     mSource = ODSource::none;

--- a/source/network/ODSocketClient.h
+++ b/source/network/ODSocketClient.h
@@ -50,7 +50,8 @@ class ODSocketClient
             mSource(ODSource::none),
             mPlayer(nullptr),
             mLastTurnAck(-1),
-            mPendingTimestamp(-1)
+            mPendingTimestamp(-1),
+            mSupportsLiveNickname(false)
         {}
 
         virtual ~ODSocketClient()
@@ -68,6 +69,8 @@ class ODSocketClient
 
         Player* getPlayer() { return mPlayer; }
         void setPlayer(Player* player) { mPlayer = player; }
+        bool supportsLiveNickname() const { return mSupportsLiveNickname; }
+        void setSupportsLiveNickname(bool supported) { mSupportsLiveNickname = supported; }
         int64_t getLastTurnAck() { return mLastTurnAck; }
         void setLastTurnAck(int64_t lastTurnAck) { mLastTurnAck = lastTurnAck; }
         const std::string& getState() {return mState;}
@@ -130,6 +133,7 @@ class ODSocketClient
         std::ofstream mReplayOutputStream;
         ODPacket mPendingPacket;
         int32_t mPendingTimestamp;
+        bool mSupportsLiveNickname;
 
         //! \brief the replay filename being written. Used to later optionally delete it
         //! if asked to.
@@ -137,4 +141,3 @@ class ODSocketClient
 };
 
 #endif // ODSOCKETCLIENT_H
-

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -140,6 +140,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "displayText";
         case ServerNotificationType::editorPortalWaveData:
             return "editorPortalWaveData";
+        case ServerNotificationType::playerNickChanged:
+            return "playerNickChanged";
         default:
             OD_LOG_ERR("Unknown enum for ServerNotificationType="
                 + Helper::toString(static_cast<int>(type)));

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -102,7 +102,10 @@ enum class ServerNotificationType
     //! \brief Answer to the editor asking what the waves of a wave portal are
     editorPortalWaveData,
 
-    exit
+    exit,
+
+    // Sent only to clients that negotiated live nickname changes.
+    playerNickChanged
 };
 
 ODPacket& operator<<(ODPacket& os, const ServerNotificationType& nt);

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -129,7 +129,14 @@ CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)
     {
         return it->second;
     }
+
     return nullptr;
+}
+
+void Gui::setRenderTarget(Ogre::RenderTarget& renderTarget)
+{
+    static_cast<CEGUI::OgreRenderer*>(CEGUI::System::getSingleton().getRenderer())
+        ->setDefaultRootRenderTarget(renderTarget);
 }
 
 bool Gui::playButtonClickSound(const CEGUI::EventArgs&)

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -24,9 +24,11 @@
 
 #include "ODApplication.h"
 #include "sound/SoundEffectsManager.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 
 #include <CEGUI/CEGUI.h>
+#include <CEGUI/BasicImage.h>
 #include <CEGUI/RendererModules/Ogre/Renderer.h>
 #include <CEGUI/RendererModules/Ogre/ResourceProvider.h>
 #include <CEGUI/RendererModules/Ogre/ImageCodec.h>
@@ -34,10 +36,93 @@
 #include <CEGUI/System.h>
 #include <CEGUI/WindowManager.h>
 #include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/widgets/TabControl.h>
 #include <CEGUI/Event.h>
 
+#include <algorithm>
+#include <sstream>
+
+namespace
+{
+const float LAYOUT_DESIGN_WIDTH = 1024.0f;
+const float LAYOUT_DESIGN_HEIGHT = 768.0f;
+const float FONT_DESIGN_WIDTH = 800.0f;
+const float FONT_DESIGN_HEIGHT = 600.0f;
+
+void scaleDimension(CEGUI::UDim& dimension, float scale)
+{
+    dimension.d_offset *= scale;
+}
+
+CEGUI::URect scaleRect(const CEGUI::URect& rect, float scale)
+{
+    CEGUI::URect scaled(rect);
+    scaleDimension(scaled.d_min.d_x, scale);
+    scaleDimension(scaled.d_min.d_y, scale);
+    scaleDimension(scaled.d_max.d_x, scale);
+    scaleDimension(scaled.d_max.d_y, scale);
+    return scaled;
+}
+
+CEGUI::USize scaleSize(const CEGUI::USize& size, float scale)
+{
+    CEGUI::USize scaled(size);
+    scaleDimension(scaled.d_width, scale);
+    scaleDimension(scaled.d_height, scale);
+    return scaled;
+}
+
+bool shouldScaleImage(const CEGUI::String& ceguiName)
+{
+    const std::string name(ceguiName.c_str());
+    return name.compare(0, 17, "OpenDungeonsSkin/") == 0
+        || name.compare(0, 18, "OpenDungeonsIcons/") == 0
+        || name.compare(0, 17, "ODMainMenuButton/") == 0
+        || name.compare(0, 7, "ODLogo/") == 0;
+}
+
+std::string scaleFormattedImageSizes(const CEGUI::String& ceguiText, float scale)
+{
+    std::string text(ceguiText.c_str());
+    size_t tagStart = 0;
+    while((tagStart = text.find("[image-size='", tagStart)) != std::string::npos)
+    {
+        size_t tagEnd = text.find("']", tagStart);
+        if(tagEnd == std::string::npos)
+            break;
+
+        const char* dimensions[] = {"w:", "h:"};
+        for(const char* dimension : dimensions)
+        {
+            const size_t marker = text.find(dimension, tagStart);
+            if(marker == std::string::npos || marker >= tagEnd)
+                continue;
+
+            const size_t valueStart = marker + 2;
+            size_t valueEnd = valueStart;
+            while(valueEnd < tagEnd && ((text[valueEnd] >= '0' && text[valueEnd] <= '9') || text[valueEnd] == '.'))
+                ++valueEnd;
+
+            float value = 0.0f;
+            std::istringstream valueParser(text.substr(valueStart, valueEnd - valueStart));
+            if(!(valueParser >> value))
+                continue;
+
+            std::ostringstream scaledValue;
+            scaledValue << std::max(1, static_cast<int>(value * scale + 0.5f));
+            text.replace(valueStart, valueEnd - valueStart, scaledValue.str());
+            tagEnd = text.find("']", tagStart);
+        }
+
+        tagStart = tagEnd + 2;
+    }
+    return text;
+}
+}
+
 Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFileName, Ogre::RenderTarget &renderTarget)
-  : mSoundEffectsManager(soundEffectsManager)
+  : mUserScale(1.0f),
+    mSoundEffectsManager(soundEffectsManager)
 {
     OD_LOG_INF("*** Initializing CEGUI ***");
     CEGUI::OgreRenderer& renderer = CEGUI::OgreRenderer::create(renderTarget);
@@ -52,6 +137,15 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
     CEGUI::SchemeManager::getSingleton().createFromFile("ODSkin.scheme");
     OD_LOG_INF("CEGUI::SchemeManager created");
+
+    float configuredScalePercent = 100.0f;
+    std::istringstream scaleParser(ConfigManager::getSingleton().getGameValue(Config::UI_SCALE, "100", false));
+    if(!(scaleParser >> configuredScalePercent))
+        configuredScalePercent = 100.0f;
+    configuredScalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), configuredScalePercent));
+    mUserScale = configuredScalePercent / 100.0f;
+    updateResourceScaling(renderer.getDisplaySize());
 
     // We want Ogre overlays to be displayed in front of CEGUI. According to
     // http://cegui.org.uk/forum/viewtopic.php?f=10&t=5694
@@ -83,6 +177,17 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
     mSheets[loadSavedGameMenu] =  wmgr->loadLayoutFromFile("MenuLoad.layout");
     mSheets[console] = wmgr->loadLayoutFromFile("WindowConsole.layout");
 
+    mDisplaySizeChangedConnection = CEGUI::System::getSingleton().subscribeEvent(
+        CEGUI::System::EventDisplaySizeChanged,
+        CEGUI::Event::Subscriber(&Gui::onDisplaySizeChanged, this));
+    mWindowDestroyedConnection = wmgr->subscribeEvent(
+        CEGUI::WindowManager::EventWindowDestroyed,
+        CEGUI::Event::Subscriber(&Gui::onWindowDestroyed, this));
+
+    for(const auto& sheet : mSheets)
+        registerWindow(sheet.second);
+    applyScale(renderer.getDisplaySize());
+
     // Set the game version
     mSheets[mainMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
     mSheets[skirmishMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
@@ -103,6 +208,8 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
 
 Gui::~Gui()
 {
+    mDisplaySizeChangedConnection.disconnect();
+    mWindowDestroyedConnection.disconnect();
     //This also calls CEGUI::System::destroy();
     CEGUI::OgreRenderer::destroySystem();
 }
@@ -117,9 +224,133 @@ CEGUI::MouseButton Gui::convertButton(OIS::MouseButtonID buttonID)
 
 void Gui::loadGuiSheet(guiSheet newSheet)
 {
+    registerWindowHierarchy(mSheets[newSheet]);
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().setRootWindow(mSheets[newSheet]);
     // This shouldn't be needed, but the gui seems to not allways change when using hideGui without it.
     CEGUI::System::getSingletonPtr()->getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::registerWindowHierarchy(CEGUI::Window* window)
+{
+    if(window == nullptr)
+        return;
+
+    registerWindow(window);
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+void Gui::registerWindow(CEGUI::Window* window)
+{
+    if(!window->isAutoWindow() && mScaledWindows.find(window) == mScaledWindows.end())
+    {
+        WindowScaleData data;
+        data.area = window->getArea();
+        data.minSize = window->getMinSize();
+        data.maxSize = window->getMaxSize();
+        data.text = window->getText();
+        data.hasFormattedImageSize = std::string(data.text.c_str()).find("[image-size='") != std::string::npos;
+        data.hasTabHeight = false;
+
+        CEGUI::TabControl* tabControl = dynamic_cast<CEGUI::TabControl*>(window);
+        if(tabControl != nullptr)
+        {
+            data.tabHeight = tabControl->getTabHeight();
+            data.hasTabHeight = true;
+        }
+
+        mScaledWindows.insert(std::make_pair(window, data));
+    }
+
+    for(size_t i = 0; i < window->getChildCount(); ++i)
+        registerWindow(window->getChildAtIdx(i));
+}
+
+void Gui::setUserScalePercent(float scalePercent)
+{
+    if(scalePercent != scalePercent)
+        scalePercent = 100.0f;
+
+    scalePercent = std::max(static_cast<float>(MIN_UI_SCALE_PERCENT),
+        std::min(static_cast<float>(MAX_UI_SCALE_PERCENT), scalePercent));
+    mUserScale = scalePercent / 100.0f;
+    applyScale(CEGUI::System::getSingleton().getRenderer()->getDisplaySize());
+}
+
+bool Gui::onDisplaySizeChanged(const CEGUI::EventArgs& e)
+{
+    const CEGUI::DisplayEventArgs& displayEvent = static_cast<const CEGUI::DisplayEventArgs&>(e);
+    applyScale(displayEvent.size);
+    return true;
+}
+
+bool Gui::onWindowDestroyed(const CEGUI::EventArgs& e)
+{
+    const CEGUI::WindowEventArgs& windowEvent = static_cast<const CEGUI::WindowEventArgs&>(e);
+    mScaledWindows.erase(windowEvent.window);
+    return true;
+}
+
+void Gui::applyScale(const CEGUI::Sizef& displaySize)
+{
+    const float resolutionScale = std::min(displaySize.d_width / LAYOUT_DESIGN_WIDTH,
+        displaySize.d_height / LAYOUT_DESIGN_HEIGHT);
+    const float scale = resolutionScale * mUserScale;
+
+    for(const auto& scaledWindow : mScaledWindows)
+        applyScale(scaledWindow.first, scaledWindow.second, scale);
+
+    updateResourceScaling(displaySize);
+    CEGUI::System::getSingleton().getDefaultGUIContext().markAsDirty();
+}
+
+void Gui::applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale)
+{
+    window->setMinSize(scaleSize(data.minSize, scale));
+    window->setMaxSize(scaleSize(data.maxSize, scale));
+    window->setArea(scaleRect(data.area, scale));
+
+    if(data.hasFormattedImageSize)
+        window->setText(scaleFormattedImageSizes(data.text, scale));
+
+    if(data.hasTabHeight)
+    {
+        CEGUI::UDim tabHeight(data.tabHeight);
+        scaleDimension(tabHeight, scale);
+        static_cast<CEGUI::TabControl*>(window)->setTabHeight(tabHeight);
+    }
+}
+
+void Gui::updateResourceScaling(const CEGUI::Sizef& displaySize)
+{
+    const CEGUI::Sizef fontNativeResolution(FONT_DESIGN_WIDTH / mUserScale,
+        FONT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::FontManager::FontIterator font = CEGUI::FontManager::getSingleton().getIterator();
+    while(!font.isAtEnd())
+    {
+        font.getCurrentValue()->setNativeResolution(fontNativeResolution);
+        font.getCurrentValue()->setAutoScaled(CEGUI::ASM_Min);
+        ++font;
+    }
+
+    const CEGUI::Sizef imageNativeResolution(LAYOUT_DESIGN_WIDTH / mUserScale,
+        LAYOUT_DESIGN_HEIGHT / mUserScale);
+    CEGUI::ImageManager::ImageIterator image = CEGUI::ImageManager::getSingleton().getIterator();
+    while(!image.isAtEnd())
+    {
+        if(shouldScaleImage(image.getCurrentKey()))
+        {
+            CEGUI::BasicImage* basicImage = dynamic_cast<CEGUI::BasicImage*>(image.getCurrentValue().first);
+            if(basicImage != nullptr)
+            {
+                basicImage->setNativeResolution(imageNativeResolution);
+                basicImage->setAutoScaled(CEGUI::ASM_Min);
+            }
+        }
+        ++image;
+    }
+
+    CEGUI::FontManager::getSingleton().notifyDisplaySizeChanged(displaySize);
+    CEGUI::ImageManager::getSingleton().notifyDisplaySizeChanged(displaySize);
 }
 
 CEGUI::Window* Gui::getGuiSheet(guiSheet sheet)

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -296,10 +296,11 @@ void Gui::applyScale(const CEGUI::Sizef& displaySize)
         displaySize.d_height / LAYOUT_DESIGN_HEIGHT);
     const float scale = resolutionScale * mUserScale;
 
+    updateResourceScaling(displaySize);
+
     for(const auto& scaledWindow : mScaledWindows)
         applyScale(scaledWindow.first, scaledWindow.second, scale);
 
-    updateResourceScaling(displaySize);
     CEGUI::System::getSingleton().getDefaultGUIContext().markAsDirty();
 }
 

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -85,6 +85,9 @@ public:
 
     CEGUI::Window* getGuiSheet(guiSheet sheet);
 
+    //! \brief Move CEGUI rendering to another Ogre render target.
+    void setRenderTarget(Ogre::RenderTarget& renderTarget);
+
     // Access names of the GUI elements
     static const std::string ROOT;
     static const std::string DISPLAY_GOLD;

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -24,7 +24,9 @@
 #ifndef GUI_H_
 #define GUI_H_
 
+#include <CEGUI/Event.h>
 #include <CEGUI/InputEvent.h>
+#include <CEGUI/Window.h>
 
 #include <OISMouse.h>
 
@@ -87,6 +89,18 @@ public:
 
     //! \brief Move CEGUI rendering to another Ogre render target.
     void setRenderTarget(Ogre::RenderTarget& renderTarget);
+
+    enum
+    {
+        MIN_UI_SCALE_PERCENT = 80,
+        MAX_UI_SCALE_PERCENT = 120
+    };
+
+    //! \brief Registers a window tree for resolution-independent scaling.
+    void registerWindowHierarchy(CEGUI::Window* window);
+
+    //! \brief Sets the user-selected UI scale and applies it immediately.
+    void setUserScalePercent(float scalePercent);
 
     // Access names of the GUI elements
     static const std::string ROOT;
@@ -155,9 +169,33 @@ public:
     bool playButtonClickSound(const CEGUI::EventArgs& e = {});
 
 private:
+    struct WindowScaleData
+    {
+        CEGUI::URect area;
+        CEGUI::USize minSize;
+        CEGUI::USize maxSize;
+        CEGUI::String text;
+        CEGUI::UDim tabHeight;
+        bool hasFormattedImageSize;
+        bool hasTabHeight;
+    };
+
     std::map<guiSheet, CEGUI::Window*> mSheets;
+    std::map<CEGUI::Window*, WindowScaleData> mScaledWindows;
+
+    float mUserScale;
+
+    CEGUI::Event::ScopedConnection mDisplaySizeChangedConnection;
+    CEGUI::Event::ScopedConnection mWindowDestroyedConnection;
 
     SoundEffectsManager* mSoundEffectsManager;
+
+    bool onDisplaySizeChanged(const CEGUI::EventArgs& e);
+    bool onWindowDestroyed(const CEGUI::EventArgs& e);
+    void registerWindow(CEGUI::Window* window);
+    void applyScale(const CEGUI::Sizef& displaySize);
+    void applyScale(CEGUI::Window* window, const WindowScaleData& data, float scale);
+    void updateResourceScaling(const CEGUI::Sizef& displaySize);
 };
 
 #endif // GUI_H_

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -43,11 +43,13 @@
 #include "sound/MusicPlayer.h"
 #include "sound/SoundEffectsManager.h"
 #include "utils/Helper.h"
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
 #include "utils/MakeUnique.h"
 
 #include <OgreCamera.h>
 #include <OgreRenderWindow.h>
+#include <OgreRenderSystem.h>
 #include <OgreRoot.h>
 #include <OgreSceneManager.h>
 #include <Overlay/OgreOverlaySystem.h>
@@ -59,6 +61,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <stdexcept>
 #include <iostream>
 
 #include <signal.h>
@@ -81,6 +84,9 @@ ODFrameListener::ODFrameListener(const std::string& mainSceneFileName, Ogre::Ren
     lastSecondFrameRenderingQueued(0),
     mInitialized(false),
     mWindow(renderWindow),
+    mPrimaryWindow(renderWindow),
+    mRenderWindowRecreationPending(false),
+    mRenderWindowSequence(0),
     mGui(gui),
     mRenderManager(RenderManager::getSingletonPtr()),
     mGameMap(Utils::make_unique<GameMap>(false)),
@@ -119,6 +125,12 @@ void ODFrameListener::windowResized(Ogre::RenderWindow* rw)
     int left, top;
     rw->getMetrics(width, height, left, top);
 
+    if(width == 0 || height == 0)
+        return;
+
+    Ogre::Camera* camera = mCameraManager.getActiveCamera();
+    camera->setAspectRatio(static_cast<Ogre::Real>(width) / static_cast<Ogre::Real>(height));
+
     mModeManager->getInputManager().setWidthAndHeight(width, height);
     //Notify CEGUI that the display size has changed.
     CEGUI::System::getSingleton().notifyDisplaySizeChanged(CEGUI::Size<float>(
@@ -148,6 +160,177 @@ ODFrameListener::~ODFrameListener()
 void ODFrameListener::requestExit()
 {
     mExitRequested = true;
+}
+
+void ODFrameListener::requestRenderWindowRecreation(
+    const std::map<std::string, std::string>& previousRendererOptions,
+    const std::map<std::string, std::string>& previousVideoConfig)
+{
+    mPreviousRendererOptions = previousRendererOptions;
+    mPreviousVideoConfig = previousVideoConfig;
+    mRenderWindowRecreationPending = true;
+}
+
+void ODFrameListener::restorePreviousVideoSettings()
+{
+    Ogre::RenderSystem* renderer = Ogre::Root::getSingleton().getRenderSystem();
+    std::map<std::string, std::string>::const_iterator fullscreen =
+        mPreviousRendererOptions.find(Config::FULL_SCREEN);
+    if(fullscreen != mPreviousRendererOptions.end())
+        renderer->setConfigOption(fullscreen->first, fullscreen->second);
+    std::map<std::string, std::string>::const_iterator videoMode =
+        mPreviousRendererOptions.find(Config::VIDEO_MODE);
+    if(videoMode != mPreviousRendererOptions.end())
+        renderer->setConfigOption(videoMode->first, videoMode->second);
+    for(const std::pair<const std::string, std::string>& option : mPreviousRendererOptions)
+    {
+        if(option.first == Config::FULL_SCREEN || option.first == Config::VIDEO_MODE)
+            continue;
+        renderer->setConfigOption(option.first, option.second);
+    }
+
+    ConfigManager& config = ConfigManager::getSingleton();
+    for(const std::pair<const std::string, std::string>& option : mPreviousVideoConfig)
+        config.setVideoValue(option.first, option.second);
+    config.saveUserConfig();
+    mPreviousRendererOptions.clear();
+    mPreviousVideoConfig.clear();
+}
+
+void ODFrameListener::applyPendingRenderWindowRecreation()
+{
+    if(!mRenderWindowRecreationPending)
+        return;
+    mRenderWindowRecreationPending = false;
+
+    Ogre::Root& root = Ogre::Root::getSingleton();
+    Ogre::RenderSystem* renderer = root.getRenderSystem();
+    Ogre::RenderWindow* previousWindow = mWindow;
+    Ogre::RenderWindow* replacementWindow = nullptr;
+    unsigned int previousWidth = 0;
+    unsigned int previousHeight = 0;
+    int previousLeft = 0;
+    int previousTop = 0;
+    previousWindow->getMetrics(previousWidth, previousHeight, previousLeft, previousTop);
+    const bool previousWasFullScreen = previousWindow->isFullScreen();
+    bool guiMoved = false;
+    bool cameraMoved = false;
+    bool inputMoved = false;
+    bool listenerMoved = false;
+    bool windowRegistered = false;
+
+    try
+    {
+        Ogre::RenderWindowDescription description = renderer->getRenderWindowDescription();
+        description.name = "OpenDungeonsLiveSettings" + Helper::toString(++mRenderWindowSequence);
+        description.miscParams["title"] = mPrimaryWindow->getName();
+        description.miscParams["hidden"] = "true";
+        if(!description.useFullScreen && !previousWasFullScreen)
+        {
+            description.miscParams["left"] = Helper::toString(previousLeft);
+            description.miscParams["top"] = Helper::toString(previousTop);
+        }
+
+        replacementWindow = root.createRenderWindow(description);
+        replacementWindow->setAutoUpdated(false);
+        replacementWindow->setActive(false);
+        Ogre::WindowEventUtilities::_addRenderWindow(replacementWindow);
+        windowRegistered = true;
+
+        renderer->_setRenderTarget(replacementWindow);
+        mCameraManager.setRenderWindow(replacementWindow);
+        cameraMoved = true;
+        mRenderManager->setViewport(mCameraManager.getViewport());
+        mGui->setRenderTarget(*replacementWindow);
+        guiMoved = true;
+        if(!mModeManager->getInputManager().setRenderWindow(replacementWindow))
+            throw std::runtime_error("input initialization failed for the replacement window");
+        mModeManager->getInputManager().refreshSettings();
+        inputMoved = true;
+
+        Ogre::WindowEventUtilities::removeWindowEventListener(previousWindow, this);
+        Ogre::WindowEventUtilities::addWindowEventListener(replacementWindow, this);
+        listenerMoved = true;
+        mWindow = replacementWindow;
+
+        previousWindow->setAutoUpdated(false);
+        previousWindow->setActive(false);
+        previousWindow->setVisible(false);
+        if(previousWasFullScreen)
+        {
+            previousWindow->setFullscreen(false, previousWidth, previousHeight);
+            if(description.useFullScreen)
+            {
+                replacementWindow->setFullscreen(false, description.width, description.height);
+                replacementWindow->setFullscreen(true, description.width, description.height);
+            }
+        }
+        replacementWindow->setVisible(true);
+        replacementWindow->setActive(true);
+        replacementWindow->setAutoUpdated(true);
+        replacementWindow->windowMovedOrResized();
+        windowResized(replacementWindow);
+
+        if(previousWindow != mPrimaryWindow)
+        {
+            Ogre::WindowEventUtilities::_removeRenderWindow(previousWindow);
+            root.destroyRenderTarget(previousWindow);
+        }
+        mPreviousRendererOptions.clear();
+        mPreviousVideoConfig.clear();
+        OD_LOG_INF("Applied video settings without restarting the game");
+    }
+    catch(const std::exception& error)
+    {
+        OD_LOG_ERR("Could not apply video settings: " + std::string(error.what()));
+        renderer->_setRenderTarget(previousWindow);
+        if(listenerMoved)
+        {
+            Ogre::WindowEventUtilities::removeWindowEventListener(replacementWindow, this);
+            Ogre::WindowEventUtilities::addWindowEventListener(previousWindow, this);
+            mWindow = previousWindow;
+        }
+        if(inputMoved)
+            mModeManager->getInputManager().setRenderWindow(previousWindow);
+        if(guiMoved)
+            mGui->setRenderTarget(*previousWindow);
+        if(cameraMoved)
+        {
+            mCameraManager.setRenderWindow(previousWindow);
+            mRenderManager->setViewport(mCameraManager.getViewport());
+        }
+        if(replacementWindow != nullptr)
+        {
+            if(windowRegistered)
+                Ogre::WindowEventUtilities::_removeRenderWindow(replacementWindow);
+            root.destroyRenderTarget(replacementWindow);
+        }
+        if(previousWasFullScreen && !previousWindow->isFullScreen())
+            previousWindow->setFullscreen(true, previousWidth, previousHeight);
+        restorePreviousVideoSettings();
+        previousWindow->setVisible(true);
+        previousWindow->setActive(true);
+        previousWindow->setAutoUpdated(true);
+        windowResized(previousWindow);
+    }
+}
+
+void ODFrameListener::prepareRenderWindowShutdown()
+{
+    if(mInitialized)
+        exitApplication();
+    mModeManager.reset();
+
+    if(mWindow != mPrimaryWindow)
+    {
+        Ogre::WindowEventUtilities::_removeRenderWindow(mWindow);
+        Ogre::Root& root = Ogre::Root::getSingleton();
+        root.getRenderSystem()->_setRenderTarget(mPrimaryWindow);
+        mGui->setRenderTarget(*mPrimaryWindow);
+        root.destroyRenderTarget(mWindow);
+        mWindow = mPrimaryWindow;
+    }
+    Ogre::WindowEventUtilities::_removeRenderWindow(mPrimaryWindow);
 }
 
 void ODFrameListener::exitApplication()
@@ -193,6 +376,7 @@ bool ODFrameListener::frameRenderingQueued(const Ogre::FrameEvent& evt)
     CEGUI::System::getSingleton().getDefaultGUIContext().injectTimePulse(evt.timeSinceLastFrame);
 
     mModeManager->update(evt);
+    applyPendingRenderWindowRecreation();
 
     int64_t currentTurn = mGameMap->getTurnNumber();
 
@@ -466,4 +650,3 @@ void ODFrameListener::readMainScene(const std::string& fileName)
     OD_LOG_INF("Load main scene file: " + fileName);
     mMainScene->readSceneMenu(fileName);
 }
-

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -36,6 +36,7 @@
 #include <OgreWindowEventUtilities.h>
 
 #include <memory>
+#include <map>
 #include <vector>
 
 
@@ -152,6 +153,13 @@ public:
     inline Ogre::RenderWindow* getRenderWindow()
     { return mWindow; }
 
+    void requestRenderWindowRecreation(
+        const std::map<std::string, std::string>& previousRendererOptions,
+        const std::map<std::string, std::string>& previousVideoConfig);
+
+    //! \brief Release window-dependent objects before ODApplication destroys the primary window.
+    void prepareRenderWindowShutdown();
+
     inline bool getIsMainMenuCreated()
     { return mIsMainMenuCreated; }
 
@@ -215,6 +223,14 @@ private:
     //! \brief The Ogre render window reference. Don't delete it.
     Ogre::RenderWindow* mWindow;
 
+    //! \brief The first window owns the main OpenGL context and remains alive as an anchor.
+    Ogre::RenderWindow* mPrimaryWindow;
+
+    bool mRenderWindowRecreationPending;
+    uint32_t mRenderWindowSequence;
+    std::map<std::string, std::string> mPreviousRendererOptions;
+    std::map<std::string, std::string> mPreviousVideoConfig;
+
     //! \brief Foreign reference to gui.
     Gui*                 mGui;
 
@@ -240,6 +256,9 @@ private:
 
     //! \brief Actually exit application
     void exitApplication();
+
+    void applyPendingRenderWindowRecreation();
+    void restorePreviousVideoSettings();
 
     //! \brief Updates server-turn independent creature animation, audio, and overall rendering.
     void updateAnimations(Ogre::Real timeSinceLastFrame);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -2498,12 +2498,12 @@ std::string RenderManager::rrBuildSkullFlagMaterial(const std::string& materialN
     return materialNameToUse;
 }
 
-void RenderManager::rrMinimapRendering(bool postRender)
+void RenderManager::rrMinimapRendering(bool postRender, bool keepWorldLighting)
 {
     if(mHandLight != nullptr)
         mHandLight->setVisible(postRender);
 
-    mLightSceneNode->setVisible(postRender);
+    mLightSceneNode->setVisible(postRender || keepWorldLighting);
 }
 
 void RenderManager::changeRenderQueueRecursive(Ogre::SceneNode* node, uint8_t renderQueueId)

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -106,6 +106,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mHandLightNode(nullptr),
     mShadowCam(nullptr),
     mCurrentFOVy(0.0f),
+    mCurrentAspectRatio(0.0f),
     mFactorWidth(0.0f),
     mFactorHeight(0.0f),
     mCreatureTextOverlayDisplayed(false),
@@ -120,42 +121,7 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     // mShaderGenerator->setShaderCacheEnabled(true);
     
     mShaderGenerator->addSceneManager(mSceneManager); 
-    if(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS)=="Yes")
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_TEXTURE_ADDITIVE);
-        // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
-        // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
-        // mSceneManager->setShadowFarDistance(100.0);
-        // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
-        // mSceneManager->setShadowTextureSelfShadow(true);
-        // donno if the below should be here -- paul424 :
-        auto myIter = Ogre::MaterialManager::getSingleton().getResourceIterator();
-        while(myIter.hasMoreElements())
-        {
-            auto myPointer = myIter.peekNextValue();
-            Ogre::SharedPtr<Ogre::Material> myCastPointer = std::dynamic_pointer_cast<Ogre::Material> (myPointer);
-            Ogre::Technique* technique;
-            technique = myCastPointer->getTechnique(0);
-
-            if( technique->getPass(technique->getNumPasses() - 1)->hasFragmentProgram())
-            {
-                if(technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->hasNamedParameters())
-                {
-                    const Ogre::GpuNamedConstants& gnc = technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->getConstantDefinitions();
-                    auto it = gnc.map.find("shadowingEnabled");
-                    if(it!=  gnc.map.end())
-                        technique->getPass(technique->getNumPasses() - 1)->getFragmentProgramParameters()->setNamedConstant("shadowingEnabled",true);
-                }
-            }
-            myIter.getNext();
-        }  
-        
-    }
-    else
-    {
-        mSceneManager->setShadowTechnique(Ogre::ShadowTechnique::SHADOWTYPE_NONE);
-
-    }
+    setDynamicShadowsEnabled(ConfigManager::getSingleton().getAudioValue(Config::SHADOWS) == "Yes");
     ddd.setStatic(true);
     mSceneManager->addListener(&ddd);
     mSceneManager->addRenderQueueListener(overlaySystem);
@@ -210,6 +176,42 @@ void RenderManager::saveTexture(Ogre::TexturePtr texture, const std::string& fil
     pixelBuffer->unlock();
 }
 
+
+void RenderManager::setDynamicShadowsEnabled(bool enabled)
+{
+    // Custom shaders apply lighting and shadows in one pass; automatic
+    // illumination splitting removes their fragment programs on GL3Plus.
+    mSceneManager->setShadowTechnique(enabled ? Ogre::SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED : Ogre::SHADOWTYPE_NONE);
+    // mSceneManager->setShadowCameraSetup(Ogre::LiSPSMShadowCameraSetup::create());
+    // mSceneManager->setShadowTextureConfig(0,1024,1024,Ogre::PixelFormat::PF_R32G32B32A32_UINT,0);
+    // mSceneManager->setShadowFarDistance(100.0);
+    // mSceneManager->setShadowDirectionalLightExtrusionDistance(500.0);
+    // mSceneManager->setShadowTextureSelfShadow(true);
+
+    // Include material clones and techniques created since the game started.
+    Ogre::ResourceManager::ResourceMapIterator materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while(materials.hasMoreElements())
+    {
+        Ogre::MaterialPtr material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+        for(unsigned short techniqueIndex = 0; techniqueIndex < material->getNumTechniques(); ++techniqueIndex)
+        {
+            Ogre::Technique* technique = material->getTechnique(techniqueIndex);
+            for(unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex)
+            {
+                Ogre::Pass* pass = technique->getPass(passIndex);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters())
+                {
+                    const Ogre::GpuNamedConstants& constants = parameters->getConstantDefinitions();
+                    if(constants.map.find("shadowingEnabled") != constants.map.end())
+                        parameters->setNamedConstant("shadowingEnabled", enabled);
+                }
+            }
+        }
+    }
+}
 
 RenderManager::~RenderManager()
 {
@@ -2425,24 +2427,15 @@ std::string RenderManager::setMaterialOpacity(const std::string& materialName, f
 void RenderManager::moveCursor(float relX, float relY)
 {
     Ogre::Camera* cam = mViewport->getCamera();
-    if(cam->getFOVy() != mCurrentFOVy)
+    if(cam->getFOVy() != mCurrentFOVy || cam->getAspectRatio() != mCurrentAspectRatio)
     {
         mCurrentFOVy = cam->getFOVy();
+        mCurrentAspectRatio = cam->getAspectRatio();
         Ogre::Radian angle = cam->getFOVy() * 0.5f;
         Ogre::Real tan = Ogre::Math::Tan(angle);
-        Ogre::Real shortestSize = KEEPER_HAND_POS_Z * tan * 2.0f;
-        Ogre::Real width = mViewport->getActualWidth();
-        Ogre::Real height = mViewport->getActualHeight();
-        if(width > height)
-        {
-            mFactorHeight = shortestSize;
-            mFactorWidth = shortestSize * width / height;
-        }
-        else
-        {
-            mFactorWidth = shortestSize;
-            mFactorHeight = shortestSize * height / width;
-        }
+        // FOVy defines the vertical extent; keep the hand aligned after resizing.
+        mFactorHeight = KEEPER_HAND_POS_Z * tan * 2.0f;
+        mFactorWidth = mFactorHeight * mCurrentAspectRatio;
     }
 
     mHandKeeperNode->setPosition(mFactorWidth * (relX - 0.5f), mFactorHeight * (0.5f - relY), -KEEPER_HAND_POS_Z);

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -182,7 +182,7 @@ public:
     //! \brief Does requested stuff for rendering in the minimap. Each time the minimap is rendered, this function will be
     //! called once before rendering is done with postRender = false and once when it is rendered with postRender = true.
     //! That allows to hide stuff that we don't want to display in the minimap
-    void rrMinimapRendering(bool postRender);
+    void rrMinimapRendering(bool postRender, bool keepWorldLighting = false);
 
     Ogre::Light* addPointLightMenu(const std::string& name, const Ogre::Vector3& pos,
         const Ogre::ColourValue& diffuse, const Ogre::ColourValue& specular, Ogre::Real attenuationRange,

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -96,8 +96,12 @@ public:
     //! \brief setup the scene
     void createScene(Ogre::Viewport*);
 
+    void setViewport(Ogre::Viewport* viewport)
+    { mViewport = viewport; }
+
     //! \brief Sets/Updates the overall world lighting value with given factor.
     void setWorldAmbientLightingFactor(float lightFactor);
+    void setDynamicShadowsEnabled(bool enabled);
 
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);
@@ -274,6 +278,7 @@ private:
     Ogre::SceneNode* mHandLightNode2;
     Ogre::Camera* mShadowCam;
     Ogre::Radian mCurrentFOVy;
+    Ogre::Real mCurrentAspectRatio;
     Ogre::Real mFactorWidth;
     Ogre::Real mFactorHeight;
 

--- a/source/tests/test_ODPacket.cpp
+++ b/source/tests/test_ODPacket.cpp
@@ -54,3 +54,32 @@ BOOST_AUTO_TEST_CASE(test_ODPacket)
 
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_optional_nickname_capability)
+{
+    // The original handshake must remain readable without an extension byte.
+    ODPacket legacy;
+    legacy << std::string("Keeper");
+    std::string nickname;
+    legacy >> nickname;
+    BOOST_REQUIRE(legacy);
+    BOOST_CHECK(legacy.endOfPacket());
+
+    // Updated peers append their capability after the unchanged nickname field.
+    ODPacket extended;
+    extended << std::string("Keeper") << true;
+    extended >> nickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK_EQUAL(nickname, "Keeper");
+    BOOST_REQUIRE(!extended.endOfPacket());
+    bool liveNickname = false;
+    extended >> liveNickname;
+    BOOST_REQUIRE(extended);
+    BOOST_CHECK(liveNickname);
+    BOOST_CHECK(extended.endOfPacket());
+
+    extended.clear();
+    BOOST_CHECK(extended.endOfPacket());
+    extended << false;
+    BOOST_CHECK(!extended.endOfPacket());
+}

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1963,4 +1963,5 @@ void ConfigManager::loadDefaultValuesForUserConfig(void)
     setGameValue("LightFactor",	"100");
     setGameValue("MinimapType",	"MiniMapDrawn");
     setGameValue("Nickname", "Player");
+    setGameValue("UI Scale", "100");
 }

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -68,6 +68,7 @@ const std::string NICKNAME = "Nickname";
 const std::string KEEPERVOICE = "KeeperVoice";
 const std::string MINIMAP_TYPE = "MinimapType";
 const std::string LIGHT_FACTOR = "LightFactor";
+const std::string UI_SCALE = "UI Scale";
 }
 
 typedef std::map<TileVisual,std::map<int,float>> HighMap;

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);


### PR DESCRIPTION
The existing minimap could relocate the camera, but navigation had no full-map workflow, independent minimap zoom or reliable overview overlays.

## Change

- Add a modal full map with pointer detail; left-click relocates the camera, while right-click, Escape or the map key closes it.
- Add independent minimap zoom with matching click-coordinate conversion and preserved renderer selection.
- Add shortcuts for the owned dungeon heart, owned portals and active fights.
- Share terrain colours and draw the owned-heart direction plus a thin camera viewport on the minimap and full map.
- Keep tile updates, texture uploads and culling ownership correct while minimap and full-map views are recreated.

## Coordination

Depends on #82 for the camera-control and input foundation. No matching open issue was found.

## Verification

The focused suites pass 1,163 installed-CEGUI checks, 1,028 viewport checks, 667 direction checks, 384 culling checks, 331 pixel-buffer checks, 138 renderer checks, 28 palette checks, 12 focus checks, 11 composed-map checks, 10 mark-update checks and five detail-lighting checks. A clean Windows x64 Release build and runtime preparation completed successfully, and the user confirmed the map controls in game. Other platforms remain unverified.

[Review only the map-navigation changes](https://github.com/Rokk001/OpenDungeonsPlus/compare/4842784c...61d8103b)
