### PR TITLE
Enable optimized Windows Release builds with debug symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,8 +183,8 @@ endif()
 if(WIN32 AND MSVC)
     #Set some extra compiler flags
     #TODO - investigate if these are what they should be
-    set(PLATFORM_C_FLAGS "/W3 /MD /Od /DWIN32 /D_WINDOWS /Gm /Gy /fp:fast /ZI /EHsc")
-    set(PLATFORM_C_FLAGS_DEBUG "/W3 /MDd /Od /Gm /Gy /fp:fast /ZI /DOD_DEBUG" )
+    set(PLATFORM_C_FLAGS "/W3 /MD /Od /DWIN32 /D_WINDOWS /Gm- /Gy /fp:fast /ZI /EHsc")
+    set(PLATFORM_C_FLAGS_DEBUG "/W3 /MDd /Od /Gm- /Gy /fp:fast /ZI /DOD_DEBUG" )
 
     # Set the application version
     add_definitions(/DOD_VERSION="${OD_MAJOR_VERSION}.${OD_MINOR_VERSION}.${OD_PATCH_LEVEL}")


### PR DESCRIPTION
Remove debug-only switches from shared MSVC flags and use optimized Release code generation while retaining debugging symbols and the existing Debug configuration.

Based on #59 and its published prerequisites. The default comparison is cumulative (2 commits); this contribution adds one focused commit. Merge prerequisites separately and recheck the remaining diff before merging.

[Contribution-only comparison](https://github.com/Rokk001/OpenDungeonsPlus/compare/25e325a650407015d486c03340f11d1be1d1e3ad...7590feaa0ca52fe3c89500521c527155bd3b540d).

Validation: Fresh CMake generation using the candidate's exact MSVC flag block passes all eight generated-project assertions; the complete fork Release build previously passed and the user accepted the reported load/optimization correction.

Limits: no new full-game or multiplayer run is claimed; no new Linux build was performed. Native regression reruns are currently blocked by Windows application-control policy; historical native results above are not claimed as fresh runs.

Issue coverage: No matching narrow open issue was found.

No version or README change is needed for corrected Release flags; this is not a new release.
