### PR TITLE
Keep tooltips within the visible screen

### DIFF
--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -34,6 +34,7 @@
 #include <CEGUI/System.h>
 #include <CEGUI/WindowManager.h>
 #include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/widgets/Tooltip.h>
 #include <CEGUI/Event.h>
 
 Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFileName, Ogre::RenderTarget &renderTarget)
@@ -66,6 +67,18 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
     context.getMouseCursor().setDefaultImage("OpenDungeonsSkin/MouseArrow");
     context.getMouseCursor().setVisible(true);
     context.setDefaultTooltipType("OD/Tooltip");
+    context.getDefaultTooltipObject()->subscribeEvent(CEGUI::Window::EventMoved,
+        CEGUI::Event::Subscriber([](const CEGUI::EventArgs& e)
+        {
+            CEGUI::Window* tooltip = static_cast<const CEGUI::WindowEventArgs&>(e).window;
+            const CEGUI::Rectf bounds = tooltip->getUnclippedOuterRect().get();
+            const CEGUI::Sizef screen = tooltip->getRootContainerSize();
+            const float x = std::max(0.0f, std::min(bounds.left(), screen.d_width - bounds.getWidth()));
+            const float y = std::max(0.0f, std::min(bounds.top(), screen.d_height - bounds.getHeight()));
+            if(x != bounds.left() || y != bounds.top())
+                tooltip->setPosition(CEGUI::UVector2(CEGUI::UDim(0, x), CEGUI::UDim(0, y)));
+            return true;
+        }));
     CEGUI::WindowManager* wmgr = CEGUI::WindowManager::getSingletonPtr();
     mSheets[hideGui] = wmgr->createWindow("DefaultWindow", "DummyWindow");
     mSheets[inGameMenu] = wmgr->loadLayoutFromFile("ModeGame.layout");


### PR DESCRIPTION
Tooltips could extend beyond the screen after being placed beside the cursor.
Clamp their final position to the current root-container bounds when they move,
updating the position only when correction is needed. Existing text, display
timing and unrelated window behavior remain unchanged.

This is an independent one-file correction with no runtime dependency on the
other interface contributions. No matching open issue was identified for this
specific screen-edge defect.

Validation: the actual production move callback with real CEGUI tooltip windows passed 96 bounds checks across three resolutions and positions beyond each screen edge. A Windows x64 Release integration build and runtime preparation passed with the existing Windows-support and GUI-scaling contributions. The user previously accepted the edge correction in the complete fork; no other-platform runtime verification is claimed.
