### PR TITLE
Hide creature captions until their first display request

### DIFF
--- a/source/render/MovableTextOverlay.cpp
+++ b/source/render/MovableTextOverlay.cpp
@@ -192,6 +192,7 @@ uint32_t MovableTextOverlay::createChildOverlay(const Ogre::String& fontName, Og
     childOverlay.mOverlayContainer = static_cast<Ogre::OverlayContainer*>(overlayManager.createOverlayElement(
         "Panel", mName + Helper::toString(id) + "_OvC"));
     childOverlay.mOverlayContainer->setDimensions(0.0, 0.0);
+    childOverlay.mOverlayContainer->hide();
 
     mOverlay->add2D(childOverlay.mOverlayContainer);
 


### PR DESCRIPTION
New creature caption panels could become visible at the screen origin before
their first display request, leaving overlapping white text in the upper-left
corner. Hide each child panel when it is created; existing timed and persistent
display paths continue to control when it becomes visible.

This changes one line in the overlay implementation and has no dependency on
the other fork UI contributions.

Validation: an isolated Ogre render probe compiled from the production class
passes all 35 checks, including initial visibility, explicit display, expiry,
offscreen hiding and cleanup; the original version failed 26 of those checks.
The corrected initial state renders zero bright pixels at the origin. The full
fork built successfully on Windows x64 and the user confirmed the fix in game.
This minimal contribution also passes a separate full Windows x64 Release
build and runtime preparation when combined with the existing Windows-support
contribution #47; other platforms remain unverified.

No matching open issue was identified for this specific initial-caption defect;
this contribution does not claim to resolve the broader interface issues.
