### PR TITLE
Improve the community exit page

### DIFF
--- a/gui/Advertisment.layout
+++ b/gui/Advertisment.layout
@@ -1,30 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <GUILayout version="4" >
-
     <Window type="OD/StaticImage" name="Advertisment" >
-        <Property name="Area" value="{{0,0},{0,0},{1,2},{1,0}}" />
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
         <Property name="Image" value="ODAdvertisment/AdvertismentA" />
-        <Property name="MaxSize" value="{{1,0},{1,0}}" /> 
-        <Window type="OD/StaticText" name="AdvertismentSlogan1" >
-            <Property name="Text" value=" Delve deeper into dark arkanes of opendungeons with c++ " />
-            <Property name="Area" value="{{0,0},{0,120},{1,0},{0,240}}" />
-            <Property name="Font" value="LiberationSans-20" />                     
-            <Property name="BackgroundEnabled" value="False" />
-            <Property name="FrameEnabled" value="False" />             
-        </Window>
-        <Window type="OD/StaticText" name="AdvertismentSlogan2" >
-            <Property name="Text" value=" Programmers and Artists wanted" />  
-            <Property name="Area" value="{{0,0},{0,240},{1,0},{0,360}}" />
-            <Property name="Font" value="LiberationSans-20" />
-            <Property name="BackgroundEnabled" value="False" />
-            <Property name="FrameEnabled" value="False" />                                    
-        </Window>   
-        <Window type="OD/StaticText" name="AdvertismentLink" >
-            <Property name="Text" value=" Click here to visit our discord channel : https://discord.gg/K2JPXuchZV" />  
-            <Property name="Area" value="{{0,0},{0,360},{1,0},{0,480}}" />
-            <Property name="Font" value="LiberationSans-20" />                                
+        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+        <Property name="FrameEnabled" value="False" />
+        <Property name="BackgroundEnabled" value="False" />
+
+        <Window type="OD/FrameWindow" name="CommunityPanel" >
+            <Property name="LookNFeel" value="OD/CommunityPanel" />
+            <Property name="Area" value="{{0.5,-300},{0.5,-155},{0.5,300},{0.5,155}}" />
+            <Property name="SizingEnabled" value="False" />
+            <Property name="DragMovingEnabled" value="False" />
+
+            <Window type="OD/StaticText" name="Title" >
+                <Property name="Area" value="{{0,24},{0,20},{1,-24},{0,70}}" />
+                <Property name="Text" value="Help shape the dungeon" />
+                <Property name="Font" value="MedievalSharp-20" />
+                <Property name="TextColours" value="tl:FFE9841C tr:FFE9841C bl:FFE9841C br:FFE9841C" />
+                <Property name="HorzFormatting" value="CentreAligned" />
+                <Property name="VertFormatting" value="CentreAligned" />
+                <Property name="FrameEnabled" value="False" />
+                <Property name="BackgroundEnabled" value="False" />
+                <Property name="InheritsAlpha" value="False" />
+                <Property name="MousePassThroughEnabled" value="True" />
+            </Window>
+
+            <Window type="OD/StaticText" name="Invitation" >
+                <Property name="Area" value="{{0,32},{0,82},{1,-32},{0,202}}" />
+                <Property name="Text" value="Built by a community of developers and artists.&#10;Join us on Discord to contribute, share feedback,&#10;or follow development." />
+                <Property name="Font" value="LiberationSans-10" />
+                <Property name="TextColours" value="tl:FFE7E0D0 tr:FFE7E0D0 bl:FFE7E0D0 br:FFE7E0D0" />
+                <Property name="HorzFormatting" value="CentreAligned" />
+                <Property name="VertFormatting" value="CentreAligned" />
+                <Property name="FrameEnabled" value="False" />
+                <Property name="BackgroundEnabled" value="False" />
+                <Property name="InheritsAlpha" value="False" />
+                <Property name="MousePassThroughEnabled" value="True" />
+            </Window>
+
+            <Window type="OD/Button" name="DiscordButton" >
+                <Property name="Area" value="{{0.5,-225},{1,-72},{0.5,-15},{1,-30}}" />
+                <Property name="Text" value="Join us on Discord" />
+                <Property name="Font" value="MedievalSharp-12" />
+                <Property name="TooltipText" value="Open the OpenDungeonsPlus Discord community" />
+                <Property name="InheritsAlpha" value="False" />
+            </Window>
+
+            <Window type="OD/Button" name="CloseButton" >
+                <Property name="Area" value="{{0.5,15},{1,-72},{0.5,225},{1,-30}}" />
+                <Property name="Text" value="Close" />
+                <Property name="Font" value="MedievalSharp-12" />
+                <Property name="TooltipText" value="Close OpenDungeonsPlus" />
+                <Property name="InheritsAlpha" value="False" />
+            </Window>
         </Window>
     </Window>
-  
 </GUILayout>

--- a/gui/OD.looknfeel
+++ b/gui/OD.looknfeel
@@ -4772,4 +4772,27 @@
         </StateImagery>
     </WidgetLook>
 
