### PR TITLE
Add a standalone creature portrait exporter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ if(WIN32 AND ${OGRE_FOUND})
 
     find_package(Boost REQUIRED COMPONENTS ${OD_BOOST_COMPONENTS})
     if(Boost_FOUND)
-        set(OD_BOOST_LIB_DIRS  ${Boost_INCLUDE_DIRS}/stage/lib)
+        set(OD_BOOST_LIB_DIRS  ${Boost_LIBRARY_DIRS})
         set(OD_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     endif()
 else()
@@ -660,6 +660,12 @@ target_link_libraries(
 )
 
 target_link_libraries(opendungeons-plus pybind11::embed)
+
+if(MSVC AND PYTHON_DEBUG_LIBRARY AND NOT PYTHON_IS_DEBUG)
+    # Keep pybind11's headers consistent with the selected debug Python library.
+    # Python's Windows header defines Py_DEBUG without a value as well.
+    target_compile_definitions(${PROJECT_BINARY_NAME} PRIVATE "$<$<CONFIG:Debug>:Py_DEBUG=>")
+endif()
 
 # Set linker options in MSVC
 if(WIN32 AND MSVC)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ following resources to learn the basic gameplay concepts:
 You can play singleplayer levels using the Skirmish menu, or host/join a
 multiplayer game by using the corresponding menus.
 
+The [creature portrait exporter](tools/portraits/README.md) builds a standalone
+tool for rendering the configured creature models to PNG files.
+
 ### Be part of the community
 
 As free software aficionados, we value community-based development and

--- a/scripts/win32/Enter-OpenDungeonsPlus.ps1
+++ b/scripts/win32/Enter-OpenDungeonsPlus.ps1
@@ -1,0 +1,13 @@
+$taskDependencyRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+$env:Path = "$taskDependencyRoot\tools\cmake-3.31.8-windows-x86_64\bin;$taskDependencyRoot\install\bin;$taskDependencyRoot\install\lib;C:\Users\mario\AppData\Local\Programs\Python\Python310;" + $env:Path
+$env:CMAKE_PREFIX_PATH = "$taskDependencyRoot\install"
+$env:CEGUI_HOME = "$taskDependencyRoot\install"
+$env:OIS_HOME = "$taskDependencyRoot\install"
+$env:BOOST_ROOT = "$taskDependencyRoot\install"
+$env:BOOST_INCLUDEDIR = "$taskDependencyRoot\install\include\boost-1_82"
+$env:BOOST_LIBRARYDIR = "$taskDependencyRoot\install\lib"
+$env:LIB = "$taskDependencyRoot\install\lib;" + $env:LIB
+Write-Output 'OpenDungeonsPlus development environment loaded (Windows x64).'

--- a/scripts/win32/configure-windows-prereqs.ps1
+++ b/scripts/win32/configure-windows-prereqs.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Enter-OpenDungeonsPlus.ps1')
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskPythonRoot = 'C:/Users/mario/AppData/Local/Programs/Python/Python310'
+$taskOptions = @('-S', $taskRepo, '-B', "$taskRepo\build\windows",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', '-DOD_BUILD_TESTING=OFF', '-DBUILD_TESTING=OFF',
+    "-DCMAKE_INSTALL_PREFIX=$taskRepo/build/windows/install",
+    "-DPYTHON_EXECUTABLE=$taskPythonRoot/python.exe", "-DPYTHON_LIBRARY=$taskPythonRoot/libs/python310.lib",
+    "-DPYTHON_DEBUG_LIBRARY=$taskPythonRoot/libs/python310_d.lib", "-DPYTHON_INCLUDE_DIR=$taskPythonRoot/include")
+Write-Output 'Checking the original project configuration with the installed prerequisites'
+$ErrorActionPreference = 'Continue'
+& cmake @taskOptions *> "$taskRoot\logs\opendungeons-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\opendungeons-configure.log" -Tail 60; throw 'Project configuration failed' }
+Write-Output 'Original project configuration succeeded'
+& (Join-Path $PSScriptRoot 'prepare-windows-runtime.ps1')

--- a/scripts/win32/export-creature-portraits.ps1
+++ b/scripts/win32/export-creature-portraits.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+Build and run the isolated creature portrait exporter using the game's renderer.
+#>
+[CmdletBinding()]
+param(
+    [string]$DependencyPrefix,
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$taskProjectRoot = (Resolve-Path -LiteralPath "$PSScriptRoot\..\..").Path
+$taskCurrentPath = $env:Path
+[Environment]::SetEnvironmentVariable('PATH', $null, 'Process')
+[Environment]::SetEnvironmentVariable('Path', $taskCurrentPath, 'Process')
+if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+    . "$PSScriptRoot\Enter-OpenDungeonsPlus.ps1"
+}
+if (-not $DependencyPrefix) {
+    $DependencyPrefix = $env:CEGUI_HOME
+}
+if (-not $DependencyPrefix) {
+    throw 'Provide DependencyPrefix or load the project development environment first.'
+}
+$taskPrefix = (Resolve-Path -LiteralPath $DependencyPrefix).Path
+if (-not $OutputDirectory) {
+    $OutputDirectory = Join-Path $taskProjectRoot 'build\portrait-export'
+}
+$taskOutput = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputDirectory)
+foreach ($taskRequired in @('bin\RenderSystem_GL3Plus.dll', 'bin\Codec_STBI.dll',
+        'include\OGRE\Ogre.h', 'include\cegui-0\CEGUI\CEGUI.h', 'lib\OgreMain.lib')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $taskPrefix $taskRequired))) {
+        throw "Missing portrait exporter prerequisite: $taskRequired"
+    }
+}
+New-Item -ItemType Directory -Path $taskOutput -Force | Out-Null
+$taskOriginalPath = $env:Path
+Push-Location -LiteralPath $taskOutput
+try {
+    # Normalize the environment key for hidden child processes on Windows.
+    [Environment]::SetEnvironmentVariable('PATH', $null, 'Process')
+    [Environment]::SetEnvironmentVariable('Path', "$taskPrefix\bin;$taskPrefix\lib;$taskOriginalPath", 'Process')
+    & cl.exe /nologo /EHsc /MD /std:c++14 "/I$taskPrefix\include\OGRE" `
+        "/I$taskPrefix\include\OGRE\RTShaderSystem" "/I$taskPrefix\include\cegui-0" `
+        "/I$taskProjectRoot\source" "$taskProjectRoot\tools\portraits\portrait-export.cpp" `
+        "$taskProjectRoot\source\render\CreaturePortrait.cpp" /Feportrait-export.exe `
+        /link "/LIBPATH:$taskPrefix\lib" OgreMain.lib CEGUIBase-0.lib `
+        CEGUIOgreRenderer-0.lib OgreRTShaderSystem.lib OgreBites.lib *> portrait-export-build.log
+    if ($LASTEXITCODE -ne 0) {
+        Get-Content portrait-export-build.log -Tail 25
+        throw 'Portrait exporter compilation failed.'
+    }
+    $taskArguments = @($taskProjectRoot, $taskPrefix, $taskOutput) | ForEach-Object { '"' + $_ + '"' }
+    $taskProcess = Start-Process -FilePath (Join-Path $taskOutput 'portrait-export.exe') `
+        -ArgumentList $taskArguments -WorkingDirectory $taskOutput -WindowStyle Hidden -Wait -PassThru `
+        -RedirectStandardOutput (Join-Path $taskOutput 'portrait-export-results.log') `
+        -RedirectStandardError (Join-Path $taskOutput 'portrait-export-stderr.log')
+    if ($taskProcess.ExitCode -ne 0) {
+        Get-Content portrait-export-stderr.log -Tail 15
+        throw "Portrait export failed: $($taskProcess.ExitCode)"
+    }
+    Select-String -LiteralPath 'portrait-export-results.log' -Pattern '^PORTRAITS='
+    Write-Output "Portraits and logs: $taskOutput"
+}
+finally {
+    [Environment]::SetEnvironmentVariable('Path', $taskOriginalPath, 'Process')
+    Pop-Location
+}

