### PR TITLE
Restore saved games through a reusable in-game browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ following resources to learn the basic gameplay concepts:
 You can play singleplayer levels using the Skirmish menu, or host/join a
 multiplayer game by using the corresponding menus.
 
+Use Load Game in the game options, or F8 while hosting a local game, to open
+the saved-game browser; Back preserves the current game until another save is
+selected. Loaded single-player saves resume their stored side without a new
+seat-selection step. Long save descriptions can be scrolled.
+
 ### Be part of the community
 
 As free software aficionados, we value community-based development and

--- a/gui/MenuLoad.layout
+++ b/gui/MenuLoad.layout
@@ -27,18 +27,20 @@
             <Property name="BackgroundEnabled" value="False" />
         </Window>
         <Window type="OD/FrameWindow" name="LevelWindowFrame" >
-            <Property name="Area" value="{{0.5,-315},{0.5,-180},{0.5,315},{0.5,240}}" />
+            <Property name="Area" value="{{0.5,-425},{0.5,-180},{0.5,425},{0.5,240}}" />
             <Property name="Text" value="Please choose a saved game..." />
-            <Property name="MaxSize" value="{{0,790},{0,470}}" />
-            <Property name="MinSize" value="{{0,630},{0,420}}" />
+            <Property name="MaxSize" value="{{0,950},{0,470}}" />
+            <Property name="MinSize" value="{{0,850},{0,420}}" />
             <Property name="AlwaysOnTop" value="True" />
             <Window type="OD/Listbox" name="SaveGameSelect" >
-                <Property name="Area" value="{{0,15},{0,40},{0.5,-20},{0.7,0}}" />
+                <Property name="Area" value="{{0,15},{0,40},{0.65,-20},{0.7,0}}" />
                 <Property name="ForceVertScrollbar" value="True" />
                 <Property name="Sort" value="True" />
             </Window>
             <Window type="OD/StaticText" name="MapDescriptionText" >
-                <Property name="Area" value="{{0.5,0},{0,40},{1,-15},{0.7,0}}" />
+                <Property name="LookNFeel" value="OD/MenuDescription" />
+                <Property name="VertScrollbar" value="True" />
+                <Property name="Area" value="{{0.65,0},{0,40},{1,-15},{0.7,0}}" />
                 <Property name="MaxSize" value="{{1,0},{1,0}}" />
                 <Property name="FrameEnabled" value="False" />
                 <Property name="HorzFormatting" value="WordWrapLeftAligned" />

--- a/gui/OD.looknfeel
+++ b/gui/OD.looknfeel
@@ -4772,4 +4772,73 @@
         </StateImagery>
     </WidgetLook>
 
