### PR TITLE
Enable screenshots across menus and dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ following resources to learn the basic gameplay concepts:
 You can play singleplayer levels using the Skirmish menu, or host/join a
 multiplayer game by using the corresponding menus.
 
+Press Print Screen to save a PNG screenshot from menus, dialogs, gameplay or
+the editor; images use the existing timestamped filenames in the configured
+user-data directory.
+
 ### Be part of the community
 
 As free software aficionados, we value community-based development and

--- a/source/modes/AbstractApplicationMode.cpp
+++ b/source/modes/AbstractApplicationMode.cpp
@@ -20,6 +20,10 @@
 #include "network/ODClient.h"
 #include "network/ODServer.h"
 #include "render/Gui.h"
+#include "render/ODFrameListener.h"
+#include "utils/ResourceManager.h"
+
+#include <OgreRenderWindow.h>
 
 #include <CEGUI/System.h>
 #include <CEGUI/GUIContext.h>
@@ -76,6 +80,9 @@ bool AbstractApplicationMode::mouseReleased(const OIS::MouseEvent& arg, OIS::Mou
 
 bool AbstractApplicationMode::keyPressed(const OIS::KeyEvent& arg)
 {
+    if(handleScreenshotKey(arg))
+        return true;
+
     switch (arg.key)
     {
     default:
@@ -85,6 +92,15 @@ bool AbstractApplicationMode::keyPressed(const OIS::KeyEvent& arg)
             static_cast<CEGUI::Key::Scan>(arg.key));
         break;
     }
+    return true;
+}
+
+bool AbstractApplicationMode::handleScreenshotKey(const OIS::KeyEvent& arg)
+{
+    if(arg.key != OIS::KC_SYSRQ)
+        return false;
+
+    ResourceManager::getSingleton().takeScreenshot(ODFrameListener::getSingleton().getRenderWindow());
     return true;
 }
 

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -126,6 +126,9 @@ public:
     {}
 
 protected:
+    //! Capture the current view before a GUI or input submode consumes the key.
+    bool handleScreenshotKey(const OIS::KeyEvent& arg);
+
     ModeManager& getModeManager()
     {
         return *mModeManager;

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -1496,6 +1496,9 @@ bool EditorMode::hidePortalWaveWindow(const CEGUI::EventArgs& /*arg*/)
 
 bool EditorMode::keyPressed(const OIS::KeyEvent &arg)
 {
+    if(handleScreenshotKey(arg))
+        return true;
+
     // Inject key to the gui currently displayed
     CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(static_cast<CEGUI::Key::Scan>(arg.key));
     CEGUI::System::getSingleton().getDefaultGUIContext().injectChar(arg.text);
@@ -1661,11 +1664,6 @@ bool EditorMode::keyPressed(const OIS::KeyEvent &arg)
     // Quit the Editor Mode
     case OIS::KC_ESCAPE:
         showQuitMenu();
-        break;
-
-    // Print a screenshot
-    case OIS::KC_SYSRQ:
-        ResourceManager::getSingleton().takeScreenshot(frameListener.getRenderWindow());
         break;
 
     case OIS::KC_1:

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -792,6 +792,9 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
 
 bool GameMode::keyPressed(const OIS::KeyEvent& arg)
 {
+    if(handleScreenshotKey(arg))
+        return true;
+
     // Inject key to Gui
     CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(static_cast<CEGUI::Key::Scan>(arg.key));
     if (arg.text != 0 && !getConsole()->isFreshlyEnabled())
@@ -938,11 +941,6 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
     case OIS::KC_ESCAPE:
         mExitToDesktop = false;
         popupExit(!mGameMap->getGamePaused());
-        break;
-
-    // Print a screenshot
-    case OIS::KC_SYSRQ:
-        ResourceManager::getSingleton().takeScreenshot(frameListener.getRenderWindow());
         break;
 
     case OIS::KC_RETURN:


### PR DESCRIPTION
Print Screen worked only after reaching the normal gameplay or editor key
switch, so menus and several dialogs or input modes could consume it first.
Handle it before GUI and submode dispatch in the base, game and editor modes,
and remove the old cases to keep one capture per press.

The existing screenshot writer, timestamped PNG names and configured user-data
directory are reused; README documents the extended screen coverage. No menu
redesign, alternative storage path or additional capture implementation is included.

Verification: the prepared contribution's compiled key-dispatch probe passes
74 checks, with 26 failures on the original target source; it instruments the
GUI, image writer and later editor commands. Separate earlier Ogre/CEGUI checks
on the complete fork exercised the actual writer with 101 assertions and 25
decoded PNGs, and the user confirmed start-screen capture. The complete fork
built on Windows x64. This minimal contribution also passes a separate full
Windows x64 Release build and runtime preparation when combined with the
existing Windows-support contribution #47; other platforms remain unverified.