--- a/scripts/win32/install-base-prereqs.ps1
+++ b/scripts/win32/install-base-prereqs.ps1
@@ -1,0 +1,39 @@
+param([string[]]$Only)
+
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPrefix = "$taskRoot\install"
+
+$taskPackages = @(
+    @{ Name = 'expat'; Source = 'expat/expat'; Options = @('-DEXPAT_BUILD_TOOLS=OFF', '-DEXPAT_BUILD_EXAMPLES=OFF', '-DEXPAT_BUILD_TESTS=OFF', '-DEXPAT_BUILD_DOCS=OFF', '-DEXPAT_SHARED_LIBS=ON') },
+    @{ Name = 'ois'; Source = 'ois'; Options = @('-DOIS_BUILD_DEMOS=OFF', '-DOIS_BUILD_SHARED_LIBS=ON') },
+    @{ Name = 'sfml'; Source = 'sfml'; Options = @('-DSFML_BUILD_EXAMPLES=OFF', '-DSFML_BUILD_DOC=OFF') },
+    @{ Name = 'freetype'; Source = 'freetype'; Options = @('-DFT_DISABLE_ZLIB=ON', '-DFT_DISABLE_BZIP2=ON', '-DFT_DISABLE_PNG=ON', '-DFT_DISABLE_HARFBUZZ=ON', '-DFT_DISABLE_BROTLI=ON') },
+    @{ Name = 'pybind11'; Source = 'pybind11'; Options = @('-DPYBIND11_TEST=OFF', '-DPYBIND11_INSTALL=ON', '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe') },
+    @{ Name = 'pcre'; Source = 'pcre-8.45'; Options = @('-DPCRE_BUILD_TESTS=OFF', '-DPCRE_BUILD_PCREGREP=OFF', '-DPCRE_BUILD_PCRECPP=OFF', '-DPCRE_SUPPORT_UTF=ON', '-DPCRE_SUPPORT_UNICODE_PROPERTIES=ON') }
+)
+
+foreach ($taskPackage in $taskPackages) {
+    if ($Only -and $taskPackage.Name -notin $Only) { continue }
+    $taskName = $taskPackage.Name
+    $taskBuild = "$taskRoot\build\$taskName"
+    $taskConfigureLog = "$taskRoot\logs\$taskName-configure.log"
+    $taskOptions = @('-S', "$taskRoot\src\$($taskPackage.Source)", '-B', $taskBuild,
+        '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskPrefix",
+        "-DCMAKE_PREFIX_PATH=$taskPrefix", '-DBUILD_SHARED_LIBS=ON', '-DCMAKE_DEBUG_POSTFIX=_d') + $taskPackage.Options
+    Write-Output "Configuring $taskName"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake @taskOptions *> $taskConfigureLog
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskConfigureLog -Tail 45; throw "$taskName configuration failed" }
+    foreach ($taskConfiguration in @('Release', 'Debug')) {
+        $taskBuildLog = "$taskRoot\logs\$taskName-$taskConfiguration.log"
+        Write-Output "Building and installing $taskName ($taskConfiguration)"
+        $ErrorActionPreference = 'Continue'
+        & $taskCmake --build $taskBuild --config $taskConfiguration --target INSTALL --parallel 8 *> $taskBuildLog
+        $ErrorActionPreference = 'Stop'
+        if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath $taskBuildLog -Tail 45; throw "$taskName $taskConfiguration build failed" }
+    }
+    Write-Output "Installed $taskName"
+}

