### PR TITLE
Add a summon effect for created workers

### DIFF
--- a/materials/scripts/SummonWorker.material
+++ b/materials/scripts/SummonWorker.material
@@ -1,0 +1,20 @@
+// Summoned-worker particle material
+
+material SummonWorker
+{
+    technique
+    {
+        pass
+        {
+            lighting off
+            scene_blend add
+            depth_write off
+            diffuse vertexcolour
+
+            texture_unit
+            {
+                texture Flare.png
+            }
+        }
+    }
+}

--- a/particles/SummonWorker.particle
+++ b/particles/SummonWorker.particle
@@ -1,0 +1,36 @@
+particle_system SummonWorker
+{
+    material        SummonWorker
+    point_rendering false
+    particle_width  0.24
+    particle_height 0.24
+    cull_each       false
+    quota           160
+    billboard_type  point
+
+    emitter Box
+    {
+        angle               180
+        colour_range_start  0.25 1.0 0.75 1.0
+        colour_range_end    0.65 1.0 0.9 1.0
+        emission_rate       500
+        time_to_live        0.8
+        direction           0 0 1
+        velocity            1.4
+        duration            0.2
+        width               0.9
+        height              0.9
+        depth               1.0
+    }
+
+    affector LinearForce
+    {
+        force_vector      0 0 0.8
+        force_application add
+    }
+
+    affector ColourFader
+    {
+        alpha -1.2
+    }
+}

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -420,8 +420,13 @@ void Creature::exportToStream(std::ostream& os) const
 
     os << "\t" << mWeaponDropDeath;
 
-    uint32_t nbEffects = mEntityParticleEffects.size();
-    os << "\t" << nbEffects;
+    uint32_t nbCreatureEffects = 0;
+    for(EntityParticleEffect* effect : mEntityParticleEffects)
+    {
+        if(effect->getEntityParticleEffectType() == EntityParticleEffectType::creature)
+            ++nbCreatureEffects;
+    }
+    os << "\t" << nbCreatureEffects;
     for(EntityParticleEffect* effect : mEntityParticleEffects)
     {
         // We only save creature particle effects. The other are expected to be re-created
@@ -865,6 +870,27 @@ void Creature::doUpkeep()
     // We apply creature effects if any
     for(auto it =  mEntityParticleEffects.begin(); it != mEntityParticleEffects.end();)
     {
+        EntityParticleEffect* entityEffect = *it;
+        if(entityEffect->getEntityParticleEffectType() != EntityParticleEffectType::creature)
+        {
+            if(entityEffect->mNbTurnsEffect < 0)
+            {
+                ++it;
+                continue;
+            }
+
+            if(entityEffect->mNbTurnsEffect > 0)
+            {
+                --entityEffect->mNbTurnsEffect;
+                ++it;
+                continue;
+            }
+
+            delete entityEffect;
+            it = mEntityParticleEffects.erase(it);
+            continue;
+        }
+
         CreatureParticleEffect* effect = static_cast<CreatureParticleEffect*>(*it);
         if(effect->mEffect->upkeepEffect(*this))
         {
@@ -3105,6 +3131,13 @@ void Creature::addCreatureEffect(CreatureEffect* effect)
     mNeedFireRefresh = true;
 }
 
+void Creature::addParticleEffect(const std::string& effectScript, uint32_t nbTurns)
+{
+    EntityParticleEffect* effect = new EntityParticleEffect(
+        nextParticleSystemsName(), effectScript, nbTurns);
+    mEntityParticleEffects.push_back(effect);
+}
+
 bool Creature::removeCreatureEffect(CreatureEffect* effectForDeletion)
 {
     mNeedFireRefresh = false;
@@ -3438,7 +3471,6 @@ void Creature::normalizeAmbient()
     RenderManager::getSingleton().rrNormalizeAmbient(this);
 
 }
-
 
 
 

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -504,6 +504,9 @@ public:
     //! Called on server side to add an effect (spell, slap, ...) to this creature
     void addCreatureEffect(CreatureEffect* effect);
 
+    //! Called on server side to add a finite presentation-only particle effect.
+    void addParticleEffect(const std::string& effectScript, uint32_t nbTurns);
+
     bool removeCreatureEffect(CreatureEffect* effectForDeletion);
 
     //!\brief Returns true if the creature has an active slap effect

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -228,6 +228,7 @@ bool SpellSummonWorker::summonWorkersOnTiles(GameMap* gameMap, Player* player, c
         Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(tile->getX()),
                                     static_cast<Ogre::Real>(tile->getY()),
                                     static_cast<Ogre::Real>(0.0));
+        newCreature->addParticleEffect("SummonWorker", 3);
         newCreature->createMesh();
         newCreature->setPosition(spawnPosition);
     }


### PR DESCRIPTION
Workers created by the summon-worker spell now play a short turquoise-green spark burst. Ordinary creature spawning and worker behavior remain unchanged.

No existing issue is fully resolved by this contribution.

Validation:

- The production particle and material scripts passed the 10-check headless OGRE probe.
- Clean Windows Release compilation and runtime preparation passed on the complete fork state.
- The effect was accepted in gameplay testing.