+    <WidgetLook name="OD/MenuScrollbarThumb" inherits="OD/VerticalScrollbarThumb">
+        <StateImagery name="Normal"><Layer><Section section="normal" /></Layer></StateImagery>
+        <StateImagery name="Hover"><Layer><Section section="hover" /></Layer></StateImagery>
+        <StateImagery name="Pushed"><Layer><Section section="hover" /></Layer></StateImagery>
+        <StateImagery name="Disabled"><Layer><Section section="normal" /></Layer></StateImagery>
+        <ImagerySection name="normal"><ImageryComponent><Area>
+                <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="RightEdge"><UnifiedDim scale="1" type="RightEdge" /></Dim>
+                <Dim type="BottomEdge"><UnifiedDim scale="1" type="BottomEdge" /></Dim>
+            </Area>
+            <Image name="OpenDungeonsSkin/SelectionBrush" />
+            <Colours topLeft="FFBBBBBB" topRight="FFBBBBBB" bottomLeft="FFBBBBBB" bottomRight="FFBBBBBB" />
+            <VertFormat type="Stretched" /><HorzFormat type="Stretched" />
+        </ImageryComponent></ImagerySection>
+        <ImagerySection name="hover"><ImageryComponent><Area>
+                <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="RightEdge"><UnifiedDim scale="1" type="RightEdge" /></Dim>
+                <Dim type="BottomEdge"><UnifiedDim scale="1" type="BottomEdge" /></Dim>
+            </Area>
+            <Image name="OpenDungeonsSkin/SelectionBrush" />
+            <VertFormat type="Stretched" /><HorzFormat type="Stretched" />
+        </ImageryComponent></ImagerySection>
+    </WidgetLook>
+
+    <WidgetLook name="OD/MenuScrollbar" inherits="OD/VerticalScrollbar">
+        <StateImagery name="Enabled"><Layer><Section section="main" /></Layer></StateImagery>
+        <StateImagery name="Disabled"><Layer><Section section="main" /></Layer></StateImagery>
+        <Child nameSuffix="__auto_thumb__" type="OD/MenuScrollbarThumb">
+            <Area>
+                <Dim type="LeftEdge"><AbsoluteDim value="2" /></Dim>
+                <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="Width"><UnifiedDim scale="1" offset="-4" type="Width" /></Dim>
+                <Dim type="Height"><UnifiedDim scale="0.1" type="Height" /></Dim>
+            </Area>
+            <Property name="MinSize" value="{{0,0},{0,25}}" />
+        </Child>
+        <ImagerySection name="main"><FrameComponent>
+                <Area>
+                    <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="Width"><UnifiedDim scale="1" type="Width" /></Dim>
+                    <Dim type="Height"><UnifiedDim scale="1" type="Height" /></Dim>
+                </Area>
+                <Image component="TopLeftCorner" name="OpenDungeonsSkin/VerticalSliderTopLeft" />
+                <Image component="TopRightCorner" name="OpenDungeonsSkin/VerticalSliderTopRight" />
+                <Image component="BottomLeftCorner" name="OpenDungeonsSkin/VerticalSliderBottomLeft" />
+                <Image component="BottomRightCorner" name="OpenDungeonsSkin/VerticalSliderBottomRight" />
+                <Image component="LeftEdge" name="OpenDungeonsSkin/VerticalSliderLeft" />
+                <Image component="RightEdge" name="OpenDungeonsSkin/VerticalSliderRight" />
+                <Image component="BottomEdge" name="OpenDungeonsSkin/VerticalSliderBottom" />
+                <Image component="TopEdge" name="OpenDungeonsSkin/VerticalSliderTop" />
+
+            </FrameComponent>
+            </ImagerySection>
+    </WidgetLook>
+
+    <WidgetLook name="OD/MenuDescription" inherits="OD/StaticText">
+        <Child nameSuffix="__auto_vscrollbar__" type="OD/MenuScrollbar">
+            <Area>
+                <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                <Dim type="Width"><OperatorDim op="Multiply"><ImageDim name="OpenDungeonsSkin/MiniVertScrollThumbNormal" dimension="Width" /><AbsoluteDim value="1.5" /></OperatorDim></Dim>
+                <Dim type="Height"><UnifiedDim scale="1" type="Height" /></Dim>
+            </Area>
+            <HorzAlignment type="RightAligned" />
+        </Child>
+    </WidgetLook>
 </Falagard>

--- a/gui/ODSkin.scheme
+++ b/gui/ODSkin.scheme
@@ -57,4 +57,6 @@
     <FalagardMapping lookNFeel="OD/Tooltip" renderer="Core/Tooltip" targetType="CEGUI/Tooltip" windowType="OD/Tooltip" />
     <FalagardMapping lookNFeel="OD/StaticImage" renderer="Core/StaticImage" targetType="DefaultWindow" windowType="OD/StaticImage" />
     <FalagardMapping lookNFeel="OD/StaticText" renderer="Core/StaticText" targetType="DefaultWindow" windowType="OD/StaticText" />
+    <FalagardMapping lookNFeel="OD/MenuScrollbarThumb" renderer="Core/Button" targetType="CEGUI/Thumb" windowType="OD/MenuScrollbarThumb" />
+    <FalagardMapping lookNFeel="OD/MenuScrollbar" renderer="Core/Scrollbar" targetType="CEGUI/Scrollbar" windowType="OD/MenuScrollbar" />
 </GUIScheme>

--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -25,8 +25,7 @@
             <Property name="Area" value="{{0.5,-80},{0,180},{0.5,80},{0,213}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/LoadIcon" />
             <Property name="Text" value="Load Game (F8)" />