--- a/scripts/win32/install-boost-prereq.ps1
+++ b/scripts/win32/install-boost-prereq.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskVsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+Import-Module "$taskVsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath $taskVsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+Set-Location -LiteralPath "$taskRoot\src\boost_1_82_0"
+Write-Output 'Preparing Boost build tool'
+$ErrorActionPreference = 'Continue'
+& .\bootstrap.bat *> "$taskRoot\logs\boost-bootstrap.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-bootstrap.log" -Tail 40; throw 'Boost bootstrap failed' }
+$taskCompiler = (Get-Command cl.exe).Source.Replace('\', '/')
+$taskCompilerSetup = "$taskVsPath\VC\Auxiliary\Build\vcvarsall.bat".Replace('\', '/')
+'using msvc : 14.3 : "{0}" : <setup>"{1}" ;' -f $taskCompiler, $taskCompilerSetup | Set-Content -LiteralPath "$taskRoot\boost-user-config.jam" -Encoding ASCII
+Write-Output 'Building and installing Boost libraries for Release and Debug'
+$ErrorActionPreference = 'Continue'
+& .\b2.exe -j8 "--user-config=$taskRoot\boost-user-config.jam" --reconfigure toolset=msvc-14.3 architecture=x86 address-model=64 variant=release,debug link=static,shared runtime-link=shared threading=multi --layout=versioned --with-filesystem --with-locale --with-program_options --with-thread --with-system --with-chrono --with-date_time --with-atomic "--prefix=$taskRoot\install" install *> "$taskRoot\logs\boost-build.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\boost-build.log" -Tail 50; throw 'Boost build failed' }
+Write-Output 'Boost installed'

--- a/scripts/win32/install-cegui-prereq.ps1
+++ b/scripts/win32/install-cegui-prereq.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskPatch = Join-Path $PSScriptRoot 'patches/cegui-msvc-snprintf.patch'
+$ErrorActionPreference = 'Continue'
+& git -C "$taskRoot\src\cegui" apply --reverse --check $taskPatch *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Output 'Applying CEGUI snprintf compatibility fix for modern MSVC'
+    & git -C "$taskRoot\src\cegui" apply $taskPatch
+    if ($LASTEXITCODE -ne 0) { throw 'CEGUI compatibility patch failed' }
+}
+$ErrorActionPreference = 'Stop'
+$taskOptions = @('-S', "$taskRoot\src\cegui", '-B', "$taskRoot\build\cegui",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4',
+    '-DCEGUI_BUILD_RENDERER_OGRE=ON', '-DCEGUI_BUILD_RENDERER_OPENGL=OFF',
+    '-DCEGUI_BUILD_RENDERER_OPENGL3=OFF', '-DCEGUI_BUILD_RENDERER_OPENGLES=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D9=OFF', '-DCEGUI_BUILD_RENDERER_DIRECT3D10=OFF',
+    '-DCEGUI_BUILD_RENDERER_DIRECT3D11=OFF', '-DCEGUI_BUILD_XMLPARSER_EXPAT=ON',
+    '-DCEGUI_BUILD_XMLPARSER_LIBXML2=OFF', '-DCEGUI_BUILD_IMAGECODEC_FREEIMAGE=OFF',
+    '-DCEGUI_SAMPLES_ENABLED=OFF', '-DCEGUI_BUILD_APPLICATION_TEMPLATES=OFF',
+    '-DCEGUI_BUILD_TESTS=OFF', '-DCEGUI_BUILD_PERFORMANCE_TESTS=OFF', '-DCEGUI_BUILD_DATAFILES_TEST=OFF',
+    '-DCEGUI_BUILD_LUA_MODULE=OFF', '-DCEGUI_BUILD_LUA_GENERATOR=OFF', '-DCEGUI_BUILD_PYTHON_MODULES=OFF',
+    '-DCEGUI_LIB_INSTALL_DIR:PATH=lib', '-DCEGUI_INCLUDE_INSTALL_DIR:PATH=include/cegui-0',
+    "-DFREETYPE_LIB_DBG=$taskRoot/install/lib/freetyped.lib",
+    "-DEXPAT_LIB_DBG=$taskRoot/install/lib/libexpatd.lib",
+    "-DPCRE_LIB_DBG=$taskRoot/install/lib/pcred.lib",
+    "-DBOOST_ROOT=$taskRoot/install", "-DBOOST_INCLUDEDIR=$taskRoot/install/include/boost-1_82",
+    '-DPYTHON_EXECUTABLE=C:/Users/mario/AppData/Local/Programs/Python/Python310/python.exe')
+Write-Output 'Configuring CEGUI'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\cegui-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-configure.log" -Tail 60; throw 'CEGUI configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing CEGUI ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\cegui" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\cegui-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\cegui-$taskConfiguration.log" -Tail 60; throw "CEGUI $taskConfiguration build failed" }
+}
+Write-Output 'CEGUI installed'

--- a/scripts/win32/install-ogre-prereq.ps1
+++ b/scripts/win32/install-ogre-prereq.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$taskRoot = 'C:\Users\mario\od-deps'
+$taskCmake = "$taskRoot\tools\cmake-3.31.8-windows-x86_64\bin\cmake.exe"
+$taskOptions = @('-S', "$taskRoot\src\ogre", '-B', "$taskRoot\build\ogre",
+    '-G', 'Visual Studio 17 2022', '-A', 'x64', "-DCMAKE_INSTALL_PREFIX=$taskRoot\install",
+    "-DCMAKE_PREFIX_PATH=$taskRoot\install", '-DOGRE_BUILD_DEPENDENCIES=OFF',
+    '-DOGRE_STATIC=OFF', '-DOGRE_CONFIG_THREAD_PROVIDER=std', '-DOGRE_CONFIG_THREADS=3',
+    '-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON', '-DOGRE_BUILD_RENDERSYSTEM_GL=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_D3D9=OFF', '-DOGRE_BUILD_RENDERSYSTEM_D3D11=OFF',
+    '-DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF', '-DOGRE_BUILD_PLUGIN_FREEIMAGE=OFF',
+    '-DOGRE_BUILD_PLUGIN_EXRCODEC=OFF', '-DOGRE_BUILD_PLUGIN_BSP=OFF',
+    '-DOGRE_BUILD_PLUGIN_PCZ=OFF', '-DOGRE_BUILD_PLUGIN_DOT_SCENE=OFF',
+    '-DOGRE_BUILD_COMPONENT_JAVA=OFF', '-DOGRE_BUILD_COMPONENT_PYTHON=OFF',
+    '-DOGRE_BUILD_COMPONENT_CSHARP=OFF', '-DOGRE_BUILD_COMPONENT_VOLUME=OFF',
+    '-DOGRE_BUILD_COMPONENT_PAGING=OFF', '-DOGRE_BUILD_COMPONENT_TERRAIN=OFF',
+    '-DOGRE_BUILD_COMPONENT_PROPERTY=OFF', '-DOGRE_BUILD_COMPONENT_MESHLODGENERATOR=OFF',
+    '-DOGRE_BUILD_COMPONENT_HLMS=OFF', '-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=OFF',
+    '-DOGRE_BUILD_SAMPLES=OFF', '-DOGRE_BUILD_TOOLS=OFF', '-DOGRE_BUILD_TESTS=OFF',
+    '-DOGRE_ENABLE_PRECOMPILED_HEADERS=ON', '-DOGRE_BUILD_MSVC_MP=OFF', '-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MP4')
+Write-Output 'Configuring OGRE'
+$ErrorActionPreference = 'Continue'
+& $taskCmake @taskOptions *> "$taskRoot\logs\ogre-configure.log"
+$ErrorActionPreference = 'Stop'
+if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-configure.log" -Tail 55; throw 'OGRE configuration failed' }
+foreach ($taskConfiguration in @('Release', 'Debug')) {
+    Write-Output "Building and installing OGRE ($taskConfiguration)"
+    $ErrorActionPreference = 'Continue'
+    & $taskCmake --build "$taskRoot\build\ogre" --config $taskConfiguration --target INSTALL --parallel 4 *> "$taskRoot\logs\ogre-$taskConfiguration.log"
+    $ErrorActionPreference = 'Stop'
+    if ($LASTEXITCODE -ne 0) { Get-Content -LiteralPath "$taskRoot\logs\ogre-$taskConfiguration.log" -Tail 55; throw "OGRE $taskConfiguration build failed" }
+}
+Write-Output 'OGRE installed'