+    <WidgetLook name="OD/CommunityPanel" inherits="OD/FrameWindow">
+        <Property name="FrameEnabled" value="False" />
+        <Property name="TitlebarEnabled" value="False" />
+        <Property name="CloseButtonEnabled" value="False" />
+        <ImagerySection name="backdrop">
+            <ImageryComponent>
+                <Area>
+                    <Dim type="LeftEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="TopEdge"><AbsoluteDim value="0" /></Dim>
+                    <Dim type="RightEdge"><UnifiedDim scale="1" type="RightEdge" /></Dim>
+                    <Dim type="BottomEdge"><UnifiedDim scale="1" type="BottomEdge" /></Dim>
+                </Area>
+                <Image name="OpenDungeonsSkin/SelectionBrush" />
+                <Colours topLeft="E6080C10" topRight="E6080C10" bottomLeft="E6080C10" bottomRight="E6080C10" />
+                <VertFormat type="Stretched" />
+                <HorzFormat type="Stretched" />
+            </ImageryComponent>
+        </ImagerySection>
+        <StateImagery name="ActiveNoTitleNoFrame"><Layer><Section section="backdrop" /></Layer></StateImagery>
+        <StateImagery name="InactiveNoTitleNoFrame"><Layer><Section section="backdrop" /></Layer></StateImagery>
+        <StateImagery name="DisabledNoTitleNoFrame"><Layer><Section section="backdrop" /></Layer></StateImagery>
+    </WidgetLook>
+
 </Falagard>

--- a/source/modes/AdvertMode.cpp
+++ b/source/modes/AdvertMode.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdlib>
 #include <CEGUI/CEGUI.h>
+#include <CEGUI/widgets/PushButton.h>
 
 
 AdvertMode::AdvertMode(ModeManager* modeManager):
@@ -31,33 +32,17 @@ AdvertMode::AdvertMode(ModeManager* modeManager):
     CEGUI::Window* rootWin = getModeManager().getGui().getGuiSheet(Gui::advertisment);
     OD_ASSERT_TRUE(rootWin != nullptr);
     addEventConnection(
-        rootWin->subscribeEvent(
-            CEGUI::Window::EventMouseClick,
-            CEGUI::Event::Subscriber(&AdvertMode::quitPressed, this)
-            )
-        );
-
-
-    addEventConnection(
-        rootWin->getChild("AdvertismentLink")->subscribeEvent(
-            CEGUI::Window::EventMouseClick,
+        rootWin->getChild("CommunityPanel/DiscordButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&AdvertMode::showWWW, this)
         )
     );
 
-
     addEventConnection(
-        rootWin->getChild("AdvertismentLink")->subscribeEvent(
-            CEGUI::Window::EventMouseEntersArea,
-            CEGUI::Event::Subscriber(&AdvertMode::hilightLink, this)
+        rootWin->getChild("CommunityPanel/CloseButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&AdvertMode::quitPressed, this)
         )
-   );
-
-    addEventConnection(
-        rootWin->getChild("AdvertismentLink")->subscribeEvent(
-            CEGUI::Window::EventMouseLeavesArea,
-            CEGUI::Event::Subscriber(&AdvertMode::unHilightLink, this)
-        )         
     );
 }
 
@@ -91,20 +76,6 @@ bool AdvertMode::showWWW()
 }
 
 
-bool AdvertMode::hilightLink()
-{
-    getModeManager().getGui().getGuiSheet(Gui::advertisment)->getChild("AdvertismentLink")->setProperty("FrameColours","tl:00000000 tr:00000000 bl:00000000 br:00000000" );
-    return true;
-}
-
-bool AdvertMode::unHilightLink()
-{
-    getModeManager().getGui().getGuiSheet(Gui::advertisment)->getChild("AdvertismentLink")->setProperty("FrameColours","tl:FFFFFFFF tr:FFFFFFFF bl:FFFFFFFF br:FFFFFFFF" );
-    return true;
-}
-
-
-        
 bool AdvertMode::quitPressed(const CEGUI::EventArgs&)
 {
     ODFrameListener::getSingletonPtr()->requestExit();

--- a/source/modes/AdvertMode.h
+++ b/source/modes/AdvertMode.h
@@ -37,10 +37,6 @@ public:
 
     bool showWWW();
 
-    bool hilightLink();
-
-    bool unHilightLink();
-    
     bool quitPressed(const CEGUI::EventArgs&);
 
 };


### PR DESCRIPTION
## Summary

- replace the loose recruitment text with a centered, skinned community panel
- provide explicit Discord and Close buttons instead of closing on any background click
- preserve the existing exit flow and community invitation URL

## Validation

- target layout and skin loaded in a real Ogre/CEGUI probe: 150 checks across 800x600, 1280x720, 1920x1080, 3440x1440 and 3840x2160 at 80%, 100% and 120% UI scaling
- the changed AdvertMode translation unit compiled successfully with MSVC
- the complete fork implementation passed its Windows Release build and runtime preparation
- the user confirmed the page and both actions in game
- the contribution contains one commit and only four functional files

## Dependencies and overlap

- #21 supplies the existing community-link launch support on Windows and macOS; this PR keeps that link method unchanged and limits itself to the page and action wiring
- no open issue is fully resolved by this contribution

## Validation limits

- a full Windows build of the isolated upstream-based branch was not run because its Windows build support is tracked separately in #47