-            <Property name="Disabled" value="True" />
-            <Property name="TooltipText" value="Not implemented yet" />
+            <Property name="TooltipText" value="Load a saved game." />
         </Window>
         <Window type="OD/IconButton" name="SettingsButton" >
             <Property name="Area" value="{{0.5,-80},{0,235},{0.5,80},{0,268}}" />

--- a/source/modes/AbstractApplicationMode.cpp
+++ b/source/modes/AbstractApplicationMode.cpp
@@ -24,6 +24,29 @@
 #include <CEGUI/System.h>
 #include <CEGUI/GUIContext.h>
 #include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/widgets/FrameWindow.h>
+#include <CEGUI/widgets/Combobox.h>
+#include <CEGUI/widgets/PopupMenu.h>
+
+#include <algorithm>
+
+namespace
+{
+void collectEscapeWindows(CEGUI::Window* window, std::vector<CEGUI::Window*>& windows)
+{
+    if(window == nullptr || !window->isVisible() || window->isDisabled())
+        return;
+
+    CEGUI::Combobox* combo = dynamic_cast<CEGUI::Combobox*>(window);
+    if(dynamic_cast<CEGUI::FrameWindow*>(window) != nullptr ||
+       dynamic_cast<CEGUI::PopupMenu*>(window) != nullptr ||
+       (combo != nullptr && combo->isDropDownListVisible()))
+        windows.push_back(window);
+
+    for(size_t i = 0; i < window->getChildCount(); ++i)
+        collectEscapeWindows(window->getChildAtIdx(i), windows);
+}
+}
 
 AbstractApplicationMode::~AbstractApplicationMode()
 {
@@ -78,6 +101,11 @@ bool AbstractApplicationMode::keyPressed(const OIS::KeyEvent& arg)
 {
     switch (arg.key)
     {
+    case OIS::KC_ESCAPE:
+        if(!CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(CEGUI::Key::Escape) &&
+           !closeTopWindow() && mModeType != ModeManager::ADVERTISMENT)
+            goBack();
+        break;
     default:
         CEGUI::System::getSingleton().getDefaultGUIContext().injectChar(
             static_cast<CEGUI::String::value_type>(arg.text));
@@ -103,4 +131,35 @@ bool AbstractApplicationMode::goBack(const CEGUI::EventArgs&)
 {
     mModeManager->requestPreviousMode();
     return true;
+}
+
+bool AbstractApplicationMode::closeTopWindow()
+{
+    CEGUI::GUIContext& context = CEGUI::System::getSingleton().getDefaultGUIContext();
+    std::vector<CEGUI::Window*> windows;
+    collectEscapeWindows(context.getModalWindow() != nullptr ?
+        context.getModalWindow() : context.getRootWindow(), windows);
+    std::sort(windows.begin(), windows.end(), [](CEGUI::Window* left, CEGUI::Window* right)
+    {
+        return left->isInFront(*right);
+    });
+
+    for(CEGUI::Window* window : windows)
+    {
+        if(CEGUI::Combobox* combo = dynamic_cast<CEGUI::Combobox*>(window))
+        {
+            combo->hideDropList();
+            return true;
+        }
+        if(CEGUI::PopupMenu* popup = dynamic_cast<CEGUI::PopupMenu*>(window))
+        {
+            popup->closePopupMenu();
+            return true;
+        }
+        CEGUI::WindowEventArgs args(window);
+        window->fireEvent(CEGUI::FrameWindow::EventCloseClicked, args);
+        if(args.handled != 0)
+            return true;
+    }
+    return false;
 }

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -126,6 +126,9 @@ public:
     {}
 
 protected:
+    //! Close the frontmost visible GUI window through its existing cancel handler.
+    bool closeTopWindow();
+
     ModeManager& getModeManager()
     {
         return *mModeManager;

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -341,11 +341,6 @@ EditorMode::EditorMode(ModeManager* modeManager):
             CEGUI::Event::Subscriber(&EditorMode::toggleOptionsWindow, this)
     ));
     addEventConnection(
-        mRootWindow->getChild("EditorOptionsWindow")->subscribeEvent(
-            CEGUI::FrameWindow::EventCloseClicked,
-            CEGUI::Event::Subscriber(&EditorMode::toggleOptionsWindow, this)
-    ));    
-    addEventConnection(
         mRootWindow->getChild("EditorOptionsWindow/SaveLevelButton")
         ->subscribeEvent(
             CEGUI::Window::EventMouseClick,
@@ -1497,8 +1492,13 @@ bool EditorMode::hidePortalWaveWindow(const CEGUI::EventArgs& /*arg*/)
 bool EditorMode::keyPressed(const OIS::KeyEvent &arg)
 {
     // Inject key to the gui currently displayed
-    CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(static_cast<CEGUI::Key::Scan>(arg.key));
+    const bool guiHandledKey = CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(
+        static_cast<CEGUI::Key::Scan>(arg.key));
     CEGUI::System::getSingleton().getDefaultGUIContext().injectChar(arg.text);
+
+    if(arg.key == OIS::KC_ESCAPE && mCurrentInputMode != InputModeConsole &&
+       mCurrentInputMode != InputModeChat && (guiHandledKey || closeTopWindow()))
+        return true;
 
     if (mCurrentInputMode == InputModeChat || mCurrentInputMode == InputModeSave || mCurrentInputMode == InputModeLoad || mCurrentInputMode == InputModeNew)
         return true;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -793,7 +793,8 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
 bool GameMode::keyPressed(const OIS::KeyEvent& arg)
 {
     // Inject key to Gui
-    CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(static_cast<CEGUI::Key::Scan>(arg.key));
+    const bool guiHandledKey = CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(
+        static_cast<CEGUI::Key::Scan>(arg.key));
     if (arg.text != 0 && !getConsole()->isFreshlyEnabled())
     {
         CEGUI::System::getSingleton().getDefaultGUIContext().injectChar(arg.text);
@@ -807,6 +808,8 @@ bool GameMode::keyPressed(const OIS::KeyEvent& arg)
             return getConsole()->keyPressed(arg);
         case InputModeNormal:
         default:
+            if(arg.key == OIS::KC_ESCAPE && guiHandledKey)
+                return true;
             return keyPressedNormal(arg);
     }
 }
@@ -934,8 +937,15 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         break;
     }
 
-    // Quit the game
+    // Close one GUI layer before considering a new exit confirmation.
     case OIS::KC_ESCAPE:
+        if(closeTopWindow())
+            break;
+        if(mRootWindow->getChild("GameEventText")->isVisible())
+        {
+            mRootWindow->getChild("GameEventText")->hide();
+            break;
+        }
         mExitToDesktop = false;
         popupExit(!mGameMap->getGamePaused());
         break;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -30,6 +30,7 @@
 #include "gamemap/Pathfinding.h"
 #include "modes/GameEditorModeConsole.h"
 #include "modes/InputBridge.h"
+#include "modes/MenuModeLoad.h"
 #include "network/ChatEventMessage.h"
 #include "network/ODClient.h"
 #include "network/ODServer.h"
@@ -210,6 +211,10 @@ GameMode::GameMode(ModeManager *modeManager):
         )
     );
     saveGameButtonWindow->setEnabled(ODServer::getSingleton().isConnected());
+    CEGUI::Window* loadGameButtonWindow = guiSheet->getChild("GameOptionsWindow/LoadGameButton");
+    addEventConnection(loadGameButtonWindow->subscribeEvent(CEGUI::PushButton::EventClicked,
+        CEGUI::Event::Subscriber(&GameMode::loadGame, this)));
+    loadGameButtonWindow->setEnabled(ODServer::getSingleton().isConnected());
     addEventConnection(
         guiSheet->getChild("GameOptionsWindow/SettingsButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
@@ -792,6 +797,8 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
 
 bool GameMode::keyPressed(const OIS::KeyEvent& arg)
 {
+    if(mLoadMenu && mLoadMenu->isOpenInGame())
+        return mLoadMenu->keyPressed(arg);
     // Inject key to Gui
     const bool guiHandledKey = CEGUI::System::getSingleton().getDefaultGUIContext().injectKeyDown(
         static_cast<CEGUI::Key::Scan>(arg.key));
@@ -838,6 +845,10 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
 
     case OIS::KC_F5:
         saveGame();
+        break;
+
+    case OIS::KC_F8:
+        loadGame();
         break;
 
     case OIS::KC_F9:
@@ -1411,6 +1422,18 @@ bool GameMode::showSkillFromOptions(const CEGUI::EventArgs& /*e*/)
 {
     mRootWindow->getChild("GameOptionsWindow")->hide();
     showSkillWindow();
+    return true;
+}
+
+bool GameMode::loadGame(const CEGUI::EventArgs& /*e*/)
+{
+    if(!ODServer::getSingleton().isConnected())
+        return true;
+    if(!mLoadMenu)
+        mLoadMenu.reset(new MenuModeLoad(&getModeManager(), true));
+    // Retain the options window so returning from the browser restores its caller.
+    showOptionsWindow();
+    mLoadMenu->activate();
     return true;
 }
 

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -33,6 +33,7 @@ class Window;
 }
 
 class Creature;
+class MenuModeLoad;
 
 enum class SpellType;
 enum class SkillType;
@@ -208,6 +209,7 @@ protected:
     bool showObjectivesFromOptions(const CEGUI::EventArgs& e = {});
     bool showSkillFromOptions(const CEGUI::EventArgs& e = {});
     bool saveGame(const CEGUI::EventArgs& e = {});
+    bool loadGame(const CEGUI::EventArgs& e = {});
     bool showSettingsFromOptions(const CEGUI::EventArgs& e = {});
 
     //! \brief Handle the keyboard input in normal mode
@@ -220,6 +222,7 @@ protected:
     virtual bool keyReleasedNormal  (const OIS::KeyEvent &arg);
 
 private:
+    std::unique_ptr<MenuModeLoad> mLoadMenu;
     //! \brief Whether the pending exit confirmation should leave to the desktop
     //! rather than back to the main menu. Set by the button that opened the
     //! confirmation popup.

--- a/source/modes/MenuModeLoad.cpp
+++ b/source/modes/MenuModeLoad.cpp
@@ -33,19 +33,21 @@
 #include "utils/ResourceManager.h"
 
 #include <CEGUI/CEGUI.h>
+#include <CEGUI/widgets/Scrollbar.h>
 #include "boost/filesystem.hpp"
 
 const std::string SAVEGAME_EXTENSION = ".level";
 
-MenuModeLoad::MenuModeLoad(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_LOAD_SAVEDGAME)
+MenuModeLoad::MenuModeLoad(ModeManager *modeManager, bool inGame, const std::string& savedGame):
+    AbstractApplicationMode(modeManager, ModeManager::MENU_LOAD_SAVEDGAME),
+    mInGame(inGame),
+    mSavedGame(savedGame)
 {
     CEGUI::Window* window = modeManager->getGui().getGuiSheet(Gui::guiSheet::loadSavedGameMenu);
     addEventConnection(
         window->getChild("LevelWindowFrame/BackButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
-            CEGUI::Event::Subscriber(&AbstractApplicationMode::goBack,
-                                     static_cast<AbstractApplicationMode*>(this))
+            CEGUI::Event::Subscriber(&MenuModeLoad::closeBrowser, this)
         )
     );
     addEventConnection(
@@ -75,10 +77,25 @@ MenuModeLoad::MenuModeLoad(ModeManager *modeManager):
     addEventConnection(
         window->getChild("LevelWindowFrame")->subscribeEvent(
             CEGUI::FrameWindow::EventCloseClicked,
-            CEGUI::Event::Subscriber(&AbstractApplicationMode::goBack,
-                                     static_cast<AbstractApplicationMode*>(this))
+            CEGUI::Event::Subscriber(&MenuModeLoad::closeBrowser, this)
         )
     );
+}
+
+MenuModeLoad::~MenuModeLoad()
+{
+    if(isOpenInGame())
+        closeBrowser();
+}
+
+bool MenuModeLoad::closeBrowser(const CEGUI::EventArgs&)
+{
+    if(!mInGame)
+        return goBack();
+    mOpen = false;
+    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(mWasPaused);
+    getModeManager().getGui().loadGuiSheet(Gui::inGameMenu);
+    return true;
 }
 
 void MenuModeLoad::activate()
@@ -86,15 +103,29 @@ void MenuModeLoad::activate()
     // Loads the corresponding Gui sheet.
     getModeManager().getGui().loadGuiSheet(Gui::guiSheet::loadSavedGameMenu);
 
-    giveFocus();
-
-    // Play the main menu music
-    MusicPlayer::getSingleton().play(ConfigManager::getSingleton().getMainMenuMusic());
-
-
     GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
-    gameMap->clearAll();
-    gameMap->setGamePaused(true);
+    CEGUI::Window* sheet = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu);
+    sheet->getChild("WelcomeBanner")->setVisible(!mInGame);
+    sheet->getChild("VersionText")->setVisible(!mInGame);
+    if(mInGame)
+    {
+        if(!mOpen)
+            mWasPaused = gameMap->getGamePaused();
+        mOpen = true;
+        gameMap->setGamePaused(true);
+    }
+    else
+    {
+        giveFocus();
+        MusicPlayer::getSingleton().play(ConfigManager::getSingleton().getMainMenuMusic());
+        gameMap->clearAll();
+        gameMap->setGamePaused(true);
+        if(!mSavedGame.empty())
+        {
+            ODFrameListener::getSingleton().stopGameRenderer();
+            ODFrameListener::getSingleton().createMainMenuScene();
+        }
+    }
 
     CEGUI::Window* tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LevelWindowFrame/SaveGameSelect");
     CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);
@@ -103,6 +134,7 @@ void MenuModeLoad::activate()
     tmpWin->hide();
     mFilesList.clear();
     levelSelectList->resetList();
+    sheet->getChild("LevelWindowFrame/MapDescriptionText")->setText("");
 
     std::string levelPath = ResourceManager::getSingleton().getSaveGamePath();
     if(Helper::fillFilesList(levelPath, mFilesList, SAVEGAME_EXTENSION))
@@ -116,6 +148,13 @@ void MenuModeLoad::activate()
             levelSelectList->addItem(item);
         }
     }
+    if(!mSavedGame.empty())
+    {
+        const std::string filename = mSavedGame;
+        mSavedGame.clear();
+        launchSavedGame(filename);
+    }
+
 }
 
 bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