--- a/scripts/win32/patches/cegui-msvc-snprintf.patch
+++ b/scripts/win32/patches/cegui-msvc-snprintf.patch
@@ -1,0 +1,8 @@
+diff --git a/cegui/include/CEGUI/PropertyHelper.h b/cegui/include/CEGUI/PropertyHelper.h
+--- a/cegui/include/CEGUI/PropertyHelper.h
++++ b/cegui/include/CEGUI/PropertyHelper.h
+@@ -51,3 +51,3 @@
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && _MSC_VER < 1900
+     #define snprintf _snprintf
+ #endif

--- a/scripts/win32/prepare-windows-runtime.ps1
+++ b/scripts/win32/prepare-windows-runtime.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$taskBuild = Join-Path $taskRepo 'build\windows'
+$taskPrefix = 'C:\Users\mario\od-deps\install'
+$taskPythonRoot = 'C:\Users\mario\AppData\Local\Programs\Python\Python310'
+$taskResourcesFile = Join-Path $taskBuild 'resources.cfg'
+
+# These include the plugins loaded dynamically by OGRE and CEGUI, as well as
+# the transitive dependencies of the installed Release libraries.
+$taskRuntimeNames = @(
+    'OgreBites.dll', 'OgreRTShaderSystem.dll', 'OgreOverlay.dll', 'OgreMain.dll'
+    'OIS.dll', 'sfml-audio-2.dll', 'sfml-network-2.dll', 'sfml-system-2.dll'
+    'CEGUIBase-0.dll', 'CEGUIOgreRenderer-0.dll'
+    'CEGUICoreWindowRendererSet.dll', 'CEGUIExpatParser.dll'
+    'Plugin_ParticleFX.dll', 'Plugin_OctreeSceneManager.dll'
+    'Codec_STBI.dll', 'RenderSystem_GL3Plus.dll'
+    'freetype.dll', 'libexpat.dll', 'pcre.dll', 'openal32.dll'
+)
+$taskRuntimeSources = @($taskRuntimeNames | ForEach-Object { Join-Path "$taskPrefix\bin" $_ })
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python310.dll'
+$taskRuntimeSources += Join-Path $taskPythonRoot 'python3.dll'
+foreach ($taskPath in ($taskRuntimeSources + @($taskResourcesFile, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs",
+    "$taskPrefix\Media\RTShaderLib\GLSL", "$taskPrefix\Media\Main"))) {
+    if (-not (Test-Path -LiteralPath $taskPath)) { throw "Required runtime input is missing: $taskPath" }
+}
+
+# The upstream template points to a Unix installation layout; the installed
+# Windows OGRE media lives in install/Media and only includes GLSL shader sources.
+$taskResourceLines = @(foreach ($taskLine in Get-Content -LiteralPath $taskResourcesFile) {
+    if ($taskLine -match '^FileSystem=.*?/share/OGRE/Media/(.+)$') {
+        $taskMediaPath = Join-Path "$taskPrefix\Media" $Matches[1]
+        if (Test-Path -LiteralPath $taskMediaPath -PathType Container) {
+            'FileSystem=' + ((Resolve-Path -LiteralPath $taskMediaPath).Path -replace '\\', '/')
+        }
+    } else {
+        $taskLine
+    }
+})
+foreach ($taskLine in $taskResourceLines) {
+    if ($taskLine -match '^FileSystem=(.+)$') {
+        $taskResourcePath = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($taskResourcePath)) {
+            $taskResourcePath = Join-Path $taskBuild $taskResourcePath
+        }
+        if (-not (Test-Path -LiteralPath $taskResourcePath -PathType Container)) {
+            throw "Game resource directory is missing: $taskResourcePath"
+        }
+    }
+}
+
+foreach ($taskSource in $taskRuntimeSources) {
+    Copy-Item -LiteralPath $taskSource -Destination $taskBuild -Force
+}
+[System.IO.File]::WriteAllLines($taskResourcesFile, [string[]]$taskResourceLines)
+
+# Resolve the existing Python installation without a prepared shell or PATH.
+# The paths apply only to the Python DLL beside this Release executable.
+$taskPythonPaths = @('.', $taskPythonRoot, "$taskPythonRoot\Lib", "$taskPythonRoot\DLLs", 'import site')
+[System.IO.File]::WriteAllLines((Join-Path $taskBuild 'python310._pth'), [string[]]$taskPythonPaths)
+Write-Output "Release runtime prepared in $taskBuild; open opendungeons-plus.exe to test the game."

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,7 +235,7 @@ void ODApplication::startClient()
     HWND hwnd;
     renderWindow->getCustomAttribute("WINDOW", static_cast<void*>(&hwnd));
     HINSTANCE hInst = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