@@ -131,18 +170,27 @@ bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
         return true;
     }
 
-    std::string nickname = ConfigManager::getSingleton().getGameValue(Config::NICKNAME, std::string(), false);
-    if (!nickname.empty())
-        ODFrameListener::getSingleton().getClientGameMap()->setLocalPlayerNick(nickname);
+    const uint32_t id = levelSelectList->getFirstSelectedItem()->getID();
+    if(id >= mFilesList.size())
+        return true;
+    const std::string level = mFilesList[id];
+    if(mInGame)
+    {
+        getModeManager().requestSavedGame(level);
+        return true;
+    }
+    return launchSavedGame(level);
+}
 
-    tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
+bool MenuModeLoad::launchSavedGame(const std::string& level)
+{
+    std::string nickname = ConfigManager::getSingleton().getGameValue(Config::NICKNAME, std::string(), false);
+    if(!nickname.empty())
+        ODFrameListener::getSingleton().getClientGameMap()->setLocalPlayerNick(nickname);
+    CEGUI::Window* tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
     tmpWin->setText("Loading...");
     tmpWin->show();
 
-    CEGUI::ListboxItem* selItem = levelSelectList->getFirstSelectedItem();
-    int id = selItem->getID();
-
-    const std::string& level = mFilesList[id];
     // In single player mode, we act as a server
     if(!ODServer::getSingleton().startServer(nickname, level, ServerMode::ModeGameLoaded, false))
     {
@@ -159,6 +207,7 @@ bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
         + ResourceManager::getSingleton().buildReplayFilename();
     if(!ODClient::getSingleton().connect("localhost", port, timeout, replayFilename))
     {
+        ODServer::getSingleton().stopServer();
         OD_LOG_ERR("Could not connect to server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
         tmpWin->setText("Error: Couldn't connect to local server!");
@@ -227,6 +276,7 @@ bool MenuModeLoad::updateDescription(const CEGUI::EventArgs&)
         mapDescription = "invalid map";
 
     descTxt->setText(mapDescription);
+    static_cast<CEGUI::Scrollbar*>(descTxt->getChild("__auto_vscrollbar__"))->setScrollPosition(0);
 
     return true;
 }

--- a/source/modes/MenuModeLoad.h
+++ b/source/modes/MenuModeLoad.h
@@ -23,7 +23,8 @@
 class MenuModeLoad: public AbstractApplicationMode
 {
 public:
-    MenuModeLoad(ModeManager*);
+    MenuModeLoad(ModeManager*, bool inGame = false, const std::string& savedGame = {});
+    ~MenuModeLoad() override;
 
     //! \brief Called when the game mode is activated
     //! Used to call the corresponding Gui Sheet.
@@ -32,8 +33,15 @@ public:
     bool launchSelectedButtonPressed(const CEGUI::EventArgs&);
     bool deleteSelectedButtonPressed(const CEGUI::EventArgs&);
     bool updateDescription(const CEGUI::EventArgs&);
+    bool closeBrowser(const CEGUI::EventArgs& = {});
+    bool isOpenInGame() const { return mInGame && mOpen; }
 
 private:
+    bool launchSavedGame(const std::string& level);
+    bool mInGame;
+    bool mOpen = false;
+    bool mWasPaused = false;
+    std::string mSavedGame;
     std::vector<std::string> mFilesList;
 };
 

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -192,6 +192,21 @@ bool MenuModeMain::toggleSettings(const CEGUI::EventArgs&)
     return true;
 }
 
+bool MenuModeMain::goBack(const CEGUI::EventArgs&)
+{
+    CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);
+    for(const std::string& name : {WINDOW_SKIRMISH, WINDOW_MULTIPLAYER, WINDOW_EDITOR})
+    {
+        CEGUI::Window* window = mainWin->getChild(name);
+        if(window->isVisible())
+        {
+            window->hide();
+            break;
+        }
+    }
+    return true;
+}
+
 bool MenuModeMain::toggleSkirmishSubMenu(const CEGUI::EventArgs&)
 {
     CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);

--- a/source/modes/MenuModeMain.h
+++ b/source/modes/MenuModeMain.h
@@ -34,6 +34,8 @@ public:
     //! Used to call the corresponding Gui Sheet.
     void activate() final override;
 
+    bool goBack(const CEGUI::EventArgs& e = {}) override;
+
 private:
     //! \brief The Settings window
     SettingsWindow mSettings;

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -73,6 +73,12 @@ void ModeManager::requestPreviousMode()
     mStoreCurrentModeAtChange = false;
 }
 