-    SetClassLong(hwnd, GCL_HICON, reinterpret_cast<LONG>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
+    SetClassLongPtr(hwnd, GCLP_HICON, reinterpret_cast<LONG_PTR>(LoadIcon(hInst, MAKEINTRESOURCE(IDI_ICON1))));
 #endif
 
     //Initialise RTshader system

--- a/source/render/CreaturePortrait.cpp
+++ b/source/render/CreaturePortrait.cpp
@@ -1,0 +1,227 @@
+/*
+ *  Copyright (C) 2026 OpenDungeons Team
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "render/CreaturePortrait.h"
+
+#include <Ogre.h>
+#include <OgreBone.h>
+#include <OgreHardwarePixelBuffer.h>
+#include <OgreRenderTexture.h>
+
+#include <CEGUI/BasicImage.h>
+#include <CEGUI/ImageManager.h>
+#include <CEGUI/RendererModules/Ogre/Renderer.h>
+#include <CEGUI/System.h>
+#include <CEGUI/Texture.h>
+
+namespace
+{
+struct PortraitScene
+{
+    Ogre::SceneManager* scene = Ogre::Root::getSingleton().createSceneManager("DefaultSceneManager");
+    std::vector<Ogre::MaterialPtr> materials;
+
+    ~PortraitScene()
+    {
+        Ogre::Root::getSingleton().destroySceneManager(scene);
+        for(const auto& material : materials)
+            Ogre::MaterialManager::getSingleton().remove(material->getHandle());
+    }
+};
+}
+
+Ogre::TexturePtr createCreaturePortrait(const std::string& meshName, const std::string& textureName)
+{
+    PortraitScene portrait;
+    Ogre::SceneManager* scene = portrait.scene;
+    scene->setAmbientLight(Ogre::ColourValue(0.6f, 0.6f, 0.6f));
+    Ogre::Light* light = scene->createLight();
+    light->setType(Ogre::Light::LT_DIRECTIONAL);
+    light->setDiffuseColour(0.8f, 0.8f, 0.8f);
+    light->setSpecularColour(0.1f, 0.1f, 0.1f);
+    Ogre::SceneNode* lightNode = scene->getRootSceneNode()->createChildSceneNode();
+    lightNode->attachObject(light);
+    lightNode->setDirection(0.4f, 1.0f, -0.6f);
+
+    Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(meshName, "Graphics");
+    unsigned short src, dest;
+    if(!mesh->suggestTangentVectorBuildParams(Ogre::VES_TANGENT, src, dest))
+        mesh->buildTangentVectors(Ogre::VES_TANGENT, src, dest);
+    Ogre::Entity* entity = scene->createEntity(mesh);
+    scene->getRootSceneNode()->createChildSceneNode()->attachObject(entity);
+    if(entity->hasAnimationState("Idle"))
+        entity->getAnimationState("Idle")->setEnabled(true);
+    entity->_updateAnimation();
+
+    // World shadow settings mutate shared material parameters. Only portrait
+    // copies may override them, and they are released after this one render.
+    for(unsigned int i = 0; i < entity->getNumSubEntities(); ++i)
+    {
+        Ogre::SubEntity* subEntity = entity->getSubEntity(i);
+        Ogre::MaterialPtr material = subEntity->getMaterial()->clone(textureName + "/" + std::to_string(i));
+        portrait.materials.push_back(material);
+        for(unsigned short t = 0; t < material->getNumTechniques(); ++t)
+        {
+            Ogre::Technique* technique = material->getTechnique(t);
+            for(unsigned short p = 0; p < technique->getNumPasses(); ++p)
+            {
+                Ogre::Pass* pass = technique->getPass(p);
+                if(!pass->hasFragmentProgram())
+                    continue;
+                Ogre::GpuProgramParametersSharedPtr parameters = pass->getFragmentProgramParameters();
+                if(parameters->hasNamedParameters() &&
+                    parameters->getConstantDefinitions().map.count("shadowingEnabled") != 0)
+                    parameters->setNamedConstant("shadowingEnabled", false);
+            }
+        }
+        subEntity->setMaterial(material);
+    }
+
+    const Ogre::AxisAlignedBox& bounds = mesh->getBounds();
+    const Ogre::Vector3 size = bounds.getSize();
+    const float height = std::max(size.z * 0.65f, size.x * 0.35f);
+    Ogre::Vector3 center = bounds.getCenter();
+    center.z = bounds.getMinimum().z + size.z * 0.72f;
+    if(size.z < size.y)
+    {
+        center = bounds.getCenter();
+        if(entity->hasSkeleton())
+        {
+            for(unsigned short i = 0; i < entity->getSkeleton()->getNumBones(); ++i)
+            {
+                Ogre::Bone* bone = entity->getSkeleton()->getBone(i);
+                std::string name = bone->getName();
+                Ogre::StringUtil::toLowerCase(name);
+                if(name == "head" || Ogre::StringUtil::endsWith(name, "_head"))
+                {
+                    center = bone->_getDerivedPosition();
+                    center.z += size.z * 0.05f;
+                    break;
+                }
+            }
+        }
+    }
+
+    Ogre::Camera* camera = scene->createCamera("PortraitCamera");
+    camera->setNearClipDistance(0.01f);
+    camera->setFarClipDistance(std::max(10.0f, size.length() * 4.0f));
+    camera->setProjectionType(Ogre::PT_ORTHOGRAPHIC);
+    camera->setOrthoWindow(height * 0.5f, height);
+    Ogre::SceneNode* cameraNode = scene->getRootSceneNode()->createChildSceneNode();
+    cameraNode->setFixedYawAxis(true, Ogre::Vector3::UNIT_Z);
+    cameraNode->attachObject(camera);
+    cameraNode->setPosition(center + Ogre::Vector3(0, -size.length() * 2.0f, size.z * 0.1f));
+    cameraNode->lookAt(center, Ogre::Node::TS_WORLD);
+
+    Ogre::TexturePtr texture = Ogre::TextureManager::getSingleton().createManual(textureName, "General",
+        Ogre::TEX_TYPE_2D, 192, 384, 0, Ogre::PF_BYTE_RGBA, Ogre::TU_RENDERTARGET);
+    try
+    {
+        Ogre::RenderTexture* target = texture->getBuffer()->getRenderTarget();
+        target->setAutoUpdated(false);
+        Ogre::Viewport* viewport = target->addViewport(camera);
+        viewport->setOverlaysEnabled(false);
+        viewport->setShadowsEnabled(false);
+        viewport->setBackgroundColour(Ogre::ColourValue(0.025f, 0.018f, 0.015f));
+        // A preceding GUI draw can leave its scissor rectangle active on this target.
+        Ogre::Root::getSingleton().getRenderSystem()->setScissorTest(false);
+        target->update();
+        target->removeAllViewports();
+    }
+    catch(...)
+    {
+        Ogre::TextureManager::getSingleton().remove(texture->getHandle());
+        throw;
+    }
+    return texture;
+}
+
+const CEGUI::Image& getCreaturePortraitImage(const std::string& meshName)
+{
+    const std::string name = "CreaturePortrait/" + meshName;
+    CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
+    if(images.isDefined(name))
+        return images.get(name);
+
+    Ogre::TexturePtr texture = createCreaturePortrait(meshName, name);
+    CEGUI::OgreRenderer& renderer = static_cast<CEGUI::OgreRenderer&>(
+        *CEGUI::System::getSingleton().getRenderer());
+    try
+    {
+        CEGUI::Texture& guiTexture = renderer.createTexture(name, texture, true);
+        CEGUI::BasicImage& image = static_cast<CEGUI::BasicImage&>(images.create("BasicImage", name));
+        image.setTexture(&guiTexture);
+        image.setArea(CEGUI::Rectf(0.0f, 0.0f, 192.0f, 384.0f));
+        image.setAutoScaled(CEGUI::ASM_Disabled);
+        return image;
+    }
+    catch(...)
+    {
+        if(images.isDefined(name))
+            images.destroy(name);
+        if(renderer.isTextureDefined(name))
+            renderer.destroyTexture(name);
+        else
+            Ogre::TextureManager::getSingleton().remove(texture->getHandle());
+        throw;
+    }
+}
+
+const CEGUI::Image& getCreaturePanelPortraitImage(const std::string& meshName)
+{
+    const std::string name = "IllustratedCreaturePortrait/" + meshName;
+    CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
+    if(images.isDefined(name))
+        return images.get(name);
+
+    const std::string filename = "portrait-" + meshName + ".png";
+    if(!Ogre::ResourceGroupManager::getSingleton().resourceExists("Graphics", filename))
+        return getCreaturePortraitImage(meshName);
+
+    CEGUI::OgreRenderer& renderer = static_cast<CEGUI::OgreRenderer&>(
+        *CEGUI::System::getSingleton().getRenderer());
+    try
+    {
+        CEGUI::Texture& texture = renderer.createTexture(name, filename, "Graphics");
+        const CEGUI::Sizef size = texture.getOriginalDataSize();
+        CEGUI::BasicImage& image = static_cast<CEGUI::BasicImage&>(images.create("BasicImage", name));
+        image.setTexture(&texture);
+        image.setArea(CEGUI::Rectf(0.0f, 0.0f, size.d_width, size.d_height));
+        image.setAutoScaled(CEGUI::ASM_Disabled);
+        return image;
+    }
+    catch(...)
+    {
+        if(images.isDefined(name))
+            images.destroy(name);
+        if(renderer.isTextureDefined(name))
+            renderer.destroyTexture(name);
+        throw;
+    }
+}
+
+const CEGUI::Image& getCreatureHandIconImage(const std::string& meshName)
+{
+    const std::string name = "CreatureHandIcon/" + meshName;
+    CEGUI::ImageManager& images = CEGUI::ImageManager::getSingleton();
+    if(images.isDefined(name))
+        return images.get(name);
+
+    getCreaturePanelPortraitImage(meshName);
+    CEGUI::Renderer& renderer = *CEGUI::System::getSingleton().getRenderer();
+    const bool illustrated = renderer.isTextureDefined("IllustratedCreaturePortrait/" + meshName);
+    const std::string portraitName = illustrated ?
+        "IllustratedCreaturePortrait/" + meshName : "CreaturePortrait/" + meshName;
+    CEGUI::Texture& texture = renderer.getTexture(portraitName);
+    const CEGUI::Sizef size = texture.getOriginalDataSize();
+    const float side = std::min(size.d_width, size.d_height);
+    const float left = (size.d_width - side) * 0.5f;
+    const float top = (size.d_height - side) * (illustrated ? 0.25f : 0.5f);
+    CEGUI::BasicImage& image = static_cast<CEGUI::BasicImage&>(images.create("BasicImage", name));
+    image.setTexture(&texture);
+    image.setArea(CEGUI::Rectf(left, top, left + side, top + side));
+    image.setAutoScaled(CEGUI::ASM_Disabled);
+    return image;
+}

--- a/source/render/CreaturePortrait.h
+++ b/source/render/CreaturePortrait.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2026 OpenDungeons Team
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef CREATUREPORTRAIT_H
+#define CREATUREPORTRAIT_H
+
+#include <OgrePrerequisites.h>
+#include <string>
+
+namespace CEGUI
+{
+    class Image;
+}
+
+//! Render the existing creature model to an isolated, static portrait texture.
+//! The caller owns the returned texture and its TextureManager registration.
+Ogre::TexturePtr createCreaturePortrait(const std::string& meshName, const std::string& textureName);
+
+//! Return the cached portrait image, owned by the current CEGUI system.
+const CEGUI::Image& getCreaturePortraitImage(const std::string& meshName);
+
+//! Prefer the authored population-panel illustration, falling back for custom meshes.
+const CEGUI::Image& getCreaturePanelPortraitImage(const std::string& meshName);
+
+//! Return a square crop sharing the cached population-panel portrait texture.
+const CEGUI::Image& getCreatureHandIconImage(const std::string& meshName);
+
+#endif

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -495,7 +495,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             const Ogre::String& typeName = setting.first;
             Ogre::String archName = setting.second;
 
-            if(!archName.empty() && archName.front() != '/') // do not modify absolute paths
+            if(!archName.empty() && !boost::filesystem::path(archName).is_absolute())
                 archName = mGameDataPath + archName;
             else
                 archName = Ogre::FileSystemLayer::resolveBundlePath(archName);

--- a/tools/portraits/README.md
+++ b/tools/portraits/README.md
@@ -1,0 +1,57 @@
+# Creature portrait export
+
+This maintained tool exports the game's existing creature portraits to PNG files
+for asset work and visual comparison. It reuses
+[`CreaturePortrait.cpp`](../../source/render/CreaturePortrait.cpp), including its
+framing, clipping correction, cache and cleanup, instead of copying that renderer.
+It discovers unique mesh names from `config/creatures.cfg`.
+
+These are model-rendered reference images, not newly illustrated artwork.
+The tool does not change the game's portrait assets or runtime behavior.
+
+## Windows prerequisites
+
+Use the Windows build prerequisites: MSVC x64 and the project's installed OGRE/CEGUI libraries, render plugins, codecs
+and media. No extra packages or game installation are required. The wrapper
+loads the repository environment helper when MSVC is not already available.
+On another workstation, load your own x64 compiler environment first and pass
+your dependency installation prefix explicitly.
+
+## Build and export
+
+From the repository root:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/win32/export-creature-portraits.ps1
+```
+
+The default output is `build/portrait-export/`. To select the installed libraries
+and an output folder:
+
+```powershell
+./scripts/win32/export-creature-portraits.ps1 -DependencyPrefix 'C:/dev/od-deps/install' -OutputDirectory 'build/portrait previews'
+```
+
+The C++ entry point and build wrapper are tracked source; generated executables,
+object files, logs and PNGs are build outputs. Repeating the command regenerates
+files with the same names in the selected output directory. Existing local
+preview scripts are not needed. The export uses a hidden rendering window and
+does not launch the game or access saved games or user settings.
+
+Each configured mesh produces `portrait-<mesh-name>.png`; the existing Kobold and
+Orc GUI composition checks additionally produce `portrait-gui-<mesh-name>.png`.
+Compilation output, renderer messages and results use the `portrait-export-`
+prefix. Successful runs report `PORTRAITS=<count>` and return zero.
+
+## Verification
+
+The exporter checks nonempty rendered pixels, cache reuse, preservation of world
+shadow parameters, and cleanup of temporary scenes, materials, viewports and
+textures. A missing configuration, empty mesh set or rendering failure returns
+an error. The wrapper reports compiler/export failures and preserves their logs.
+
+The Windows build and hidden export passed for all 33 configured meshes on
+September 7, 2026, including an output path containing spaces. These checks
+validate the existing export path; artistic acceptance of future illustrated
+portraits remains separate. Linux and other render plugins are not validated
+by this Windows wrapper.

--- a/tools/portraits/portrait-export.cpp
+++ b/tools/portraits/portrait-export.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 OpenDungeons Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "render/CreaturePortrait.h"
+#include <Ogre.h>
+#include <RTShaderSystem/OgreShaderGenerator.h>
+#include <Bites/OgreSGTechniqueResolverListener.h>
+#include <OgreHardwarePixelBuffer.h>
+#include <OgreRenderTexture.h>
+#include <CEGUI/BasicImage.h>
+#include <CEGUI/RenderTarget.h>
+#include <CEGUI/GeometryBuffer.h>
+#include <CEGUI/System.h>
+#include <CEGUI/RendererModules/Ogre/Renderer.h>
+#include <CEGUI/RendererModules/Ogre/Texture.h>
+#include <CEGUI/RendererModules/Ogre/ResourceProvider.h>
+#include <CEGUI/RendererModules/Ogre/ImageCodec.h>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <sstream>
+
+int main(int argc, char** argv)
+{
+    if(argc != 4)
+    {
+        std::cerr << "Usage: portrait-export <project-root> <dependency-prefix> <output-directory>\n";
+        return 2;
+    }
+    const std::string project = argv[1];
+    const std::string dependencies = argv[2];
+    const std::string output = argv[3];
+    try
+    {
+        Ogre::Root root("", "", output + "/portrait-export-Ogre.log");
+        root.loadPlugin(dependencies + "/bin/RenderSystem_GL3Plus.dll");
+        root.loadPlugin(dependencies + "/bin/Codec_STBI.dll");
+        auto* renderer = root.getAvailableRenderers().front();
+        root.setRenderSystem(renderer);
+        renderer->setConfigOption("Full Screen", "No");
+        renderer->setConfigOption("Debug Layer", "Off");
+        root.initialise(false);
+        Ogre::NameValuePairList options;
+        options["hidden"] = "true";
+        options["FSAA"] = "0";
+        auto* window = root.createRenderWindow("PortraitAssetPreview", 192, 384, false, &options);
+        window->setAutoUpdated(false);
+        auto& resources = Ogre::ResourceGroupManager::getSingleton();
+        for(const auto* directory : {"/models", "/materials/scripts/Creatures", "/materials/textures", "/shaders"})
+            resources.addResourceLocation(project + directory, "FileSystem", "Graphics");
+        resources.addResourceLocation(dependencies + "/Media/Main", "FileSystem", "OgreInternal");
+        resources.addResourceLocation(dependencies + "/Media/Main", "FileSystem", "Graphics");
+        resources.addResourceLocation(dependencies + "/Media/RTShaderLib/GLSL", "FileSystem", "Graphics");
+        resources.initialiseAllResourceGroups();
+        resources.addResourceLocation(project + "/materials/scripts", "FileSystem", "Graphics");
+        Ogre::MaterialManager::getSingleton().parseScript(resources.openResource("ReflMetal.material", "Graphics"), "Graphics");
+
+        Ogre::RTShader::ShaderGenerator::initialize();
+        auto* shaderGenerator = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+        OgreBites::SGTechniqueResolverListener listener(shaderGenerator);
+        Ogre::MaterialManager::getSingleton().addListener(&listener);
+        auto* mainScene = root.createSceneManager("DefaultSceneManager");
+        shaderGenerator->addSceneManager(mainScene);
+        auto* mainCamera = mainScene->createCamera("MainCamera");
+        mainScene->getRootSceneNode()->createChildSceneNode()->attachObject(mainCamera);
+        window->addViewport(mainCamera)->setBackgroundColour(Ogre::ColourValue::Black);
+        Ogre::MaterialManager::getSingleton().setActiveScheme(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+        auto& guiRenderer = CEGUI::OgreRenderer::create(*window);
+        auto& provider = CEGUI::OgreRenderer::createOgreResourceProvider();
+        auto& codec = CEGUI::OgreRenderer::createOgreImageCodec();
+        CEGUI::System::create(guiRenderer, &provider, nullptr, &codec, nullptr, "", (output + "/portrait-export-CEGUI.log").c_str());
+        guiRenderer.setFrameControlExecutionEnabled(false);
+        std::vector<std::pair<Ogre::GpuProgramParametersSharedPtr, size_t>> shadowParameters;
+        auto materials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+        while(materials.hasMoreElements())
+        {
+            auto material = std::static_pointer_cast<Ogre::Material>(materials.getNext());
+            for(unsigned short t = 0; t < material->getNumTechniques(); ++t)
+                for(unsigned short p = 0; p < material->getTechnique(t)->getNumPasses(); ++p)
+                {
+                    auto* pass = material->getTechnique(t)->getPass(p);
+                    if(!pass->hasFragmentProgram()) continue;
+                    auto parameters = pass->getFragmentProgramParameters();
+                    if(!parameters->hasNamedParameters()) continue;
+                    auto found = parameters->getConstantDefinitions().map.find("shadowingEnabled");
+                    if(found == parameters->getConstantDefinitions().map.end()) continue;
+                    parameters->setNamedConstant("shadowingEnabled", 1);
+                    shadowParameters.emplace_back(parameters, found->second.physicalIndex);
+                }
+        }
+        std::ifstream config(project + "/config/creatures.cfg");
+        if(!config) throw std::runtime_error("Cannot read creature configuration");
+        std::string line;
+        std::set<std::string> meshes;
+        while(std::getline(config, line))
+        {
+            std::istringstream tokens(line);
+            std::string field, value;
+            if(tokens >> field >> value && field == "MeshName") meshes.insert(value);
+        }
+        if(meshes.empty()) throw std::runtime_error("No creature meshes found");
+        for(const auto& meshName : meshes)
+        {
+            const auto& image = getCreaturePortraitImage(meshName);
+            if(&image != &getCreaturePortraitImage(meshName)) throw std::runtime_error("Portrait cache miss");
+            const auto& guiTexture = static_cast<const CEGUI::OgreTexture&>(guiRenderer.getTexture("CreaturePortrait/" + meshName));
+            auto texture = guiTexture.getOgreTexture();
+            auto* target = texture->getBuffer()->getRenderTarget();
+            target->writeContentsToFile(output + "/portrait-" + meshName + ".png");
+            const auto width = texture->getWidth();
+            const auto height = texture->getHeight();
+            std::vector<unsigned char> pixels(width * height * 4);
+            Ogre::PixelBox box(width, height, 1, Ogre::PF_BYTE_RGBA, pixels.data());
+            texture->getBuffer()->blitToMemory(box);
+            unsigned int coloured = 0;
+            for(size_t p = 0; p < pixels.size(); p += 4)
+                if(pixels[p] > 20 || pixels[p + 1] > 20 || pixels[p + 2] > 20) ++coloured;
+            if(coloured < width * height / 100) throw std::runtime_error("Empty portrait: " + meshName);
+            if(target->getNumViewports() != 0) throw std::runtime_error("Retained portrait viewport");
+            if(meshName == "Kobold.mesh" || meshName == "Orc.mesh")
+            {
+                window->update(false);
+                auto& buffer = guiRenderer.createGeometryBuffer();
+                buffer.setClippingRegion(CEGUI::Rectf(0, 0, 192, 384));
+                image.render(buffer, CEGUI::Rectf(0, 0, 192, 384), nullptr, CEGUI::ColourRect(0xFFFFFFFF));
+                guiRenderer.beginRendering();
+                auto& guiTarget = guiRenderer.getDefaultRenderTarget();
+                guiTarget.activate();
+                guiTarget.draw(buffer);
+                guiTarget.deactivate();
+                guiRenderer.endRendering();
+                window->writeContentsToFile(output + "/portrait-gui-" + meshName + ".png");
+                window->swapBuffers();
+                guiRenderer.destroyGeometryBuffer(buffer);
+            }
+            std::cout << meshName << " visiblePixels=" << coloured << std::endl;
+            for(const auto& value : shadowParameters)
+                if(value.first->getIntPointer(value.second)[0] != 1)
+                    throw std::runtime_error("World shadow parameter changed");
+            auto scenes = root.getSceneManagerIterator();
+            while(scenes.hasMoreElements())
+                if(scenes.getNext() != mainScene) throw std::runtime_error("Retained portrait scene");
+            auto remainingMaterials = Ogre::MaterialManager::getSingleton().getResourceIterator();
+            while(remainingMaterials.hasMoreElements())
+                if(remainingMaterials.getNext()->getName().find("CreaturePortrait/") == 0)
+                    throw std::runtime_error("Retained portrait material copy");
+        }
+        CEGUI::OgreRenderer::destroySystem();
+        for(const auto& meshName : meshes)
+            if(Ogre::TextureManager::getSingleton().resourceExists("CreaturePortrait/" + meshName, "General"))
+                throw std::runtime_error("Retained portrait texture after GUI shutdown");
+        shaderGenerator->removeSceneManager(mainScene);
+        root.destroySceneManager(mainScene);
+        Ogre::MaterialManager::getSingleton().removeListener(&listener);
+        Ogre::RTShader::ShaderGenerator::destroy();
+        std::cout << "PORTRAITS=" << meshes.size() << std::endl;
+    }
+    catch(const std::exception& error)
+    {
+        std::cerr << error.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
Add a maintained standalone utility that exports the configured creature models
as PNG portraits for asset work. Include its shared portrait renderer, cache,
clipping/resource cleanup, C++ entry point, Windows build wrapper and usage guide
as one usable tool rather than separate helper-only contributions.

The wrapper accepts dependency and output paths, including paths with spaces;
generated binaries, logs and PNGs remain build outputs. It uses a hidden render
window and does not launch the game or read saved games. This contribution does
not introduce the separate creature-population interface or illustrated artwork.

Depends on #47 for the maintained Windows environment helper. The default
comparison includes that prerequisite; [review this contribution alone](https://github.com/Rokk001/OpenDungeonsPlus/compare/392b26470975a6d4f8795615314acd82a0e4b619...73f7fc1b33d1214caf216f6af69e858e8697366c).
It does not close #10, which requests the original authoring sources for the
project's assets rather than generated portrait images.

Validation: the exact shared renderer and wrapper compiled on Windows x64 and exported all 33 configured meshes successfully to an output path containing spaces. The exporter checked nonempty images, cache reuse, world-shadow parameter preservation and resource cleanup. The isolated combined game Release build also passed; the utility itself does not alter the game build target. No game was launched and no other-platform execution is claimed.