+void ModeManager::requestSavedGame(const std::string& filename)
+{
+    mRequestedSavedGame = filename;
+    requestMode(MENU_LOAD_SAVEDGAME, false);
+}
+
 void ModeManager::checkModeChange()
 {
     if (mRequestedMode == NONE)
@@ -128,7 +134,10 @@ void ModeManager::checkModeChange()
         mCurrentApplicationMode = Utils::make_unique<EditorMode>(this);
         break;
     case MENU_LOAD_SAVEDGAME:
-        mCurrentApplicationMode = Utils::make_unique<MenuModeLoad>(this);
+        mCurrentApplicationMode = Utils::make_unique<MenuModeLoad>(this, false, mRequestedSavedGame);
+        mRequestedSavedGame.clear();
+        if(previousMode == GAME)
+            mPreviousModeTypes.clear();
         break;
     case MENU_MASTERSERVER_HOST:
         mCurrentApplicationMode = Utils::make_unique<MenuModeMultiplayerServer>(this, true);

--- a/source/modes/ModeManager.h
+++ b/source/modes/ModeManager.h
@@ -55,6 +55,7 @@ public:
 
     //! \brief Request to load the previous mode type.
     void requestPreviousMode();
+    void requestSavedGame(const std::string& filename);
 
     InputManager& getInputManager()
     { return mInputManager; }
@@ -83,6 +84,7 @@ private:
     //! \brief Tells whether the current mode should be kept in history
     //! when changing from the current mode.
     bool mStoreCurrentModeAtChange;
+    std::string mRequestedSavedGame;
 
     //! \brief Actually change the mode if needed
     void checkModeChange();

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -234,9 +234,39 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
             {
                 case ServerMode::ModeGameSinglePlayer:
                 case ServerMode::ModeGameMultiPlayer:
-                case ServerMode::ModeGameLoaded:
                     frameListener->getModeManager()->requestMode(AbstractModeManager::MENU_CONFIGURE_SEATS);
                     break;
+                case ServerMode::ModeGameLoaded:
+                {
+                    // A saved skirmish already fixes its human side, faction and team.
+                    bool fixedSeats = getSource() != ODSource::file;
+                    uint32_t humanSeats = 0;
+                    for(Seat* seat : gameMap->getSeats())
+                    {
+                        if(seat->isRogueSeat())
+                            continue;
+                        if(seat->getPlayerType() == Seat::PLAYER_TYPE_HUMAN)
+                            ++humanSeats;
+                        else if(seat->getPlayerType() != Seat::PLAYER_TYPE_AI &&
+                                seat->getPlayerType() != Seat::PLAYER_TYPE_INACTIVE)
+                            fixedSeats = false;
+                        if(seat->getAvailableTeamIds().size() != 1 ||
+                           seat->getFaction() == Seat::PLAYER_FACTION_CHOICE)
+                            fixedSeats = false;
+                    }
+                    if(fixedSeats && humanSeats == 1)
+                    {
+                        ODPacket ready;
+                        ready << ClientNotificationType::readyForSeatConfiguration;
+                        send(ready);
+                        ODPacket start;
+                        start << ClientNotificationType::seatConfigurationSet;
+                        send(start);
+                    }
+                    else
+                        frameListener->getModeManager()->requestMode(AbstractModeManager::MENU_CONFIGURE_SEATS);
+                    break;
+                }
                 case ServerMode::ModeEditor:
                     break;
                 default:
@@ -273,6 +303,8 @@ bool ODClient::processMessage(ServerNotificationType cmd, ODPacket& packetReceiv
        
         case ServerNotificationType::addPlayers:
         {
+            if(frameListener->getModeManager()->getCurrentModeType() == ModeManager::MENU_LOAD_SAVEDGAME)
+                break;
             if(frameListener->getModeManager()->getCurrentModeType() != ModeManager::ModeType::MENU_CONFIGURE_SEATS)
             {
                 OD_LOG_ERR("Wrong mode " + Helper::toString(frameListener->getModeManager()->getCurrentModeType()));


### PR DESCRIPTION
Loading a saved single-player game could reopen the new-game seat-selection
lobby, and the Load command was disabled during play. Reuse the saved-game
browser over the active local game, preserve that game and its pause state on
Back, and defer replacement until a save has been selected. Fixed single-human
saves resume their stored side through the existing protocol.

The same browser keeps long descriptions accessible through a usable scrollbar,
resets the scroll position when selection changes and clears stale descriptions
on reopening. Its required scrollbar skin is included; the broader menu redesign
is not a dependency of this contribution. The existing save format is unchanged.

Depends on #80 for Escape/back dispatch. The default comparison includes that
prerequisite; [review this contribution alone](https://github.com/Rokk001/OpenDungeonsPlus/compare/360922369bed1b92925f87fcdb4e245c93c5640a...140ff86ebb0958e6adcef11c3b97a42f5162f4d2).
The separate room-lighting teardown correction remains in #81. No matching open
issue was identified for this complete loading/browser outcome.

Validation: a Windows x64 Release integration build with #47/#53 and the other independently scoped contributions passed, as did runtime preparation; this is not a standalone cross-platform build claim. The production browser with real CEGUI events passed 176 checks, including scrolling and reset; existing protocol/seat setup passed 201 checks and deferred mode transitions passed 18. The user previously accepted loading during play and description access in the complete fork. No game was launched for this assembly; other-platform runtime and complete save-format fidelity remain outside this verification.
